### PR TITLE
#163 Feat/add graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2122,6 +2122,7 @@ dependencies = [
  "hyper-util",
  "inventory",
  "jsonwebtoken",
+ "nix",
  "prometheus",
  "rapina-macros",
  "schemars",
@@ -2130,6 +2131,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "serial_test",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2392,6 +2394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2433,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -2686,6 +2703,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -21,6 +21,7 @@ hyper-util = { version = "0.1.19", features = [
   "tokio",
   "client-legacy",
   "http1",
+  "server-graceful",
 ] }
 http = "1.4.0"
 http-body-util = "0.1.3"
@@ -70,6 +71,10 @@ async-trait = { version = "0.1", optional = true }
 
 # Prometheus (optional)
 prometheus = { version = '0.13', optional = true }
+
+[dev-dependencies]
+nix = { version = "0.30", features = ["signal"] }
+serial_test = "3"
 
 [features]
 default = []

--- a/rapina/src/server.rs
+++ b/rapina/src/server.rs
@@ -1,57 +1,301 @@
+use std::future::Future;
 use std::net::SocketAddr;
+use std::pin::{Pin, pin};
 use std::sync::Arc;
+use std::time::Duration;
 
 use hyper::Request;
 use hyper::body::Incoming;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper_util::rt::TokioIo;
+use hyper_util::server::graceful::GracefulShutdown;
 use tokio::net::TcpListener;
+use tokio::signal::unix::SignalKind;
 
 use crate::context::RequestContext;
 use crate::middleware::MiddlewareStack;
 use crate::router::Router;
 use crate::state::AppState;
 
-pub async fn serve(
+/// A shutdown hook: a closure that returns a boxed future.
+pub(crate) type ShutdownHook = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+pub(crate) async fn serve(
     router: Router,
     state: AppState,
     middlewares: MiddlewareStack,
     addr: SocketAddr,
+    shutdown_timeout: Duration,
+    shutdown_hooks: Vec<ShutdownHook>,
 ) -> std::io::Result<()> {
     let router = Arc::new(router);
     let state = Arc::new(state);
     let middlewares = Arc::new(middlewares);
     let listener = TcpListener::bind(addr).await?;
+    let graceful = GracefulShutdown::new();
+    let mut ctrl_c = pin!(tokio::signal::ctrl_c());
+    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())
+        .expect("failed to install SIGTERM handler");
 
     tracing::info!("Rapina listening on http://{}", addr);
 
     loop {
-        let (stream, _) = listener.accept().await?;
-        let io = TokioIo::new(stream);
-        let router = router.clone();
-        let state = state.clone();
-        let middlewares = middlewares.clone();
-
-        tokio::spawn(async move {
-            let service = service_fn(move |mut req: Request<Incoming>| {
+        tokio::select! {
+            result = listener.accept() => {
+                let (stream, _) = result?;
+                let io = TokioIo::new(stream);
                 let router = router.clone();
                 let state = state.clone();
                 let middlewares = middlewares.clone();
 
-                // Create and inject RequestContext at request start
-                let ctx = RequestContext::new();
-                req.extensions_mut().insert(ctx.clone());
+                let service = service_fn(move |mut req: Request<Incoming>| {
+                    let router = router.clone();
+                    let state = state.clone();
+                    let middlewares = middlewares.clone();
 
-                async move {
-                    let response = middlewares.execute(req, &router, &state, &ctx).await;
-                    Ok::<_, std::convert::Infallible>(response)
-                }
-            });
+                    let ctx = RequestContext::new();
+                    req.extensions_mut().insert(ctx.clone());
 
-            if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
-                tracing::error!("connection error: {}", e);
+                    async move {
+                        let response = middlewares.execute(req, &router, &state, &ctx).await;
+                        Ok::<_, std::convert::Infallible>(response)
+                    }
+                });
+
+                let conn = http1::Builder::new().serve_connection(io, service);
+                let conn = graceful.watch(conn);
+
+                tokio::spawn(async move {
+                    if let Err(e) = conn.await {
+                        tracing::error!("connection error: {}", e);
+                    }
+                });
             }
+            _ = ctrl_c.as_mut() => {
+                drop(listener);
+                tracing::info!("Shutdown signal received, waiting for connections to drain...");
+                break;
+            }
+            _ = sigterm.recv() => {
+                drop(listener);
+                tracing::info!("Shutdown signal received, waiting for connections to drain...");
+                break;
+            }
+        }
+    }
+
+    tokio::select! {
+        _ = graceful.shutdown() => {
+            tracing::info!("All connections drained.");
+        }
+        _ = tokio::time::sleep(shutdown_timeout) => {
+            tracing::warn!("Shutdown timeout reached, forcing close.");
+        }
+    }
+
+    for hook in shutdown_hooks {
+        hook().await;
+    }
+
+    tracing::info!("Server stopped.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::getpid;
+    use serial_test::serial;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    async fn free_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        listener.local_addr().unwrap().port()
+    }
+
+    async fn http_get(port: u16, path: &str) -> String {
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+            path
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8_lossy(&buf).to_string()
+    }
+
+    fn send_sigint() {
+        kill(getpid(), Signal::SIGINT).unwrap();
+    }
+
+    fn send_sigterm() {
+        kill(getpid(), Signal::SIGTERM).unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_shutdown_hooks_execute_in_order() {
+        let port = free_port().await;
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+
+        let log1 = log.clone();
+        let log2 = log.clone();
+
+        let router = Router::new().route(http::Method::GET, "/", |_, _, _| async { "ok" });
+
+        let handle = tokio::spawn(serve(
+            router,
+            AppState::new(),
+            MiddlewareStack::new(),
+            format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_secs(5),
+            vec![
+                Box::new(move || {
+                    Box::pin(async move {
+                        log1.lock().unwrap().push("db_pool_closed".to_string());
+                    }) as Pin<Box<dyn Future<Output = ()> + Send>>
+                }),
+                Box::new(move || {
+                    Box::pin(async move {
+                        log2.lock().unwrap().push("metrics_flushed".to_string());
+                    }) as Pin<Box<dyn Future<Output = ()> + Send>>
+                }),
+            ],
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let response = http_get(port, "/").await;
+        assert!(response.contains("200"), "server should respond with 200");
+
+        send_sigint();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(result.is_ok(), "server should shut down within timeout");
+        assert!(
+            result.unwrap().unwrap().is_ok(),
+            "server should exit cleanly"
+        );
+
+        let entries = log.lock().unwrap();
+        assert_eq!(
+            *entries,
+            vec!["db_pool_closed", "metrics_flushed"],
+            "shutdown hooks should run in registration order"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_inflight_request_completes_before_shutdown() {
+        let port = free_port().await;
+
+        let router = Router::new().route(http::Method::GET, "/slow", |_, _, _| async {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            "done"
         });
+
+        let handle = tokio::spawn(serve(
+            router,
+            AppState::new(),
+            MiddlewareStack::new(),
+            format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_secs(5),
+            vec![],
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let response_task = tokio::spawn(async move { http_get(port, "/slow").await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        send_sigint();
+
+        let response = tokio::time::timeout(Duration::from_secs(5), response_task)
+            .await
+            .expect("response should arrive within timeout")
+            .expect("response task should not panic");
+
+        assert!(
+            response.contains("done"),
+            "in-flight request should complete during graceful shutdown"
+        );
+
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_shutdown_timeout_enforced() {
+        let port = free_port().await;
+
+        let router = Router::new().route(http::Method::GET, "/hang", |_, _, _| async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            "never"
+        });
+
+        let handle = tokio::spawn(serve(
+            router,
+            AppState::new(),
+            MiddlewareStack::new(),
+            format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_secs(1),
+            vec![],
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let _hang = tokio::spawn(async move {
+            let _ = http_get(port, "/hang").await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        send_sigint();
+
+        let result = tokio::time::timeout(Duration::from_secs(3), handle).await;
+        assert!(
+            result.is_ok(),
+            "server should exit after shutdown timeout, not wait for hanging connections"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_sigterm_triggers_shutdown() {
+        let port = free_port().await;
+
+        let router = Router::new().route(http::Method::GET, "/", |_, _, _| async { "ok" });
+
+        let handle = tokio::spawn(serve(
+            router,
+            AppState::new(),
+            MiddlewareStack::new(),
+            format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_secs(5),
+            vec![],
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let response = http_get(port, "/").await;
+        assert!(response.contains("200"), "server should respond with 200");
+
+        send_sigterm();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(result.is_ok(), "server should shut down within timeout");
+        assert!(
+            result.unwrap().unwrap().is_ok(),
+            "server should exit cleanly after SIGTERM"
+        );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds graceful shutdown support to Rapina. When the server receives SIGINT/SIGTERM(ctrl-c), it now:

1. Stops accepting new connections
2. Waits for in-flight requests to finish (configurable timeout, default 30s)
3. Runs registered cleanup hooks (e.g., close DB pools, flush metrics)
4. Exits cleanly

## Changes

- **`server.rs`** — Rewrote the accept loop using `hyper_util::GracefulShutdown` and `tokio::select!` to handle shutdown signals
- **`app.rs`** — Added two new builder methods: `.shutdown_timeout(Duration)` and `.on_shutdown(|| async { ... })`
- **`Cargo.toml`** — Enabled `server-graceful` feature on `hyper-util`, added `nix` as dev-dependency for tests
- **`tests/graceful_shutdown.rs`** — Integration tests for hook execution order, in-flight request draining, and timeout enforcement
- **`app.rs` unit tests** — Tests for default timeout, custom timeout, and hook registration

## Related Issues

#163 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
