### PR TITLE
Fix syntax highlighting on docs pages

### DIFF
--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -248,8 +248,13 @@
             return excerpt;
         }
 
-        // Initialize syntax highlighting
-        hljs.highlightAll();
+        // Initialize syntax highlighting for template code blocks only.
+        // Skip blocks already highlighted by Zola (they have inline styles).
+        document.querySelectorAll('pre code').forEach(function(block) {
+            if (!block.parentElement.style.color) {
+                hljs.highlightElement(block);
+            }
+        });
 
         // Mobile menu
         function toggleMobileMenu() {


### PR DESCRIPTION
highlight.js was running on every code block including the ones Zola already highlighted at build time with catppuccin-mocha inline styles. The client-side pass was stripping those colors and replacing them with github-dark.

Now highlight.js only touches template code blocks (homepage examples) and skips anything Zola already processed.