### PR TITLE
feat: add tracing integration for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +448,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -546,6 +576,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "validator",
 ]
@@ -671,6 +703,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,7 +844,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -804,6 +866,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -870,6 +975,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -29,6 +29,10 @@ serde_urlencoded = "0.7"
 # Validation
 validator = { version = "0.20.0", features = ["derive"] }
 
+# Observability
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+
 uuid = { version = "1", features = ["v4"] }
 
 # Our macros

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use crate::middleware::{Middleware, MiddlewareStack};
+use crate::observability::TracingConfig;
 use crate::router::Router;
 use crate::server::serve;
 use crate::state::AppState;
@@ -32,6 +33,11 @@ impl Rapina {
 
     pub fn middleware<M: Middleware>(mut self, middleware: M) -> Self {
         self.middlewares.add(middleware);
+        self
+    }
+
+    pub fn with_tracing(self, config: TracingConfig) -> Self {
+        config.init();
         self
     }
 

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod extract;
 pub mod handler;
 pub mod middleware;
+pub mod observability;
 pub mod response;
 pub mod router;
 pub mod server;
@@ -16,11 +17,13 @@ pub mod prelude {
     pub use crate::error::{Error, Result};
     pub use crate::extract::{Context, Form, Headers, Json, Path, Query, Validated};
     pub use crate::middleware::{Middleware, Next};
+    pub use crate::observability::TracingConfig;
     pub use crate::response::IntoResponse;
     pub use crate::router::Router;
 
     pub use http::{Method, StatusCode};
     pub use serde::{Deserialize, Serialize};
+    pub use tracing;
     pub use validator::Validate;
 
     pub use rapina_macros::{delete, get, post, put};

--- a/rapina/src/observability/mod.rs
+++ b/rapina/src/observability/mod.rs
@@ -1,0 +1,3 @@
+mod tracing;
+
+pub use self::tracing::TracingConfig;

--- a/rapina/src/observability/tracing.rs
+++ b/rapina/src/observability/tracing.rs
@@ -1,0 +1,125 @@
+use tracing::Level;
+use tracing_subscriber::{EnvFilter, fmt};
+
+#[derive(Debug, Clone)]
+pub struct TracingConfig {
+    pub json: bool,
+    pub level: Level,
+    pub with_target: bool,
+    pub with_file: bool,
+    pub with_line_number: bool,
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            json: false,
+            level: Level::INFO,
+            with_target: true,
+            with_file: false,
+            with_line_number: false,
+        }
+    }
+}
+
+impl TracingConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    pub fn level(mut self, level: Level) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn with_target(mut self, enabled: bool) -> Self {
+        self.with_target = enabled;
+        self
+    }
+
+    pub fn with_file(mut self, enabled: bool) -> Self {
+        self.with_file = enabled;
+        self
+    }
+
+    pub fn with_line_number(mut self, enabled: bool) -> Self {
+        self.with_line_number = enabled;
+        self
+    }
+
+    pub fn init(self) {
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(self.level.to_string()));
+
+        if self.json {
+            fmt()
+                .with_env_filter(filter)
+                .with_target(self.with_target)
+                .with_file(self.with_file)
+                .with_line_number(self.with_line_number)
+                .json()
+                .init();
+        } else {
+            fmt()
+                .with_env_filter(filter)
+                .with_target(self.with_target)
+                .with_file(self.with_file)
+                .with_line_number(self.with_line_number)
+                .init();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tracing_config_default() {
+        let config = TracingConfig::default();
+        assert!(!config.json);
+        assert_eq!(config.level, Level::INFO);
+        assert!(config.with_target);
+        assert!(!config.with_file);
+        assert!(!config.with_line_number);
+    }
+
+    #[test]
+    fn test_tracing_config_new() {
+        let config = TracingConfig::new();
+        assert!(!config.json);
+    }
+
+    #[test]
+    fn test_tracing_config_json() {
+        let config = TracingConfig::new().json();
+        assert!(config.json);
+    }
+
+    #[test]
+    fn test_tracing_config_level() {
+        let config = TracingConfig::new().level(Level::DEBUG);
+        assert_eq!(config.level, Level::DEBUG);
+    }
+
+    #[test]
+    fn test_tracing_config_builder_chain() {
+        let config = TracingConfig::new()
+            .json()
+            .level(Level::TRACE)
+            .with_target(false)
+            .with_file(true)
+            .with_line_number(true);
+
+        assert!(config.json);
+        assert_eq!(config.level, Level::TRACE);
+        assert!(!config.with_target);
+        assert!(config.with_file);
+        assert!(config.with_line_number);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `observability` module with `TracingConfig` for structured logging
- Add `with_tracing()` builder method to `Rapina`
- Support JSON and pretty-print output formats
- Configurable log level, target, file, and line number display
- Re-export `tracing` crate in prelude

## Usage
```rust
use rapina::prelude::*;

Rapina::new()
    .with_tracing(TracingConfig::new().json().level(tracing::Level::DEBUG))
    .router(router)
    .listen("127.0.0.1:3000")
    .await
```

## Test plan
- [x] All 122 tests pass
- [x] Clippy passes

Closes #11