### PR TITLE
test: add unit tests for openapi and introspection endpoint handlers

### DIFF
--- a/rapina/src/introspection/endpoint.rs
+++ b/rapina/src/introspection/endpoint.rs
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_routes_returns_404_and_empty_body_when_with_introspection_disable() {
+    async fn test_list_routes_returns_404_and_empty_body_when_with_introspection_disabled() {
         let router = Router::new().route(Method::GET, "/hello", |_, _, _| async { "hello" });
         let app = Rapina::new().router(router).with_introspection(false);
         let client = TestClient::new(app).await;

--- a/rapina/src/openapi/endpoint.rs
+++ b/rapina/src/openapi/endpoint.rs
@@ -88,7 +88,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_openapi_spec_returns_404_and_empty_body_when_openapi_is_disable() {
+    async fn test_openapi_spec_returns_404_and_empty_body_when_openapi_is_disabled() {
         let router = Router::new().route(Method::GET, "/hello", |_, _, _| async { "hello" });
         let app = Rapina::new().router(router);
         let client = TestClient::new(app).await;


### PR DESCRIPTION
## Summary

What does this PR do?
- add unit tests for openapi and introspection endpoint handlers

## Related Issues
#225 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
