### PR TITLE
fix use declarative macros in project template

### DIFF
--- a/rapina-cli/src/commands/new.rs
+++ b/rapina-cli/src/commands/new.rs
@@ -110,8 +110,6 @@ hyper = "1"
 fn generate_main_rs() -> String {
     r#"use rapina::prelude::*;
 use rapina::middleware::RequestLogMiddleware;
-use serde::Serialize;
-use std::sync::Arc;
 
 #[derive(Serialize)]
 struct MessageResponse {
@@ -127,8 +125,8 @@ struct HealthResponse {
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let router = Router::new()
-        .get_named("/", "hello", hello)
-        .get_named("/health", "health_check", health);
+        .get("/", hello)
+        .get("/health", health);
 
     Rapina::new()
         .with_tracing(TracingConfig::new())
@@ -138,21 +136,15 @@ async fn main() -> std::io::Result<()> {
         .await
 }
 
-async fn hello(
-    _req: hyper::Request<hyper::body::Incoming>,
-    _params: rapina::extract::PathParams,
-    _state: Arc<rapina::state::AppState>,
-) -> Json<MessageResponse> {
+#[get("/path")]
+async fn hello() -> Json<MessageResponse> {
     Json(MessageResponse {
         message: "Hello from Rapina!".to_string(),
     })
 }
 
-async fn health(
-    _req: hyper::Request<hyper::body::Incoming>,
-    _params: rapina::extract::PathParams,
-    _state: Arc<rapina::state::AppState>,
-) -> Json<HealthResponse> {
+#[get("/path")]
+async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "healthy".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),


### PR DESCRIPTION
The template generated by `rapina new` cmd was using the old verbose handler style. 
Updated it to use the declarative macros which is how we actually think people will write Rapina apps.

Closes #56 