### PR TITLE
Add OpenAPI error envelope

### DIFF
--- a/rapina/examples/macros.rs
+++ b/rapina/examples/macros.rs
@@ -105,6 +105,7 @@ async fn main() -> std::io::Result<()> {
         .post("/users", create_user);
 
     Rapina::new()
+        .openapi("Rapina Test", "1.0.0")
         .state(config)
         .router(router)
         .listen("127.0.0.1:3000")


### PR DESCRIPTION
## Summary
  - Add ErrorResponse schema to OpenAPI components
  - Include default error response in all operations

  Part of #58 (Step 2)