### PR TITLE
feat: add rapina new command for project scaffolding

### DIFF
--- a/rapina-cli/src/commands/mod.rs
+++ b/rapina-cli/src/commands/mod.rs
@@ -1,5 +1,3 @@
 //! CLI command implementations.
-//!
-//! This module will contain implementations for:
-//! - `rapina new` - Create new Rapina projects
-//! - `rapina dev` - Run development server with hot reload
+
+pub mod new;

--- a/rapina-cli/src/commands/new.rs
+++ b/rapina-cli/src/commands/new.rs
@@ -1,0 +1,172 @@
+//! Implementation of the `rapina new` command.
+
+use colored::Colorize;
+use std::fs;
+use std::path::Path;
+
+/// Execute the `new` command to create a new Rapina project.
+pub fn execute(name: &str) -> Result<(), String> {
+    // Validate project name
+    validate_project_name(name)?;
+
+    // Check if directory already exists
+    let project_path = Path::new(name);
+    if project_path.exists() {
+        return Err(format!("Directory '{}' already exists", name));
+    }
+
+    println!();
+    println!(
+        "  {} {}",
+        "Creating new Rapina project:".bright_cyan(),
+        name.bold()
+    );
+    println!();
+
+    // Create project directory structure
+    let src_path = project_path.join("src");
+    fs::create_dir_all(&src_path).map_err(|e| format!("Failed to create directory: {}", e))?;
+
+    // Create Cargo.toml
+    let cargo_toml = generate_cargo_toml(name);
+    let cargo_path = project_path.join("Cargo.toml");
+    fs::write(&cargo_path, cargo_toml).map_err(|e| format!("Failed to write Cargo.toml: {}", e))?;
+    println!("  {} Created {}", "✓".green(), "Cargo.toml".cyan());
+
+    // Create src/main.rs
+    let main_rs = generate_main_rs();
+    let main_path = src_path.join("main.rs");
+    fs::write(&main_path, main_rs).map_err(|e| format!("Failed to write main.rs: {}", e))?;
+    println!("  {} Created {}", "✓".green(), "src/main.rs".cyan());
+
+    // Create .gitignore
+    let gitignore = generate_gitignore();
+    let gitignore_path = project_path.join(".gitignore");
+    fs::write(&gitignore_path, gitignore)
+        .map_err(|e| format!("Failed to write .gitignore: {}", e))?;
+    println!("  {} Created {}", "✓".green(), ".gitignore".cyan());
+
+    println!();
+    println!("  {} Project created successfully!", "🎉".bold());
+    println!();
+    println!("  {}:", "Next steps".bright_yellow());
+    println!("    cd {}", name.cyan());
+    println!("    cargo run");
+    println!();
+
+    Ok(())
+}
+
+/// Validate that the project name is a valid Rust crate name.
+fn validate_project_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Project name cannot be empty".to_string());
+    }
+
+    // Check if name starts with a digit
+    if name.chars().next().unwrap().is_ascii_digit() {
+        return Err("Project name cannot start with a digit".to_string());
+    }
+
+    // Check for valid characters (alphanumeric, underscore, hyphen)
+    for c in name.chars() {
+        if !c.is_alphanumeric() && c != '_' && c != '-' {
+            return Err(format!(
+                "Project name contains invalid character: '{}'. Only alphanumeric characters, underscores, and hyphens are allowed.",
+                c
+            ));
+        }
+    }
+
+    // Check for reserved names
+    let reserved = ["test", "self", "super", "crate", "Self"];
+    if reserved.contains(&name) {
+        return Err(format!("'{}' is a reserved Rust keyword", name));
+    }
+
+    Ok(())
+}
+
+/// Generate the content for Cargo.toml.
+fn generate_cargo_toml(name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rapina = "0.1"
+tokio = {{ version = "1", features = ["full"] }}
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+"#
+    )
+}
+
+/// Generate the content for src/main.rs.
+fn generate_main_rs() -> String {
+    r#"use rapina::prelude::*;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let router = Router::new()
+        .get_named("/", "hello", hello)
+        .get_named("/health", "health_check", health);
+
+    println!("Starting Rapina server on http://127.0.0.1:3000");
+
+    Rapina::new()
+        .router(router)
+        .listen("127.0.0.1:3000")
+        .await
+}
+
+async fn hello(
+    _req: hyper::Request<hyper::body::Incoming>,
+    _params: rapina::extract::PathParams,
+    _state: std::sync::Arc<rapina::state::AppState>,
+) -> &'static str {
+    "Hello from Rapina!"
+}
+
+async fn health(
+    _req: hyper::Request<hyper::body::Incoming>,
+    _params: rapina::extract::PathParams,
+    _state: std::sync::Arc<rapina::state::AppState>,
+) -> &'static str {
+    "OK"
+}
+"#
+    .to_string()
+}
+
+/// Generate the content for .gitignore.
+fn generate_gitignore() -> String {
+    r#"/target
+Cargo.lock
+"#
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_project_name_valid() {
+        assert!(validate_project_name("my-app").is_ok());
+        assert!(validate_project_name("my_app").is_ok());
+        assert!(validate_project_name("myapp").is_ok());
+        assert!(validate_project_name("myapp123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_project_name_invalid() {
+        assert!(validate_project_name("").is_err());
+        assert!(validate_project_name("123app").is_err());
+        assert!(validate_project_name("my app").is_err());
+        assert!(validate_project_name("my.app").is_err());
+        assert!(validate_project_name("self").is_err());
+    }
+}

--- a/rapina-cli/src/main.rs
+++ b/rapina-cli/src/main.rs
@@ -17,6 +17,11 @@ struct Cli {
 enum Commands {
     /// Display version information
     Version,
+    /// Create a new Rapina project
+    New {
+        /// Name of the project to create
+        name: String,
+    },
 }
 
 fn main() {
@@ -25,6 +30,12 @@ fn main() {
     match cli.command {
         Some(Commands::Version) => {
             print_version();
+        }
+        Some(Commands::New { name }) => {
+            if let Err(e) = commands::new::execute(&name) {
+                eprintln!("{} {}", "Error:".red().bold(), e);
+                std::process::exit(1);
+            }
         }
         None => {
             print_banner();


### PR DESCRIPTION
## Summary
- Add `rapina new <name>` command to create new Rapina projects
- Generate project with Cargo.toml, src/main.rs, and .gitignore
- Include project name validation (valid Rust crate names)
- Colored CLI output with success messages and next steps

## Usage
```bash
rapina new my-app
```

## Generated Structure
```
my-app/
├── Cargo.toml
├── src/
│   └── main.rs
└── .gitignore
```

Closes #39

## Test plan
- [x] `cargo build -p rapina-cli` compiles
- [x] `rapina new my-app` creates project with correct files
- [x] Invalid project names are rejected with clear error messages
- [x] Existing directories are detected and rejected
- [x] Unit tests pass for name validation