### PR TITLE
feat: add body limit middleware

### DIFF
--- a/rapina/src/middleware/body_limit.rs
+++ b/rapina/src/middleware/body_limit.rs
@@ -1,0 +1,49 @@
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+
+use crate::context::RequestContext;
+use crate::error::Error;
+use crate::response::{BoxBody, IntoResponse};
+
+use super::{BoxFuture, Middleware, Next};
+
+const DEFAULT_MAX_SIZE: usize = 1024 * 1024; // 1MB
+
+pub struct BodyLimitMiddleware {
+    max_size: usize,
+}
+
+impl BodyLimitMiddleware {
+    pub fn new(max_size: usize) -> Self {
+        Self { max_size }
+    }
+}
+
+impl Default for BodyLimitMiddleware {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_SIZE)
+    }
+}
+
+impl Middleware for BodyLimitMiddleware {
+    fn handle<'a>(
+        &'a self,
+        req: Request<Incoming>,
+        _ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        Box::pin(async move {
+            let content_length = req
+                .headers()
+                .get(hyper::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<usize>().ok());
+
+            if content_length.is_some_and(|len| len > self.max_size) {
+                return Error::bad_request("body too large").into_response();
+            }
+
+            next.run(req).await
+        })
+    }
+}

--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -1,5 +1,7 @@
+mod body_limit;
 mod timeout;
 
+pub use body_limit::BodyLimitMiddleware;
 pub use timeout::TimeoutMiddleware;
 
 use std::future::Future;


### PR DESCRIPTION
## Summary

- Add `BodyLimitMiddleware` that checks `Content-Length` header
- Rejects requests with bodies larger than the configured limit
- Returns 400 Bad Request with "body too large" message
- Default limit is 1MB

## Usage

```rust
use rapina::prelude::*;
use rapina::middleware::BodyLimitMiddleware;

// Custom limit (512KB)
Rapina::new()
    .middleware(BodyLimitMiddleware::new(512 * 1024))
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

Or use the default 1MB limit:

```rust
Rapina::new()
    .middleware(BodyLimitMiddleware::default())
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #5