### PR TITLE
Add Type-safe configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +926,7 @@ name = "rapina"
 version = "0.1.0-alpha.4"
 dependencies = [
  "bytes",
+ "dotenvy",
  "http",
  "http-body-util",
  "hyper",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,53 @@ rapina routes                           # List all registered routes
 rapina doctor                           # Run API health checks
 ```
 
+### Configuration
+
+Type-safe configuration with the `Config` derive macro:
+
+```rust
+use rapina::prelude::*;
+
+#[derive(Config)]
+struct Settings {
+    #[env = "DATABASE_URL"]
+    database_url: String,
+
+    #[env = "PORT"]
+    #[default = "3000"]
+    port: u16,
+
+    #[env = "HOST"]
+    #[default = "127.0.0.1"]
+    host: String,
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    load_dotenv();
+
+    let config = Settings::from_env().expect("Missing config");
+
+    Rapina::new()
+        .router(router)
+        .listen(format!("{}:{}", config.host, config.port))
+        .await
+}
+```
+
+Features:
+- Loads from environment variables and `.env` files
+- Fail-fast validation with clear error messages
+- Type-safe parsing with defaults
+
+Create a `.env` file for local development:
+
+```bash
+DATABASE_URL=postgres://localhost/myapp
+PORT=3000
+JWT_SECRET=your-secret-key
+```
+
 ### Typed Extractors
 
 ```rust

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -39,6 +39,9 @@ tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 uuid = { version = "1", features = ["v4"] }
 
+# Environtment
+dotenvy = "0.15.7"
+
 # OpenAPI
 schemars = "1.2.0"
 

--- a/rapina/examples/macros.rs
+++ b/rapina/examples/macros.rs
@@ -2,9 +2,19 @@ use rapina::extract::{FromRequestParts, State};
 use rapina::prelude::*;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Clone, Config)]
 struct AppConfig {
+    #[env = "APP_NAME"]
+    #[default = "Rapina Demo"]
     app_name: String,
+
+    #[env = "PORT"]
+    #[default = "3000"]
+    port: u16,
+
+    #[env = "HOST"]
+    #[default = "127.0.0.1"]
+    host: String,
 }
 
 #[derive(Deserialize)]
@@ -93,9 +103,10 @@ async fn create_user(body: Json<CreateUser>) -> Json<User> {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let config = AppConfig {
-        app_name: "Rapina Demo".to_string(),
-    };
+    // Load .env file if present
+    load_dotenv();
+    let config = AppConfig::from_env().expect("Failed to load config");
+    let addr = format!("{}:{}", config.host, config.port);
 
     let router = Router::new()
         .get("/", hello)
@@ -108,6 +119,6 @@ async fn main() -> std::io::Result<()> {
         .openapi("Rapina Test", "1.0.0")
         .state(config)
         .router(router)
-        .listen("127.0.0.1:3000")
+        .listen(&addr)
         .await
 }

--- a/rapina/src/config.rs
+++ b/rapina/src/config.rs
@@ -1,0 +1,113 @@
+//! Type-safe configuration loading from environment variables
+//!
+//! This module provides utilities for loading configuration from
+//! environment variables and `.env` files
+
+use std::env;
+use std::str::FromStr;
+
+/// Load environment variables from `.env` files if it exists.
+///
+/// Call this at the start of your application before accessing config.
+pub fn load_dotenv() {
+    let _ = dotenvy::dotenv();
+}
+
+/// Get a required environment variable.
+///
+/// Returns an error if the variable is not set.
+pub fn get_env(key: &str) -> Result<String, ConfigError> {
+    env::var(key).map_err(|_| ConfigError::Missing(key.to_string()))
+}
+
+/// Get an optional environment with a default value
+pub fn get_env_or(key: &str, default: &str) -> String {
+    env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+/// Get and parse an environment variable.
+pub fn get_env_parsed<T: FromStr>(key: &str) -> Result<T, ConfigError> {
+    let value = get_env(key)?;
+    value.parse().map_err(|_| ConfigError::Invalid {
+        key: key.to_string(),
+        value,
+    })
+}
+
+/// Get and parse an environment variable with a default.
+pub fn get_env_parsed_or<T: FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Configuration loading errors.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// Environment variable is not set.
+    Missing(String),
+    /// Multiple environment variables are not set.
+    MissingMultiple(Vec<String>),
+    /// Environment variable value is invalid.
+    Invalid { key: String, value: String },
+}
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::Missing(key) => write!(
+                f,
+                "missing
+  required config: {}",
+                key
+            ),
+            ConfigError::MissingMultiple(keys) => {
+                writeln!(f, "missing required configuration:")?;
+                for key in keys {
+                    writeln!(f, "  - {}", key)?;
+                }
+                Ok(())
+            }
+            ConfigError::Invalid { key, value } => {
+                write!(f, "invalid config for {}: '{}'", key, value)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_env_missing() {
+        let result = get_env("RAPINA_TEST_MISSING_VAR_12345");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_env_or_default() {
+        let value = get_env_or("RAPINA_TEST_MISSING_VAR_12345", "default");
+        assert_eq!(value, "default");
+    }
+
+    #[test]
+    fn test_get_env_parsed_or_default() {
+        let value: u16 = get_env_parsed_or("RAPINA_TEST_MISSING_VAR_12345", 3000);
+        assert_eq!(value, 3000);
+    }
+
+    #[test]
+    fn test_config_error_display() {
+        let err = ConfigError::Missing("DATABASE_URL".to_string());
+        assert_eq!(err.to_string(), "missing\n  required config: DATABASE_URL");
+
+        let err = ConfigError::Invalid {
+            key: "PORT".to_string(),
+            value: "abc".to_string(),
+        };
+        assert_eq!(err.to_string(), "invalid config for PORT: 'abc'");
+    }
+}

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -78,6 +78,7 @@
 //! - [`TestClient`](testing::TestClient) - Test client for integration testing
 
 pub mod app;
+pub mod config;
 pub mod context;
 pub mod error;
 pub mod extract;
@@ -103,6 +104,9 @@ pub mod testing;
 /// ```
 pub mod prelude {
     pub use crate::app::Rapina;
+    pub use crate::config::{
+        ConfigError, get_env, get_env_or, get_env_parsed, get_env_parsed_or, load_dotenv,
+    };
     pub use crate::context::RequestContext;
     pub use crate::error::{DocumentedError, Error, ErrorVariant, IntoApiError, Result};
     pub use crate::extract::{Context, Form, Headers, Json, Path, Query, Validated};
@@ -118,7 +122,7 @@ pub mod prelude {
     pub use tracing;
     pub use validator::Validate;
 
-    pub use rapina_macros::{delete, get, post, put};
+    pub use rapina_macros::{Config, delete, get, post, put};
 }
 
 // Re-export schemars so users don't need to add it to their Cargo.toml


### PR DESCRIPTION
## Summary
  - Add `#[derive(Config)]` macro for type-safe configuration from
  environment variables
  - Support `#[env = "VAR_NAME"]` to specify env var names
  - Support `#[default = "value"]` for optional fields with
  defaults
  - Fail-fast validation that reports all missing variables at once
  - Add `load_dotenv()` helper for `.env` file support

  ## Test plan
  - [x] Run `cargo build` - compiles successfully
  - [x] Run `cargo test` - all tests pass
  - [x] Run `cargo clippy` - no warnings
  - [x] Test with `macros.rs` example - server starts correctly