### PR TITLE
feat: add Validated<T> extractor for request validation

### DIFF
--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -14,13 +14,14 @@ pub mod prelude {
     pub use crate::app::Rapina;
     pub use crate::context::RequestContext;
     pub use crate::error::{Error, Result};
-    pub use crate::extract::{Context, Form, Headers, Json, Path, Query};
+    pub use crate::extract::{Context, Form, Headers, Json, Path, Query, Validated};
     pub use crate::middleware::{Middleware, Next};
     pub use crate::response::IntoResponse;
     pub use crate::router::Router;
 
     pub use http::{Method, StatusCode};
     pub use serde::{Deserialize, Serialize};
+    pub use validator::Validate;
 
     pub use rapina_macros::{delete, get, post, put};
 }


### PR DESCRIPTION
## Summary
- Add `Validated<T>` wrapper extractor that validates inner values using the `validator` crate
- Implement `FromRequest` for `Validated<Json<T>>` and `Validated<Form<T>>`
- Returns 422 `VALIDATION_ERROR` with detailed error info on validation failure
- Export `Validated` and `validator::Validate` in prelude for easy access

## Usage
```rust
use rapina::prelude::*;

#[derive(Deserialize, Validate)]
struct CreateUser {
    #[validate(email)]
    email: String,
    #[validate(length(min = 8))]
    password: String,
}

#[post("/users")]
async fn create_user(body: Validated<Json<CreateUser>>) -> Result<Json<User>> {
    let data = body.into_inner().into_inner();
    // data is guaranteed to be valid at this point
}
```

## Test plan
- [x] All 117 tests pass
- [x] Clippy passes with no warnings
- [x] Unit tests for `Validated::into_inner()`

Closes #10