### PR TITLE
feat: add timeout middleware

### DIFF
--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -1,3 +1,7 @@
+mod timeout;
+
+pub use timeout::TimeoutMiddleware;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -10,7 +14,7 @@ use crate::response::BoxBody;
 use crate::router::Router;
 use crate::state::AppState;
 
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub trait Middleware: Send + Sync + 'static {
     fn handle<'a>(

--- a/rapina/src/middleware/timeout.rs
+++ b/rapina/src/middleware/timeout.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+
+use crate::context::RequestContext;
+use crate::error::Error;
+use crate::response::{BoxBody, IntoResponse};
+
+use super::{BoxFuture, Middleware, Next};
+
+pub struct TimeoutMiddleware {
+    duration: Duration,
+}
+
+impl TimeoutMiddleware {
+    pub fn new(duration: Duration) -> Self {
+        Self { duration }
+    }
+}
+
+impl Default for TimeoutMiddleware {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(30))
+    }
+}
+
+impl Middleware for TimeoutMiddleware {
+    fn handle<'a>(
+        &'a self,
+        req: Request<Incoming>,
+        _ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        Box::pin(async move {
+            match tokio::time::timeout(self.duration, next.run(req)).await {
+                Ok(response) => response,
+                Err(_) => Error::internal("request timeout").into_response(),
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TimeoutMiddleware` that wraps handler execution in `tokio::time::timeout()`
- Returns 500 Internal Error with "request timeout" message on expiration
- Default timeout is 30 seconds

## Usage

```rust
use std::time::Duration;
use rapina::prelude::*;
use rapina::middleware::TimeoutMiddleware;

Rapina::new()
    .middleware(TimeoutMiddleware::new(Duration::from_secs(10)))
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

Or use the default 30 second timeout:

```rust
Rapina::new()
    .middleware(TimeoutMiddleware::default())
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #4