### PR TITLE
feat: add Query extractor for query string parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ dependencies = [
  "rapina-macros",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "uuid",
  "validator",
@@ -603,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +656,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/rapina-macros/src/lib.rs
+++ b/rapina-macros/src/lib.rs
@@ -111,7 +111,10 @@ fn route_macro_core(
 }
 
 fn is_parts_only_extractor(type_str: &str) -> bool {
-    type_str.contains("Path") || type_str.contains("State") || type_str.contains("Context")
+    type_str.contains("Path")
+        || type_str.contains("Query")
+        || type_str.contains("State")
+        || type_str.contains("Context")
 }
 
 fn route_macro(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.11.0"
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+serde_urlencoded = "0.7"
 
 # Validation
 validator = { version = "0.20.0", features = ["derive"] }

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
     pub use crate::app::Rapina;
     pub use crate::context::RequestContext;
     pub use crate::error::{Error, Result};
-    pub use crate::extract::{Context, Json, Path};
+    pub use crate::extract::{Context, Json, Path, Query};
     pub use crate::middleware::{Middleware, Next};
     pub use crate::response::IntoResponse;
     pub use crate::router::Router;


### PR DESCRIPTION
## Summary

- Add `Query<T>` extractor to parse query string parameters into typed structs
- Uses `serde_urlencoded` for parsing
- Returns 400 Bad Request on parse errors
- Added to macro's parts-only extractor list

## Usage

```rust
use rapina::prelude::*;

#[derive(Deserialize)]
struct Pagination {
    page: Option<u32>,
    limit: Option<u32>,
}

#[get("/users")]
async fn list_users(query: Query<Pagination>) -> Json<Vec<User>> {
    let page = query.0.page.unwrap_or(1);
    let limit = query.0.limit.unwrap_or(10);
    // GET /users?page=2&limit=20
}
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #7