### PR TITLE
feat: add test client for integration testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +259,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -250,12 +269,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -838,6 +863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1018,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 
 # HTTP server
 hyper = { version = "1.8.1", features = ["server", "http1", "http2"] }
-hyper-util = { version = "0.1.19", features = ["tokio"] }
+hyper-util = { version = "0.1.19", features = ["tokio", "client-legacy", "http1"] }
 http = "1.4.0"
 http-body-util = "0.1.3"
 bytes = "1.11.0"

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -31,10 +31,14 @@ use crate::state::AppState;
 /// }
 /// ```
 pub struct Rapina {
-    router: Router,
-    state: AppState,
-    middlewares: MiddlewareStack,
-    introspection: bool,
+    /// The router for this application.
+    pub(crate) router: Router,
+    /// The application state.
+    pub(crate) state: AppState,
+    /// The middleware stack.
+    pub(crate) middlewares: MiddlewareStack,
+    /// Whether introspection is enabled.
+    pub(crate) introspection: bool,
 }
 
 impl Rapina {

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -70,6 +70,12 @@
 //! Access route metadata for documentation and tooling:
 //!
 //! - [`RouteInfo`](introspection::RouteInfo) - Metadata about registered routes
+//!
+//! ## Testing
+//!
+//! Integration testing utilities:
+//!
+//! - [`TestClient`](testing::TestClient) - Test client for integration testing
 
 pub mod app;
 pub mod context;
@@ -84,6 +90,7 @@ pub mod router;
 pub mod server;
 pub mod state;
 pub mod test;
+pub mod testing;
 
 /// Convenient re-exports for common Rapina types.
 ///

--- a/rapina/src/testing/client.rs
+++ b/rapina/src/testing/client.rs
@@ -1,0 +1,487 @@
+//! Test client for integration testing Rapina applications.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+use http_body_util::{BodyExt, Full};
+use hyper::Request;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioIo;
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+
+use crate::context::RequestContext;
+use crate::introspection::RouteRegistry;
+use crate::middleware::MiddlewareStack;
+use crate::router::Router;
+use crate::state::AppState;
+
+/// A test client for making HTTP requests to a Rapina application.
+///
+/// The test client spawns a lightweight HTTP server on a random port
+/// and provides a convenient API for making requests and asserting responses.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rapina::prelude::*;
+/// use rapina::testing::TestClient;
+///
+/// #[tokio::test]
+/// async fn test_hello() {
+///     let app = Rapina::new()
+///         .router(Router::new().get("/", |_, _, _| async { "Hello!" }));
+///
+///     let client = TestClient::new(app).await;
+///     let response = client.get("/").send().await;
+///
+///     assert_eq!(response.status(), StatusCode::OK);
+///     assert_eq!(response.text(), "Hello!");
+/// }
+/// ```
+pub struct TestClient {
+    addr: SocketAddr,
+    client: Client<hyper_util::client::legacy::connect::HttpConnector, Full<Bytes>>,
+    _shutdown: oneshot::Sender<()>,
+}
+
+impl TestClient {
+    /// Creates a new test client from a Rapina application.
+    ///
+    /// This spawns a background server on a random available port.
+    pub async fn new(app: crate::app::Rapina) -> Self {
+        Self::from_parts(app.router, app.state, app.middlewares, app.introspection).await
+    }
+
+    /// Creates a test client from router, state, and middlewares.
+    pub async fn from_parts(
+        mut router: Router,
+        mut state: AppState,
+        middlewares: MiddlewareStack,
+        introspection: bool,
+    ) -> Self {
+        // Apply introspection if enabled
+        if introspection {
+            let routes = router.routes();
+            state = state.with(RouteRegistry::with_routes(routes));
+            router = router.get_named(
+                "/.__rapina/routes",
+                "list_routes",
+                crate::introspection::list_routes,
+            );
+        }
+
+        let router = Arc::new(router);
+        let state = Arc::new(state);
+        let middlewares = Arc::new(middlewares);
+
+        // Bind to a random available port
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Create shutdown channel
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+        // Spawn the server
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, _)) => {
+                                let io = TokioIo::new(stream);
+                                let router = router.clone();
+                                let state = state.clone();
+                                let middlewares = middlewares.clone();
+
+                                tokio::spawn(async move {
+                                    let service = service_fn(move |mut req: Request<Incoming>| {
+                                        let router = router.clone();
+                                        let state = state.clone();
+                                        let middlewares = middlewares.clone();
+
+                                        let ctx = RequestContext::new();
+                                        req.extensions_mut().insert(ctx.clone());
+
+                                        async move {
+                                            let response = middlewares.execute(req, &router, &state, &ctx).await;
+                                            Ok::<_, std::convert::Infallible>(response)
+                                        }
+                                    });
+
+                                    let _ = http1::Builder::new()
+                                        .serve_connection(io, service)
+                                        .await;
+                                });
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    _ = &mut shutdown_rx => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        let client = Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
+
+        Self {
+            addr,
+            client,
+            _shutdown: shutdown_tx,
+        }
+    }
+
+    /// Creates a GET request builder.
+    pub fn get(&self, path: &str) -> TestRequestBuilder<'_> {
+        self.request(Method::GET, path)
+    }
+
+    /// Creates a POST request builder.
+    pub fn post(&self, path: &str) -> TestRequestBuilder<'_> {
+        self.request(Method::POST, path)
+    }
+
+    /// Creates a PUT request builder.
+    pub fn put(&self, path: &str) -> TestRequestBuilder<'_> {
+        self.request(Method::PUT, path)
+    }
+
+    /// Creates a DELETE request builder.
+    pub fn delete(&self, path: &str) -> TestRequestBuilder<'_> {
+        self.request(Method::DELETE, path)
+    }
+
+    /// Creates a PATCH request builder.
+    pub fn patch(&self, path: &str) -> TestRequestBuilder<'_> {
+        self.request(Method::PATCH, path)
+    }
+
+    /// Creates a request builder with the given method and path.
+    pub fn request(&self, method: Method, path: &str) -> TestRequestBuilder<'_> {
+        TestRequestBuilder::new(self, method, path)
+    }
+
+    /// Returns the address the test server is listening on.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+}
+
+/// Builder for constructing test requests.
+pub struct TestRequestBuilder<'a> {
+    client: &'a TestClient,
+    method: Method,
+    path: String,
+    headers: HeaderMap,
+    body: Bytes,
+}
+
+impl<'a> TestRequestBuilder<'a> {
+    fn new(client: &'a TestClient, method: Method, path: &str) -> Self {
+        Self {
+            client,
+            method,
+            path: path.to_string(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        }
+    }
+
+    /// Adds a header to the request.
+    pub fn header(mut self, key: &str, value: &str) -> Self {
+        self.headers.insert(
+            HeaderName::from_bytes(key.as_bytes()).unwrap(),
+            HeaderValue::from_str(value).unwrap(),
+        );
+        self
+    }
+
+    /// Sets a JSON body on the request.
+    pub fn json<T: Serialize>(mut self, body: &T) -> Self {
+        self.body = Bytes::from(serde_json::to_vec(body).unwrap());
+        self.headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        self
+    }
+
+    /// Sets a form body on the request.
+    pub fn form<T: Serialize>(mut self, body: &T) -> Self {
+        self.body = Bytes::from(serde_urlencoded::to_string(body).unwrap());
+        self.headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
+        self
+    }
+
+    /// Sets raw body bytes.
+    pub fn body(mut self, body: impl Into<Bytes>) -> Self {
+        self.body = body.into();
+        self
+    }
+
+    /// Sends the request and returns the response.
+    pub async fn send(self) -> TestResponse {
+        let uri = format!("http://{}{}", self.client.addr, self.path);
+
+        let mut builder = Request::builder().method(self.method).uri(&uri);
+
+        for (key, value) in self.headers.iter() {
+            builder = builder.header(key, value);
+        }
+
+        let request = builder.body(Full::new(self.body)).unwrap();
+
+        let response = self.client.client.request(request).await.unwrap();
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+
+        TestResponse {
+            status,
+            headers,
+            body,
+        }
+    }
+}
+
+/// Response from a test request.
+pub struct TestResponse {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Bytes,
+}
+
+impl TestResponse {
+    /// Returns the HTTP status code.
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Returns the response headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Returns the response body as text.
+    pub fn text(&self) -> String {
+        String::from_utf8_lossy(&self.body).to_string()
+    }
+
+    /// Returns the response body as raw bytes.
+    pub fn bytes(&self) -> &Bytes {
+        &self.body
+    }
+
+    /// Deserializes the response body as JSON.
+    pub fn json<T: DeserializeOwned>(&self) -> T {
+        serde_json::from_slice(&self.body).unwrap()
+    }
+
+    /// Attempts to deserialize the response body as JSON.
+    pub fn try_json<T: DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_slice(&self.body)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::Rapina;
+
+    #[tokio::test]
+    async fn test_client_get() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new().get("/", |_, _, _| async { "Hello!" }));
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text(), "Hello!");
+    }
+
+    #[tokio::test]
+    async fn test_client_post_json() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new().post("/echo", |req, _, _| async move {
+                use http_body_util::BodyExt;
+                let body = req.into_body().collect().await.unwrap().to_bytes();
+                String::from_utf8_lossy(&body).to_string()
+            }));
+
+        let client = TestClient::new(app).await;
+        let response = client
+            .post("/echo")
+            .json(&serde_json::json!({"name": "test"}))
+            .send()
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.text().contains("test"));
+    }
+
+    #[tokio::test]
+    async fn test_client_with_headers() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new().get("/headers", |req, _, _| async move {
+                let auth = req
+                    .headers()
+                    .get("authorization")
+                    .map(|v| v.to_str().unwrap_or(""))
+                    .unwrap_or("");
+                auth.to_string()
+            }));
+
+        let client = TestClient::new(app).await;
+        let response = client
+            .get("/headers")
+            .header("authorization", "Bearer token123")
+            .send()
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text(), "Bearer token123");
+    }
+
+    #[tokio::test]
+    async fn test_client_not_found() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new());
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/nonexistent").send().await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_client_json_response() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new().get("/json", |_, _, _| async {
+                http::Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "application/json")
+                    .body(http_body_util::Full::new(bytes::Bytes::from(
+                        r#"{"id":1,"name":"test"}"#,
+                    )))
+                    .unwrap()
+            }));
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/json").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct Data {
+            id: i32,
+            name: String,
+        }
+
+        let data: Data = response.json();
+        assert_eq!(data.id, 1);
+        assert_eq!(data.name, "test");
+    }
+
+    #[tokio::test]
+    async fn test_client_with_state() {
+        use std::sync::Arc;
+
+        #[derive(Clone)]
+        struct AppConfig {
+            name: String,
+        }
+
+        let app = Rapina::new()
+            .with_introspection(false)
+            .state(AppConfig {
+                name: "TestApp".to_string(),
+            })
+            .router(
+                Router::new().get("/config", |_, _, state: Arc<AppState>| async move {
+                    let config = state.get::<AppConfig>().unwrap();
+                    config.name.clone()
+                }),
+            );
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/config").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text(), "TestApp");
+    }
+
+    #[tokio::test]
+    async fn test_client_put() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(
+                Router::new().route(Method::PUT, "/resource", |_, _, _| async {
+                    StatusCode::NO_CONTENT
+                }),
+            );
+
+        let client = TestClient::new(app).await;
+        let response = client.put("/resource").send().await;
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_client_delete() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(
+                Router::new().route(Method::DELETE, "/resource", |_, _, _| async {
+                    StatusCode::NO_CONTENT
+                }),
+            );
+
+        let client = TestClient::new(app).await;
+        let response = client.delete("/resource").send().await;
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_response_bytes() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new().get("/bytes", |_, _, _| async { "raw bytes" }));
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/bytes").send().await;
+
+        assert_eq!(response.bytes(), &Bytes::from("raw bytes"));
+    }
+
+    #[tokio::test]
+    async fn test_client_addr() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .router(Router::new());
+
+        let client = TestClient::new(app).await;
+        let addr = client.addr();
+
+        assert!(addr.port() > 0);
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+    }
+}

