### PR TITLE
Add criterion benchmarks for router resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,10 +50,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -72,9 +78,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -312,6 +318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,10 +360,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.0"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -359,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -371,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -471,10 +510,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -493,6 +587,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1064,6 +1164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1226,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1454,10 +1571,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1596,6 +1733,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
 
 [[package]]
 name = "md-5"
@@ -1826,6 +1969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openapiv3"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2143,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2218,6 +2395,7 @@ version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "criterion",
  "dashmap",
  "dotenvy",
  "flate2",
@@ -2229,6 +2407,7 @@ dependencies = [
  "hyper-util",
  "inventory",
  "jsonwebtoken",
+ "matchit",
  "nix 0.31.2",
  "prometheus",
  "rapina-macros",
@@ -2278,6 +2457,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3397,6 +3596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3906,6 +4115,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -83,8 +83,14 @@ tokio-tungstenite = { version = "0.28", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["sink"] }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+matchit = "0.8"
 nix = { version = "0.31", features = ["signal"] }
 serial_test = "3"
+
+[[bench]]
+name = "router"
+harness = false
 
 # Windows specific import for graceful shutdown tests
 [target.'cfg(windows)'.dev-dependencies]

--- a/rapina/benches/router.rs
+++ b/rapina/benches/router.rs
@@ -1,0 +1,230 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use http::Method;
+use rapina::prelude::*;
+
+/// Resources used to generate realistic REST routes.
+const RESOURCES: &[&str] = &[
+    "users",
+    "posts",
+    "comments",
+    "tags",
+    "categories",
+    "products",
+    "orders",
+    "invoices",
+    "payments",
+    "sessions",
+    "notifications",
+    "messages",
+    "teams",
+    "projects",
+    "tasks",
+    "events",
+    "tickets",
+    "reviews",
+    "subscriptions",
+    "reports",
+    "analytics",
+    "settings",
+    "profiles",
+    "addresses",
+    "shipments",
+    "coupons",
+    "campaigns",
+    "contacts",
+    "leads",
+    "deals",
+    "pipelines",
+    "workflows",
+    "templates",
+    "assets",
+    "files",
+    "folders",
+    "permissions",
+    "roles",
+    "groups",
+    "organizations",
+];
+
+/// Dummy async handler that satisfies the Router's type signature.
+async fn noop(
+    _req: http::Request<hyper::body::Incoming>,
+    _params: std::collections::HashMap<String, String>,
+    _state: std::sync::Arc<rapina::state::AppState>,
+) -> http::StatusCode {
+    http::StatusCode::OK
+}
+
+/// Number of resources needed for a given total route count.
+/// Each resource produces 5 routes (GET/POST collection + GET/PUT/DELETE individual).
+fn resources_for(route_count: usize) -> usize {
+    route_count / 5
+}
+
+/// Build a frozen router with `n` total routes (must be divisible by 5).
+fn build_frozen_router(n: usize) -> Router {
+    let count = resources_for(n);
+    let mut router = Router::new();
+    for &resource in &RESOURCES[..count] {
+        let collection = format!("/v1/{resource}");
+        let individual = format!("/v1/{resource}/:id");
+        router = router
+            .route(Method::GET, &collection, noop)
+            .route(Method::POST, &collection, noop)
+            .route(Method::GET, &individual, noop)
+            .route(Method::PUT, &individual, noop)
+            .route(Method::DELETE, &individual, noop);
+    }
+    router.prepare_bench();
+    router
+}
+
+/// Build a router with `n` total routes but WITHOUT freezing (no static map, no trie).
+/// Used for linear scan baseline comparison.
+fn build_unfrozen_router(n: usize) -> Router {
+    let count = resources_for(n);
+    let mut router = Router::new();
+    for &resource in &RESOURCES[..count] {
+        let collection = format!("/v1/{resource}");
+        let individual = format!("/v1/{resource}/:id");
+        router = router
+            .route(Method::GET, &collection, noop)
+            .route(Method::POST, &collection, noop)
+            .route(Method::GET, &individual, noop)
+            .route(Method::PUT, &individual, noop)
+            .route(Method::DELETE, &individual, noop);
+    }
+    router
+}
+
+const ROUTE_COUNTS: &[usize] = &[10, 50, 200];
+
+fn static_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("static_lookup");
+    for &n in ROUTE_COUNTS {
+        let router = build_frozen_router(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| router.resolve(black_box(&Method::GET), black_box("/v1/users")));
+        });
+    }
+    group.finish();
+}
+
+fn dynamic_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dynamic_lookup");
+    for &n in ROUTE_COUNTS {
+        let router = build_frozen_router(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| router.resolve(black_box(&Method::GET), black_box("/v1/users/42")));
+        });
+    }
+    group.finish();
+}
+
+fn not_found(c: &mut Criterion) {
+    let mut group = c.benchmark_group("not_found");
+    for &n in ROUTE_COUNTS {
+        let router = build_frozen_router(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| router.resolve(black_box(&Method::GET), black_box("/v1/nonexistent/path")));
+        });
+    }
+    group.finish();
+}
+
+fn mixed_traffic(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mixed_traffic");
+    for &n in ROUTE_COUNTS {
+        let router = build_frozen_router(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                // Static hit
+                router.resolve(black_box(&Method::GET), black_box("/v1/users"));
+                // Dynamic hit
+                router.resolve(black_box(&Method::GET), black_box("/v1/users/42"));
+                // 404
+                router.resolve(black_box(&Method::GET), black_box("/v1/nonexistent/path"));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn linear_scan(c: &mut Criterion) {
+    let mut group = c.benchmark_group("linear_scan");
+    for &n in ROUTE_COUNTS {
+        let router = build_unfrozen_router(n);
+        group.bench_with_input(BenchmarkId::new("static", n), &n, |b, _| {
+            b.iter(|| router.resolve_linear(black_box(&Method::GET), black_box("/v1/users")));
+        });
+        group.bench_with_input(BenchmarkId::new("dynamic", n), &n, |b, _| {
+            b.iter(|| router.resolve_linear(black_box(&Method::GET), black_box("/v1/users/42")));
+        });
+        group.bench_with_input(BenchmarkId::new("not_found", n), &n, |b, _| {
+            b.iter(|| {
+                router.resolve_linear(black_box(&Method::GET), black_box("/v1/nonexistent/path"))
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("mixed", n), &n, |b, _| {
+            b.iter(|| {
+                router.resolve_linear(black_box(&Method::GET), black_box("/v1/users"));
+                router.resolve_linear(black_box(&Method::GET), black_box("/v1/users/42"));
+                router.resolve_linear(black_box(&Method::GET), black_box("/v1/nonexistent/path"));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Build a matchit router with the same route patterns for apples-to-apples comparison.
+///
+/// matchit only does path matching (no method dispatch), so each unique path is
+/// registered once. The value stored is a dummy index matching the order our
+/// Router would assign. This isolates the radix trie comparison without
+/// conflating method lookup overhead.
+fn build_matchit_router(n: usize) -> matchit::Router<usize> {
+    let count = resources_for(n);
+    let mut router = matchit::Router::new();
+    for (i, &resource) in RESOURCES[..count].iter().enumerate() {
+        let collection = format!("/v1/{resource}");
+        let individual = format!("/v1/{resource}/{{id}}");
+        router.insert(&collection, i * 2).unwrap();
+        router.insert(&individual, i * 2 + 1).unwrap();
+    }
+    router
+}
+
+fn matchit_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("matchit");
+    for &n in ROUTE_COUNTS {
+        let router = build_matchit_router(n);
+        group.bench_with_input(BenchmarkId::new("static", n), &n, |b, _| {
+            b.iter(|| router.at(black_box("/v1/users")));
+        });
+        group.bench_with_input(BenchmarkId::new("dynamic", n), &n, |b, _| {
+            b.iter(|| router.at(black_box("/v1/users/42")));
+        });
+        group.bench_with_input(BenchmarkId::new("not_found", n), &n, |b, _| {
+            b.iter(|| router.at(black_box("/v1/nonexistent/path")));
+        });
+        group.bench_with_input(BenchmarkId::new("mixed", n), &n, |b, _| {
+            b.iter(|| {
+                let _ = router.at(black_box("/v1/users"));
+                let _ = router.at(black_box("/v1/users/42"));
+                let _ = router.at(black_box("/v1/nonexistent/path"));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    static_lookup,
+    dynamic_lookup,
+    not_found,
+    mixed_traffic,
+    linear_scan,
+    matchit_baseline
+);
+criterion_main!(benches);

--- a/rapina/src/router/mod.rs
+++ b/rapina/src/router/mod.rs
@@ -317,6 +317,45 @@ impl Router {
         self
     }
 
+    /// Resolves a route without calling the handler.
+    ///
+    /// Returns the matched route index and extracted path parameters,
+    /// or `None` if no route matches. This is the pure routing decision
+    /// isolated from the async handler call and HTTP plumbing.
+    #[doc(hidden)]
+    pub fn resolve(&self, method: &Method, path: &str) -> Option<(usize, PathParams)> {
+        if let Some(ref static_map) = self.static_map {
+            if let Some(idx) = static_map.lookup(method, path) {
+                return Some((idx, PathParams::new()));
+            }
+        }
+        if let Some(ref trie) = self.trie {
+            let mut params = PathParams::new();
+            if let Some(idx) = trie.lookup(method, path, &mut params) {
+                return Some((idx, params));
+            }
+        }
+        None
+    }
+
+    /// Resolves a route using the old linear scan (pre-trie) algorithm.
+    ///
+    /// Iterates over all registered routes checking each pattern against the
+    /// request path. This is the O(n) baseline that the static map and trie
+    /// replaced. Exposed only for benchmark comparison.
+    #[doc(hidden)]
+    pub fn resolve_linear(&self, method: &Method, path: &str) -> Option<(usize, PathParams)> {
+        for (idx, (route_method, route)) in self.routes.iter().enumerate() {
+            if *route_method != *method {
+                continue;
+            }
+            if let Some(params) = crate::extract::extract_path_params(&route.pattern, path) {
+                return Some((idx, params));
+            }
+        }
+        None
+    }
+
     /// Handles an incoming request by matching it to a route.
     pub async fn handle(&self, req: Request<Incoming>, state: &Arc<AppState>) -> Response<BoxBody> {
         // Layer 1: O(1) static map — no allocation, no cloning.
@@ -337,6 +376,16 @@ impl Router {
         }
 
         StatusCode::NOT_FOUND.into_response()
+    }
+
+    /// Sorts routes and builds lookup structures for benchmarking.
+    ///
+    /// Combines `sort_routes()` and `freeze()` into a single call accessible
+    /// from benchmarks. Not part of the public API.
+    #[doc(hidden)]
+    pub fn prepare_bench(&mut self) {
+        self.sort_routes();
+        self.freeze();
     }
 
     /// Sorts routes so static segments come before parameterized ones.


### PR DESCRIPTION
Adds criterion benchmarks that measure route resolution performance across the static map, radix trie, and the old linear scan baseline. Also includes matchit as an external reference point using the same routes and lookup paths for an honest apples-to-apples comparison.

The benchmarks expose three `#[doc(hidden)]` methods on Router: `resolve()` (frozen router path matching without the async handler call), `resolve_linear()` (the old O(n) loop for baseline comparison), and `prepare_bench()` (combines sort + freeze for external callers).

Five benchmark groups run at 10/50/200 routes using realistic REST patterns (5 routes per resource — GET/POST collection + GET/PUT/DELETE individual):

- **static_lookup** — parameterless route via static map
- **dynamic_lookup** — parameterized route via radix trie
- **not_found** — 404 path exercising full traversal
- **mixed_traffic** — alternates static hit, dynamic hit, and 404
- **linear_scan** — same scenarios against the pre-trie algorithm
- **matchit** — same scenarios against matchit 0.8 for external comparison

Results on M3:

| Scenario | Routes | rapina | matchit | linear scan |
|----------|--------|--------|---------|-------------|
| Static | 10 | 24ns | 12ns | 89ns |
| Static | 200 | 24ns | 15ns | 89ns |
| Dynamic | 10 | 115ns | 19ns | 264ns |
| Dynamic | 200 | 118ns | 23ns | 264ns |
| 404 | 10 | 32ns | 6ns | 484ns |
| 404 | 200 | 38ns | 12ns | 9.97µs |
| Mixed | 10 | 178ns | 34ns | 854ns |
| Mixed | 200 | 186ns | 50ns | 10.45µs |

The trie numbers are flat across route counts, confirming O(path_depth) behavior. The 404 path at 200 routes shows 256x improvement over linear scan. The matchit gap (5-6x on dynamic) is dominated by PathParams allocation (`HashMap<String, String>` vs matchit's zero-copy borrowed params) and per-node method dispatch, both are optimization targets for a follow-up PR.

Partial #311 

