### PR TITLE
docs: add comprehensive documentation to all public APIs

### DIFF
--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -1,3 +1,70 @@
+//! # Rapina
+//!
+//! A fast, type-safe web framework for Rust inspired by FastAPI.
+//!
+//! Rapina focuses on **productivity**, **type safety**, and **clear conventions**,
+//! making it easy to build production-ready APIs.
+//!
+//! ## Features
+//!
+//! - **Type-safe extractors** - Parse request data with compile-time guarantees
+//! - **Declarative routing** - Use proc macros like `#[get]`, `#[post]` for clean route definitions
+//! - **Middleware system** - Composable middleware with async support
+//! - **Structured errors** - Standardized error responses with `trace_id` for debugging
+//! - **Validation** - Built-in request validation using the `validator` crate
+//! - **Observability** - Integrated tracing for structured logging
+//!
+//! ## Quick Start
+//!
+//! ```rust,ignore
+//! use rapina::prelude::*;
+//!
+//! #[get("/")]
+//! async fn hello() -> &'static str {
+//!     "Hello, Rapina!"
+//! }
+//!
+//! #[get("/users/:id")]
+//! async fn get_user(id: Path<u64>) -> Result<Json<serde_json::Value>> {
+//!     let id = id.into_inner();
+//!     Ok(Json(serde_json::json!({ "id": id })))
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let router = Router::new()
+//!         .get("/", hello)
+//!         .get("/users/:id", get_user);
+//!
+//!     Rapina::new()
+//!         .router(router)
+//!         .listen("127.0.0.1:3000")
+//!         .await
+//! }
+//! ```
+//!
+//! ## Extractors
+//!
+//! Rapina provides several extractors for parsing request data:
+//!
+//! - [`Json`](extract::Json) - Parse JSON request bodies
+//! - [`Path`](extract::Path) - Extract path parameters
+//! - [`Query`](extract::Query) - Parse query string parameters
+//! - [`Form`](extract::Form) - Parse URL-encoded form data
+//! - [`Headers`](extract::Headers) - Access request headers
+//! - [`State`](extract::State) - Access application state
+//! - [`Context`](extract::Context) - Access request context with trace_id
+//! - [`Validated`](extract::Validated) - Validate extracted data
+//!
+//! ## Middleware
+//!
+//! Built-in middleware for common use cases:
+//!
+//! - [`TimeoutMiddleware`](middleware::TimeoutMiddleware) - Request timeout handling
+//! - [`BodyLimitMiddleware`](middleware::BodyLimitMiddleware) - Limit request body size
+//! - [`TraceIdMiddleware`](middleware::TraceIdMiddleware) - Add trace IDs to requests
+//! - [`RequestLogMiddleware`](middleware::RequestLogMiddleware) - Structured request logging
+
 pub mod app;
 pub mod context;
 pub mod error;
@@ -11,6 +78,14 @@ pub mod server;
 pub mod state;
 pub mod test;
 
+/// Convenient re-exports for common Rapina types.
+///
+/// This module re-exports the most commonly used types so you can
+/// import everything you need with a single `use` statement:
+///
+/// ```
+/// use rapina::prelude::*;
+/// ```
 pub mod prelude {
     pub use crate::app::Rapina;
     pub use crate::context::RequestContext;

--- a/rapina/src/observability/mod.rs
+++ b/rapina/src/observability/mod.rs
@@ -1,3 +1,7 @@
+//! Observability utilities for Rapina applications.
+//!
+//! This module provides tools for logging, tracing, and monitoring.
+
 mod tracing;
 
 pub use self::tracing::TracingConfig;

--- a/rapina/src/observability/tracing.rs
+++ b/rapina/src/observability/tracing.rs
@@ -1,12 +1,33 @@
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, fmt};
 
+/// Configuration for the tracing/logging system.
+///
+/// Use the builder pattern to configure logging output format and level.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rapina::prelude::*;
+///
+/// // JSON logging for production
+/// Rapina::new()
+///     .with_tracing(TracingConfig::new().json())
+///     .router(router)
+///     .listen("127.0.0.1:3000")
+///     .await
+/// ```
 #[derive(Debug, Clone)]
 pub struct TracingConfig {
+    /// Output logs as JSON.
     pub json: bool,
+    /// The minimum log level.
     pub level: Level,
+    /// Include the target (module path) in logs.
     pub with_target: bool,
+    /// Include the source file in logs.
     pub with_file: bool,
+    /// Include line numbers in logs.
     pub with_line_number: bool,
 }
 
@@ -23,35 +44,42 @@ impl Default for TracingConfig {
 }
 
 impl TracingConfig {
+    /// Creates a new tracing configuration with default values.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Enables JSON output format.
     pub fn json(mut self) -> Self {
         self.json = true;
         self
     }
 
+    /// Sets the minimum log level.
     pub fn level(mut self, level: Level) -> Self {
         self.level = level;
         self
     }
 
+    /// Configures whether to include the target in logs.
     pub fn with_target(mut self, enabled: bool) -> Self {
         self.with_target = enabled;
         self
     }
 
+    /// Configures whether to include file names in logs.
     pub fn with_file(mut self, enabled: bool) -> Self {
         self.with_file = enabled;
         self
     }
 
+    /// Configures whether to include line numbers in logs.
     pub fn with_line_number(mut self, enabled: bool) -> Self {
         self.with_line_number = enabled;
         self
     }
 
+    /// Initializes the tracing subscriber with this configuration.
     pub fn init(self) {
         let filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new(self.level.to_string()));

--- a/rapina/src/response.rs
+++ b/rapina/src/response.rs
@@ -1,10 +1,39 @@
+//! Response types and conversion traits.
+//!
+//! This module defines the [`IntoResponse`] trait which allows various types
+//! to be converted into HTTP responses.
+
 use bytes::Bytes;
 use http::{Response, StatusCode};
 use http_body_util::Full;
 
+/// The body type used for HTTP responses.
 pub type BoxBody = Full<Bytes>;
 
+/// Trait for types that can be converted into an HTTP response.
+///
+/// Implement this trait to allow your type to be returned from handlers.
+/// Rapina provides implementations for common types like strings,
+/// status codes, and JSON.
+///
+/// # Examples
+///
+/// ```
+/// use rapina::response::{BoxBody, IntoResponse};
+/// use http::Response;
+///
+/// struct MyResponse {
+///     message: String,
+/// }
+///
+/// impl IntoResponse for MyResponse {
+///     fn into_response(self) -> Response<BoxBody> {
+///         self.message.into_response()
+///     }
+/// }
+/// ```
 pub trait IntoResponse {
+    /// Converts this type into an HTTP response.
     fn into_response(self) -> Response<BoxBody>;
 }
 


### PR DESCRIPTION
## Summary
- Add crate-level documentation with quick start examples
- Document all public extractors with examples and error conditions
- Document Error type and all helper methods
- Document IntoResponse trait and implementations
- Document Router and routing methods
- Document Rapina application builder
- Document middleware system and all built-in middleware
- Document observability/tracing configuration

## Test plan
- [x] `cargo doc --no-deps` builds without warnings
- [x] `cargo test --doc` passes
- [x] All library tests pass
- [x] Clippy passes

Closes #32