### PR TITLE
Replace PathParams HashMap with SmallVec-backed struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serial_test",
+ "smallvec",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/rapina-macros/src/lib.rs
+++ b/rapina-macros/src/lib.rs
@@ -529,7 +529,7 @@ fn relay_macro_impl(
                 if let Some(u) = __rapina_current_user {
                     __rapina_parts.extensions.insert(u);
                 }
-                let __rapina_params: rapina::extract::PathParams = std::collections::HashMap::new();
+                let __rapina_params = rapina::extract::PathParams::new();
                 #(#extractor_extractions)*
                 #func_name(#(#call_args),*).await
             })

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -55,6 +55,9 @@ jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 # Rate Limiting
 dashmap = "6.1.0"
 
+# SmallVec for stack-allocated path params
+smallvec = "1"
+
 # Compression
 flate2 = "1.1"
 

--- a/rapina/benches/router.rs
+++ b/rapina/benches/router.rs
@@ -49,7 +49,7 @@ const RESOURCES: &[&str] = &[
 /// Dummy async handler that satisfies the Router's type signature.
 async fn noop(
     _req: http::Request<hyper::body::Incoming>,
-    _params: std::collections::HashMap<String, String>,
+    _params: rapina::extract::PathParams,
     _state: std::sync::Arc<rapina::state::AppState>,
 ) -> http::StatusCode {
     http::StatusCode::OK

--- a/rapina/src/extract.rs
+++ b/rapina/src/extract.rs
@@ -8,6 +8,8 @@ use http::Request;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use serde::de::DeserializeOwned;
+use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::str::FromStr;
@@ -222,8 +224,82 @@ pub struct Context(pub RequestContext);
 #[derive(Debug)]
 pub struct Validated<T>(pub T);
 
-/// Type alias for path parameters extracted from the URL.
-pub type PathParams = HashMap<String, String>;
+/// Path parameters extracted from the URL during route matching.
+///
+/// Stores up to 4 parameters on the stack without heap allocation.
+/// Uses linear search which outperforms HashMap for the small N
+/// typical of REST APIs (1-3 path parameters).
+#[derive(Debug, Clone, Default)]
+pub struct PathParams {
+    entries: SmallVec<[(Cow<'static, str>, String); 4]>,
+}
+
+impl PathParams {
+    pub fn new() -> Self {
+        Self {
+            entries: SmallVec::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.entries
+            .iter()
+            .find(|(k, _)| k.as_ref() == key)
+            .map(|(_, v)| v)
+    }
+
+    pub fn insert(&mut self, key: String, value: String) -> Option<String> {
+        if let Some(entry) = self.entries.iter_mut().find(|(k, _)| k.as_ref() == key) {
+            let old = std::mem::replace(&mut entry.1, value);
+            Some(old)
+        } else {
+            self.entries.push((Cow::Owned(key), value));
+            None
+        }
+    }
+
+    /// Push a static key without checking for duplicates.
+    ///
+    /// Used by the trie during route matching where param names are
+    /// leaked to `&'static str` at freeze time and the same key is never
+    /// inserted twice in a single lookup. Zero allocation for the key,
+    /// and skips the linear scan that `insert()` does.
+    pub(crate) fn push(&mut self, key: &'static str, value: String) {
+        self.entries.push((Cow::Borrowed(key), value));
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<String> {
+        if let Some(pos) = self.entries.iter().position(|(k, _)| k.as_ref() == key) {
+            Some(self.entries.swap_remove(pos).1)
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &String)> {
+        self.entries.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+}
+
+impl FromIterator<(String, String)> for PathParams {
+    fn from_iter<I: IntoIterator<Item = (String, String)>>(iter: I) -> Self {
+        Self {
+            entries: iter.into_iter().map(|(k, v)| (Cow::Owned(k), v)).collect(),
+        }
+    }
+}
 
 /// Trait for extractors that consume the request body.
 ///
@@ -578,7 +654,7 @@ pub fn extract_path_params(pattern: &str, path: &str) -> Option<PathParams> {
         return None;
     }
 
-    let mut params = HashMap::new();
+    let mut params = PathParams::new();
 
     for (pattern_part, path_part) in pattern_parts.iter().zip(path_parts.iter()) {
         if let Some(param_name) = pattern_part.strip_prefix(':') {

--- a/rapina/src/router/trie.rs
+++ b/rapina/src/router/trie.rs
@@ -62,7 +62,10 @@ struct Node {
     /// Arena index of the `:param` child, if any. At most one per node.
     param_child: Option<usize>,
     /// If this node was reached via a param edge, the param name (without `:`).
-    param_name: Option<String>,
+    /// Leaked to `&'static str` at build time — the trie lives for the entire
+    /// application lifetime so this is never reclaimed (and it's a handful of
+    /// bytes total for any realistic route table).
+    param_name: Option<&'static str>,
     /// Route index if this is a terminal node.
     value: Option<usize>,
     /// Number of routes reachable through this subtree.
@@ -174,17 +177,18 @@ impl RadixTrie {
                 Segment::Param(name) => {
                     if let Some(child_id) = self.arena[current].param_child {
                         // Validate that the existing param name matches.
-                        if let Some(ref existing) = self.arena[child_id].param_name {
+                        if let Some(existing) = self.arena[child_id].param_name {
                             assert!(
-                                existing == name,
+                                existing == *name,
                                 "conflicting param names at the same position: \
                                  `:{existing}` and `:{name}` in pattern `{pattern}` — \
                                  all routes sharing this param position must use the same name",
                             );
                         }
                     } else {
+                        let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
                         let id = self.alloc(Node {
-                            param_name: Some((*name).to_string()),
+                            param_name: Some(leaked),
                             ..Node::new()
                         });
                         self.arena[current].param_child = Some(id);
@@ -379,8 +383,8 @@ impl RadixTrie {
             // is already valid UTF-8 from uri.path().
             let value = &remaining[..end];
             let param_node = &self.arena[param_idx];
-            if let Some(ref name) = param_node.param_name {
-                params.insert(name.clone(), value.to_string());
+            if let Some(name) = param_node.param_name {
+                params.push(name, value.to_string());
             }
 
             if let Some(result) = self.lookup_recursive(param_idx, &remaining[end..], params) {
@@ -388,7 +392,7 @@ impl RadixTrie {
             }
 
             // Param child also failed — remove the param we just inserted.
-            if let Some(ref name) = param_node.param_name {
+            if let Some(name) = param_node.param_name {
                 params.remove(name);
             }
         }


### PR DESCRIPTION
PathParams was a `type PathParams = HashMap<String, String>`. Every dynamic route lookup paid for bucket allocation, key hashing, and a string clone for each param name, all wasted work when REST APIs have 1-3 params.

This replaces it with a proper struct backed by `SmallVec<[(Cow<'static, str>, String); 4]>`. Up to 4 params live entirely on the stack. Linear search beats HashMap for small N. The trie leaks param names to `&'static str` at freeze time (a handful of bytes for the app lifetime), so the hot path does zero allocation for keys and skips duplicate checking via `push()`.

The public API is unchanged: `get()`, `insert()`, `remove()`, `iter()`, `FromIterator` all have compatible signatures. `iter()` yields `(&str, &String)` instead of `(&String, &String)` which is strictly more general.

Benchmark results (dynamic route `/v1/users/42`, 200 routes registered):

| | before | after | matchit |
|---|---|---|---|
| dynamic lookup | 115ns | **68ns** | 24ns |
| static lookup | 30ns | 32ns | 15ns |
| not found | 40ns | 40ns | 12ns |

1.7x improvement on dynamic routes. The remaining gap to matchit is `value.to_string()`, the last heap allocation on the hot path, which requires zero-copy borrows to eliminate.

Closes #311 