### PR TITLE
feat: add Form extractor for URL-encoded form data

### DIFF
--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -13,7 +13,7 @@ pub mod prelude {
     pub use crate::app::Rapina;
     pub use crate::context::RequestContext;
     pub use crate::error::{Error, Result};
-    pub use crate::extract::{Context, Headers, Json, Path, Query};
+    pub use crate::extract::{Context, Form, Headers, Json, Path, Query};
     pub use crate::middleware::{Middleware, Next};
     pub use crate::response::IntoResponse;
     pub use crate::router::Router;


### PR DESCRIPTION
## Summary

- Add `Form<T>` extractor for parsing `application/x-www-form-urlencoded` request bodies
- Validates `Content-Type` header before parsing
- Returns 400 Bad Request on invalid content-type or parse errors
- Uses `serde_urlencoded` for parsing

## Usage

```rust
use rapina::prelude::*;

#[derive(Deserialize)]
struct LoginForm {
    username: String,
    password: String,
}

#[post("/login")]
async fn login(form: Form<LoginForm>) -> Result<Json<Token>> {
    let data = form.into_inner();
    // Authenticate user...
}
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes

Closes #9