### PR TITLE
feat: add trace ID middleware

### DIFF
--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -1,8 +1,10 @@
 mod body_limit;
 mod timeout;
+mod trace_id;
 
 pub use body_limit::BodyLimitMiddleware;
 pub use timeout::TimeoutMiddleware;
+pub use trace_id::TraceIdMiddleware;
 
 use std::future::Future;
 use std::pin::Pin;

--- a/rapina/src/middleware/trace_id.rs
+++ b/rapina/src/middleware/trace_id.rs
@@ -1,0 +1,58 @@
+use hyper::body::Incoming;
+use hyper::header::HeaderValue;
+use hyper::{Request, Response};
+
+use crate::context::RequestContext;
+use crate::response::BoxBody;
+
+use super::{BoxFuture, Middleware, Next};
+
+pub struct TraceIdMiddleware;
+
+impl TraceIdMiddleware {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TraceIdMiddleware {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Middleware for TraceIdMiddleware {
+    fn handle<'a>(
+        &'a self,
+        mut req: Request<Incoming>,
+        ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        Box::pin(async move {
+            // Check for incoming x-trace-id header for distributed tracing
+            let incoming_trace_id = req
+                .headers()
+                .get("x-trace-id")
+                .and_then(|v| v.to_str().ok())
+                .map(String::from);
+
+            let trace_id = if let Some(id) = incoming_trace_id {
+                // Use the provided trace_id and update context in extensions
+                let new_ctx = RequestContext::with_trace_id(id.clone());
+                req.extensions_mut().insert(new_ctx);
+                id
+            } else {
+                ctx.trace_id.clone()
+            };
+
+            let mut response = next.run(req).await;
+
+            // Add x-trace-id to response headers
+            if let Ok(header_value) = HeaderValue::from_str(&trace_id) {
+                response.headers_mut().insert("x-trace-id", header_value);
+            }
+
+            response
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Add `TraceIdMiddleware` for distributed tracing support
- Extracts `trace_id` from incoming `x-trace-id` header if present
- Falls back to auto-generated trace_id if header not present
- Adds `x-trace-id` response header for client correlation

## Usage

```rust
use rapina::prelude::*;
use rapina::middleware::TraceIdMiddleware;

Rapina::new()
    .middleware(TraceIdMiddleware::new())
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

When a client sends a request with `x-trace-id: abc123`, the middleware will:
1. Use that trace_id for the request context
2. Return the same `x-trace-id: abc123` in the response

When no header is provided, the middleware uses the auto-generated UUID and returns it in the response header.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #6