### PR TITLE
fix: consolidate Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://crates.io/crates/rapina"><img src="https://img.shields.io/crates/v/rapina.svg" alt="Crates.io"></a>
   <a href="https://docs.rs/rapina"><img src="https://docs.rs/rapina/badge.svg" alt="Documentation"></a>
   <a href="https://github.com/arferreira/rapina/actions/workflows/ci.yml"><img src="https://github.com/arferreira/rapina/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://discord.gg/ttRYzbHh"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/jMhhfjEE"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>
 


### PR DESCRIPTION
## Summary
This PR consolidates all Discord invite links to use a single permanent link (#161).

## Changes Made
- Updated README.md to use  instead of 
- All Discord links in the project now point to the same permanent invite link

## Files Changed
-  - Updated Discord badge link

This resolves issue #161 by ensuring all Discord invite links use the same permanent URL.