### PR TITLE
Release 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "rapina"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/docs/templates/changelog.html
+++ b/docs/templates/changelog.html
@@ -14,7 +14,7 @@
         <div class="timeline-item">
             <div class="timeline-marker"></div>
             <div class="timeline-content">
-                <div class="timeline-date">Unreleased</div>
+                <div class="timeline-date">March 6, 2026</div>
                 <h2>v0.9.0</h2>
                 <span class="timeline-tag tag-feature">Feature</span>
                 <span class="timeline-tag tag-docs">Docs</span>
@@ -24,14 +24,18 @@
                     <li>Relay system for real-time push over WebSocket with pub/sub, channel handlers, and presence tracking</li>
                     <li>Endpoint groups in route macros: <code>#[get("/users", group = "/api")]</code> for auto-discovery</li>
                     <li>Starter templates: <code>rapina new --template crud</code> and <code>--template auth</code></li>
+                    <li><code>rapina import openapi</code> command for importing external API specs</li>
                     <li>HTTP upgrade support via <code>auto::Builder</code></li>
-                    <li>Testing, OpenAPI, and validation documentation pages</li>
-                    <li>Migration documentation page</li>
-                    <li>WebSocket and Relay documentation</li>
+                    <li>Windows-compatible graceful shutdown</li>
+                    <li>Typed content-type constants replacing hardcoded strings</li>
+                    <li>Interactive tutorial with 6 chapters covering the core framework</li>
+                    <li>Redesigned landing page and getting started documentation</li>
+                    <li>WebSocket/Relay, validation, testing, OpenAPI, migrations, and DI documentation pages</li>
+                    <li>Updated all docs to use Deref pattern for extractors</li>
                     <li>Fixed syntax highlighting on documentation site</li>
                     <li>OpenAPI check now respects <code>SERVER_PORT</code> environment variable</li>
                 </ul>
-                <p class="timeline-contributors">Contributors: <a href="https://github.com/arferreira">@arferreira</a>, <a href="https://github.com/Ismaellima4">@Ismaellima4</a>, <a href="https://github.com/LevelUpExtreme">@LevelUpExtreme</a>, <a href="https://github.com/ShiraiEd">@ShiraiEd</a>, <a href="https://github.com/uemuradevexe">@uemuradevexe</a></p>
+                <p class="timeline-contributors">Contributors: <a href="https://github.com/Ismaellima4">@Ismaellima4</a>, <a href="https://github.com/ShiraiEd">@ShiraiEd</a>, <a href="https://github.com/uemuradevexe">@uemuradevexe</a>, <a href="https://github.com/juv">@juv</a>, <a href="https://github.com/LevelUpExtreme">@LevelUpExtreme</a> — thank you all for making this release happen.</p>
             </div>
         </div>
 

--- a/docs/templates/roadmap.html
+++ b/docs/templates/roadmap.html
@@ -141,6 +141,35 @@ block content %}
                     </div>
                 </div>
                 <div class="roadmap-card">
+                    <h4>Interactive Tutorial</h4>
+                    <p>
+                        6-chapter browser-based tutorial with CodeMirror editor,
+                        pattern-based validation, and simulated HTTP responses.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.9.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Cross-Platform Shutdown</h4>
+                    <p>
+                        Graceful shutdown now works on Windows in addition to Unix.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.9.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>OpenAPI Import</h4>
+                    <p>
+                        <code>rapina import openapi</code> to generate handlers
+                        and types from external API specs.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.9.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
                     <h4>Endpoint Groups</h4>
                     <p>
                         Group parameter in route macros for auto-discovery:

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-cli"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI tool for Rapina web framework - create and run Rapina projects"

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-macros"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Procedural macros for the Rapina web framework"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A fast, type-safe web framework for Rust inspired by FastAPI"
@@ -59,7 +59,7 @@ dashmap = "6.1.0"
 flate2 = "1.1"
 
 # Our macros
-rapina-macros = { version = "0.8.0", path = "../rapina-macros/" }
+rapina-macros = { version = "0.9.0", path = "../rapina-macros/" }
 
 # Auto-discovery
 inventory = "0.3"


### PR DESCRIPTION
Version bump across all three crates. Changelog and roadmap updated. Tag v0.9.0 on the merge commit after CI passes.