### PR TITLE
feat: add Headers extractor for request headers

### DIFF
--- a/rapina-macros/src/lib.rs
+++ b/rapina-macros/src/lib.rs
@@ -113,6 +113,7 @@ fn route_macro_core(
 fn is_parts_only_extractor(type_str: &str) -> bool {
     type_str.contains("Path")
         || type_str.contains("Query")
+        || type_str.contains("Headers")
         || type_str.contains("State")
         || type_str.contains("Context")
 }

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
     pub use crate::app::Rapina;
     pub use crate::context::RequestContext;
     pub use crate::error::{Error, Result};
-    pub use crate::extract::{Context, Json, Path, Query};
+    pub use crate::extract::{Context, Headers, Json, Path, Query};
     pub use crate::middleware::{Middleware, Next};
     pub use crate::response::IntoResponse;
     pub use crate::router::Router;


### PR DESCRIPTION
## Summary

- Add `Headers` extractor that provides access to request headers
- Wraps `http::HeaderMap` with a convenient `get()` method
- Added to macro's parts-only extractor list

## Usage

```rust
use rapina::prelude::*;

#[get("/me")]
async fn get_me(headers: Headers) -> Result<Json<User>> {
    let auth = headers.get("authorization")
        .ok_or_else(|| Error::unauthorized("missing authorization header"))?;
    // ...
}
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #8