### PR TITLE
fix: fixed Cargo.toml parse error

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,21 +9,56 @@ on:
 permissions: {}
 
 jobs:
-  welcome:
-    name: Greet first-time contributors
+  welcome-pr:
+    if: github.event_name == 'pull_request_target'
+    name: Greet first-time PR author
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check if first PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh pr list --repo "${{ github.repository }}" \
+            --author "${{ github.event.pull_request.user.login }}" \
+            --state all --json number --jq 'length')
+          echo "pr_count=$count" >> "$GITHUB_OUTPUT"
+      - name: Welcome first-time contributor
+        if: steps.check.outputs.pr_count == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Thanks for your first PR! A maintainer will review it shortly.
+
+          Make sure CI passes and take a look at our [contributing guide](https://github.com/arferreira/rapina/blob/main/CONTRIBUTING.md) if you haven't already."
+
+  welcome-issue:
+    if: github.event_name == 'issues'
+    name: Greet first-time issue author
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
-            Thanks for opening your first issue! We appreciate you taking the time to report this.
+      - name: Check if first issue
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh issue list --repo "${{ github.repository }}" \
+            --author "${{ github.event.issue.user.login }}" \
+            --state all --json number --jq 'length')
+          echo "issue_count=$count" >> "$GITHUB_OUTPUT"
+      - name: Welcome first-time contributor
+        if: steps.check.outputs.issue_count == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "Thanks for opening your first issue! We appreciate you taking the time to report this.
 
-            If you're interested in contributing a fix, check out our [contributing guide](https://github.com/arferreira/rapina/blob/main/CONTRIBUTING.md) and feel free to open a PR.
-          pr_message: |
-            Thanks for your first PR! A maintainer will review it shortly.
-
-            Make sure CI passes and take a look at our [contributing guide](https://github.com/arferreira/rapina/blob/main/CONTRIBUTING.md) if you haven't already.
+          If you're interested in contributing a fix, check out our [contributing guide](https://github.com/arferreira/rapina/blob/main/CONTRIBUTING.md) and feel free to open a PR."

--- a/rapina-cli/src/commands/dev.rs
+++ b/rapina-cli/src/commands/dev.rs
@@ -1,5 +1,6 @@
 //! Implementation of the `rapina dev` command.
 
+use crate::commands::verify_rapina_project;
 use colored::Colorize;
 use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
 use std::path::Path;
@@ -149,35 +150,6 @@ pub fn execute(config: DevConfig) -> Result<(), String> {
     );
     let _ = server_process.kill();
     let _ = server_process.wait();
-
-    Ok(())
-}
-
-/// Verify that we're in a valid Rapina project directory.
-fn verify_rapina_project() -> Result<(), String> {
-    let cargo_toml = Path::new("Cargo.toml");
-    if !cargo_toml.exists() {
-        return Err("No Cargo.toml found. Are you in a Rust project directory?".to_string());
-    }
-
-    let content = std::fs::read_to_string(cargo_toml)
-        .map_err(|e| format!("Failed to read Cargo.toml: {}", e))?;
-
-    let parsed: toml::Value = content
-        .parse()
-        .map_err(|e| format!("Failed to parse Cargo.toml: {}", e))?;
-
-    // Check for rapina in dependencies
-    let has_rapina = parsed
-        .get("dependencies")
-        .and_then(|deps| deps.get("rapina"))
-        .is_some();
-
-    if !has_rapina {
-        return Err(
-            "This doesn't appear to be a Rapina project (no rapina dependency found)".to_string(),
-        );
-    }
 
     Ok(())
 }

--- a/rapina-cli/src/commands/mod.rs
+++ b/rapina-cli/src/commands/mod.rs
@@ -8,3 +8,31 @@ pub mod new;
 pub mod openapi;
 pub mod routes;
 pub mod test;
+
+/// Verify that we're in a valid Rapina project directory.
+pub fn verify_rapina_project() -> Result<(), String> {
+    let cargo_toml = std::path::Path::new("Cargo.toml");
+    if !cargo_toml.exists() {
+        return Err("No Cargo.toml found. Are you in a Rust project directory?".to_string());
+    }
+
+    let content = std::fs::read_to_string(cargo_toml)
+        .map_err(|e| format!("Failed to read Cargo.toml: {}", e))?;
+
+    let parsed: toml::Value =
+        toml::from_str(&content).map_err(|e| format!("Failed to parse Cargo.toml: {}", e))?;
+
+    // Check for rapina in dependencies
+    let has_rapina = parsed
+        .get("dependencies")
+        .and_then(|deps| deps.get("rapina"))
+        .is_some();
+
+    if !has_rapina {
+        return Err(
+            "This doesn't appear to be a Rapina project (no rapina dependency found)".to_string(),
+        );
+    }
+
+    Ok(())
+}

--- a/rapina-cli/src/commands/test.rs
+++ b/rapina-cli/src/commands/test.rs
@@ -1,5 +1,6 @@
 //! Implementation of the `rapina test` command.
 
+use crate::commands::verify_rapina_project;
 use colored::Colorize;
 use notify_debouncer_mini::{DebounceEventResult, new_debouncer, notify::RecursiveMode};
 use std::io::{BufRead, BufReader};
@@ -52,34 +53,6 @@ fn check_coverage_tool() -> Result<(), String> {
             Err("cargo-llvm-cov not found. Install with: cargo install cargo-llvm-cov".to_string())
         }
     }
-}
-
-/// Verify that we're in a valid Rapina project directory.
-fn verify_rapina_project() -> Result<(), String> {
-    let cargo_toml = Path::new("Cargo.toml");
-    if !cargo_toml.exists() {
-        return Err("No Cargo.toml found. Are you in a Rust project directory?".to_string());
-    }
-
-    let content = std::fs::read_to_string(cargo_toml)
-        .map_err(|e| format!("Failed to read Cargo.toml: {}", e))?;
-
-    let parsed: toml::Value = content
-        .parse()
-        .map_err(|e| format!("Failed to parse Cargo.toml: {}", e))?;
-
-    let has_rapina = parsed
-        .get("dependencies")
-        .and_then(|deps| deps.get("rapina"))
-        .is_some();
-
-    if !has_rapina {
-        return Err(
-            "This doesn't appear to be a Rapina project (no rapina dependency found)".to_string(),
-        );
-    }
-
-    Ok(())
 }
 
 /// Run tests once.


### PR DESCRIPTION
- Replace .parse() with toml::from_str to fix parsing failures

## Summary

What does this PR do?

- fixed Cargo.toml parse error when running rapina dev and rapina test commands

## Related Issues
#229 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