--- a/rapina/src/testing/mod.rs
+++ b/rapina/src/testing/mod.rs
@@ -1,0 +1,8 @@
+//! Testing utilities for Rapina applications.
+//!
+//! This module provides a test client for integration testing without
+//! starting a full HTTP server.
+
+mod client;
+
+pub use client::{TestClient, TestRequestBuilder, TestResponse};


### PR DESCRIPTION
Closes #15

## Summary
- Add `testing` module with `TestClient`, `TestRequestBuilder`, and `TestResponse`
- TestClient spawns a lightweight server on a random port for testing
- Support for all HTTP methods (GET, POST, PUT, DELETE, PATCH)
- Fluent API for building requests with headers, JSON, and form bodies
- Response helpers for parsing JSON and text

## Usage
```rust
use rapina::prelude::*;
use rapina::testing::TestClient;

#[tokio::test]
async fn test_hello() {
    let app = Rapina::new()
        .router(Router::new().get("/", |_, _, _| async { "Hello!" }));

    let client = TestClient::new(app).await;
    let response = client.get("/").send().await;

    assert_eq!(response.status(), StatusCode::OK);
    assert_eq!(response.text(), "Hello!");
}
```

## Test plan
- [x] Tests for GET, POST, PUT, DELETE requests
- [x] Tests for headers and JSON bodies
- [x] Tests for state and middleware
- [x] All existing tests pass
- [x] Clippy clean