### PR TITLE
Update docs to use Deref pattern

### DIFF
--- a/docs/content/docs/core-concepts/authentication.md
+++ b/docs/content/docs/core-concepts/authentication.md
@@ -91,13 +91,10 @@ Use `AuthConfig` to create tokens:
 #[public]
 #[post("/login")]
 async fn login(body: Json<LoginRequest>, auth: State<AuthConfig>) -> Result<Json<TokenResponse>> {
-    let req = body.into_inner();
-    let auth_config = auth.into_inner();
-
     // Validate credentials (example)
-    if req.username == "admin" && req.password == "secret" {
-        let token = auth_config.create_token(&req.username)?;
-        Ok(Json(TokenResponse::new(token, auth_config.expiration())))
+    if body.username == "admin" && body.password == "secret" {
+        let token = auth.create_token(&body.username)?;
+        Ok(Json(TokenResponse::new(token, auth.expiration())))
     } else {
         Err(Error::unauthorized("invalid credentials"))
     }

--- a/docs/content/docs/core-concepts/caching.md
+++ b/docs/content/docs/core-concepts/caching.md
@@ -24,7 +24,7 @@ async fn list_products(db: Db) -> Result<Json<Vec<Product>>> {
 
 #[post("/products")]
 async fn create_product(db: Db, body: Json<NewProduct>) -> Result<Json<Product>> {
-    let product = body.into_inner().insert(db.conn()).await?;
+    let product = body.into_inner().insert(db.conn()).await?;  // into_inner() — ownership needed for insert
     Ok(Json(product))
 }
 
@@ -293,7 +293,7 @@ async fn list_products(db: Db) -> Result<Json<Vec<Product>>> {
 #[get("/products/:id")]
 #[cache(ttl = 120)]
 async fn get_product(db: Db, id: Path<i32>) -> Result<Json<Product>> {
-    let product = Product::find_by_id(id.into_inner())
+    let product = Product::find_by_id(*id)
         .one(db.conn())
         .await?
         .ok_or(Error::not_found("product not found"))?;
@@ -302,7 +302,7 @@ async fn get_product(db: Db, id: Path<i32>) -> Result<Json<Product>> {
 
 #[post("/products")]
 async fn create_product(db: Db, body: Validated<Json<NewProduct>>) -> Result<Json<Product>> {
-    let product = body.into_inner().into_inner().insert(db.conn()).await?;
+    let product = body.into_inner().into_inner().insert(db.conn()).await?;  // ownership needed for insert
     Ok(Json(product))
 }
 

--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -265,7 +265,7 @@ Database errors are automatically converted to appropriate HTTP responses:
 ```rust
 #[get("/posts/:id")]
 async fn get_post(id: Path<i32>, db: Db) -> Result<Json<PostResponse>> {
-    let post = Post::find_by_id(id.into_inner())
+    let post = Post::find_by_id(*id)
         .one(db.conn())
         .await
         .map_err(DbError::from)?  // Converts to 500

--- a/docs/content/docs/core-concepts/errors.md
+++ b/docs/content/docs/core-concepts/errors.md
@@ -43,13 +43,11 @@ Return `Result<T, Error>` or just `Result<T>` from handlers:
 ```rust
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> Result<Json<User>> {
-    let id = id.into_inner();
-
-    if id == 0 {
+    if *id == 0 {
         return Err(Error::bad_request("id cannot be zero"));
     }
 
-    let user = find_user(id)
+    let user = find_user(*id)
         .ok_or_else(|| Error::not_found("user not found"))?;
 
     Ok(Json(user))
@@ -109,8 +107,7 @@ Use with the `?` operator:
 ```rust
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> Result<Json<User>, UserError> {
-    let id = id.into_inner();
-    let user = find_user(id).ok_or(UserError::NotFound(id))?;
+    let user = find_user(*id).ok_or(UserError::NotFound(*id))?;
     Ok(Json(user))
 }
 ```

--- a/docs/content/docs/core-concepts/extractors.md
+++ b/docs/content/docs/core-concepts/extractors.md
@@ -24,6 +24,32 @@ Extractors automatically parse request data and inject it into your handlers. If
 | `Paginate` | Pagination params (requires feature) |
 | `Db` | Database connection (requires feature) |
 
+## Accessing Extractor Values
+
+Every Rapina extractor implements `Deref` to its inner type. This means you can access fields and methods directly without unwrapping:
+
+```rust
+#[get("/users/:id")]
+async fn get_user(id: Path<u64>, config: State<AppConfig>) -> String {
+    // Deref lets you access fields directly
+    format!("User {} on {}", *id, config.app_name)
+}
+
+#[post("/users")]
+async fn create_user(body: Json<CreateUser>) -> String {
+    // Access struct fields through the extractor
+    format!("Hello, {}", body.name)
+}
+```
+
+**When to use what:**
+
+- **Direct field access** — `body.name`, `config.app_name`, `query.page`. Works anywhere you need `&T` thanks to auto-deref. This is the common case.
+- **Explicit deref (`*`)** — `*id`, `*count`. Needed for primitives in format strings or when passing a `Copy` value where the compiler needs the concrete type.
+- **`into_inner()`** — when you need to *own* the value. Moving it into a struct, passing it to a function that takes `T` (not `&T`), or consuming it in a builder chain.
+
+Avoid using `.0` to access extractor contents — it's an implementation detail. Deref or `into_inner()` are always clearer.
+
 ## Path Parameters
 
 Extract values from URL path segments:
@@ -31,12 +57,12 @@ Extract values from URL path segments:
 ```rust
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> String {
-    format!("User ID: {}", id.into_inner())
+    format!("User ID: {}", *id)
 }
 
 #[get("/posts/:year/:month")]
 async fn archive(year: Path<u32>, month: Path<u32>) -> String {
-    format!("{}/{}", year.into_inner(), month.into_inner())
+    format!("{}/{}", *year, *month)
 }
 ```
 
@@ -53,8 +79,8 @@ struct Pagination {
 
 #[get("/users")]
 async fn list_users(query: Query<Pagination>) -> String {
-    let page = query.0.page.unwrap_or(1);
-    let limit = query.0.limit.unwrap_or(20);
+    let page = query.page.unwrap_or(1);
+    let limit = query.limit.unwrap_or(20);
     format!("Page {} with {} items", page, limit)
 }
 ```
@@ -72,8 +98,8 @@ struct CreateUser {
 
 #[post("/users")]
 async fn create_user(body: Json<CreateUser>) -> Json<User> {
-    let input = body.into_inner();
-    // Create user...
+    // Access fields directly through Deref
+    let user = User::new(&body.name, &body.email);
     Json(user)
 }
 ```
@@ -91,8 +117,8 @@ struct LoginForm {
 
 #[post("/login")]
 async fn login(form: Form<LoginForm>) -> Result<Json<TokenResponse>> {
-    let credentials = form.into_inner();
-    // Authenticate...
+    // Access fields directly through Deref
+    authenticate(&form.username, &form.password).await
 }
 ```
 
@@ -124,7 +150,7 @@ struct AppConfig {
 
 #[get("/info")]
 async fn info(config: State<AppConfig>) -> String {
-    format!("App: {}", config.into_inner().app_name)
+    format!("App: {}", config.app_name)
 }
 ```
 
@@ -140,7 +166,7 @@ struct Session {
 
 #[get("/dashboard")]
 async fn dashboard(session: Cookie<Session>) -> String {
-    format!("Session: {}", session.into_inner().session_id)
+    format!("Session: {}", session.session_id)
 }
 ```
 
@@ -175,9 +201,9 @@ struct CreateUser {
 
 #[post("/users")]
 async fn create_user(body: Validated<Json<CreateUser>>) -> Json<User> {
-    // body is guaranteed to be valid
-    let input = body.into_inner().into_inner();
-    // ...
+    // Validated also implements Deref — access fields directly
+    let user = User::new(&body.email, &body.password);
+    Json(user)
 }
 ```
 

--- a/docs/content/docs/core-concepts/pagination.md
+++ b/docs/content/docs/core-concepts/pagination.md
@@ -142,10 +142,10 @@ async fn list_users(
 ) -> Result<Paginated<user::Model>> {
     let mut select = User::find();
 
-    if let Some(role) = &query.0.role {
+    if let Some(role) = &query.role {
         select = select.filter(user::Column::Role.eq(role.clone()));
     }
-    if let Some(active) = query.0.active {
+    if let Some(active) = query.active {
         select = select.filter(user::Column::Active.eq(active));
     }
 
@@ -202,7 +202,7 @@ async fn list_user_posts(
     page: Paginate,
 ) -> Result<Paginated<post::Model>> {
     let select = Post::find()
-        .filter(post::Column::AuthorId.eq(id.into_inner()))
+        .filter(post::Column::AuthorId.eq(*id))
         .order_by_desc(post::Column::CreatedAt);
 
     page.exec(select, db.conn()).await

--- a/docs/content/docs/core-concepts/routing.md
+++ b/docs/content/docs/core-concepts/routing.md
@@ -79,7 +79,7 @@ async fn home() -> &'static str {
 
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> String {
-    format!("User ID: {}", id.into_inner())
+    format!("User ID: {}", *id)
 }
 
 #[tokio::main]
@@ -169,7 +169,7 @@ Extract dynamic values from URL segments using the `:param` syntax:
 ```rust
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> String {
-    format!("User ID: {}", id.into_inner())
+    format!("User ID: {}", *id)
 }
 ```
 
@@ -181,14 +181,14 @@ Path parameters are automatically parsed to their target type:
 #[get("/items/:id")]
 async fn get_item(id: Path<u64>) -> Result<Json<Item>> {
     // id is parsed as u64
-    let item = find_item(id.into_inner()).await?;
+    let item = find_item(*id).await?;
     Ok(Json(item))
 }
 
 #[get("/products/:slug")]
 async fn get_product(slug: Path<String>) -> Result<Json<Product>> {
-    // slug is kept as String
-    let product = find_by_slug(&slug.into_inner()).await?;
+    // slug is kept as String — deref coercion gives &str
+    let product = find_by_slug(&slug).await?;
     Ok(Json(product))
 }
 ```
@@ -294,7 +294,7 @@ async fn list_users() -> Json<Vec<User>> {
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> Result<Json<User>> {
     let user = User {
-        id: id.into_inner(),
+        id: *id,
         name: "Alice".into(),
         email: "alice@example.com".into(),
     };
@@ -303,11 +303,10 @@ async fn get_user(id: Path<u64>) -> Result<Json<User>> {
 
 #[post("/users")]
 async fn create_user(body: Json<CreateUser>) -> (StatusCode, Json<User>) {
-    let input = body.into_inner();
     let user = User {
         id: 3,
-        name: input.name,
-        email: input.email,
+        name: body.name.clone(),
+        email: body.email.clone(),
     };
     (StatusCode::CREATED, Json(user))
 }

--- a/docs/content/docs/core-concepts/validation.md
+++ b/docs/content/docs/core-concepts/validation.md
@@ -128,8 +128,8 @@ struct RegisterUser {
 
 #[post("/v1/users/register")]
 async fn register(body: Validated<Json<RegisterUser>>) -> impl IntoResponse {
-    let user = body.into_inner().0;
-    // All fields are valid — safe to persist
+    // All fields are valid — Validated derefs through to the inner type
+    let user = body.into_inner().into_inner();
     Json(serde_json::json!({
         "message": "user registered",
         "email": user.email


### PR DESCRIPTION
Since PR #266 landed Deref implementations on all extractors, the docs still showed `into_inner()` and `.0` everywhere. This updates every example across 10 documentation pages to use the idiomatic patterns: auto-deref for field access, explicit `*` for primitives, and `into_inner()` only where ownership transfer is actually needed.

The extractors page also gets a new "Accessing Extractor Values" section that teaches the pattern — when deref is the right call, when `into_inner()` still makes sense, and why `.0` should never appear in user-facing code.

Closes #272, partial #164