### PR TITLE
Add seed database support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
 ]
@@ -274,14 +274,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytecheck"
@@ -325,9 +325,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -347,9 +347,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -410,21 +410,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -618,12 +618,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.30.1",
+ "nix",
  "windows-sys 0.61.2",
 ]
 
@@ -651,7 +651,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -675,7 +675,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -686,7 +686,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -748,7 +748,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -766,11 +766,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "block2",
  "libc",
  "objc2",
@@ -784,7 +784,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1003,9 +1003,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1027,15 +1027,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1055,27 +1055,27 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1083,6 +1083,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -1116,19 +1117,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1357,12 +1358,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1533,7 +1535,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1553,7 +1555,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "inotify-sys",
  "libc",
 ]
@@ -1610,9 +1612,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1678,15 +1680,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
-version = "0.2.16"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -1694,9 +1696,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1764,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -1804,23 +1806,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1832,7 +1822,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1851,7 +1841,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "inotify 0.11.0",
  "kqueue",
  "libc",
@@ -1879,7 +1869,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1955,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -2027,7 +2017,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2119,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2215,7 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2255,7 +2245,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2275,7 +2265,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "version_check",
  "yansi",
 ]
@@ -2323,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -2335,6 +2325,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2420,7 +2416,7 @@ dependencies = [
  "inventory",
  "jsonwebtoken",
  "matchit",
- "nix 0.31.2",
+ "nix",
  "prometheus",
  "rapina-macros",
  "redis",
@@ -2450,9 +2446,12 @@ dependencies = [
  "clap",
  "colored",
  "ctrlc",
+ "dotenvy",
+ "fastrand",
  "notify 8.2.0",
  "notify-debouncer-mini",
  "openapiv3",
+ "sea-orm",
  "sea-schema",
  "serde",
  "serde_json",
@@ -2461,6 +2460,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -2470,7 +2470,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2523,16 +2523,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2552,14 +2552,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rend"
@@ -2697,7 +2697,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2706,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "ring",
@@ -2746,9 +2746,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -2770,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2786,14 +2786,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2818,7 +2818,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2880,7 +2880,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.117",
+ "syn 2.0.114",
  "unicode-ident",
 ]
 
@@ -2943,7 +2943,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "thiserror 2.0.18",
 ]
 
@@ -2969,7 +2969,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3036,7 +3036,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3109,7 +3109,7 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3189,9 +3189,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -3201,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -3216,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3307,7 +3307,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3330,7 +3330,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.114",
  "tokio",
  "url",
 ]
@@ -3344,7 +3344,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3391,7 +3391,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3506,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3523,7 +3523,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3539,7 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3571,7 +3571,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3582,7 +3582,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3685,7 +3685,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3726,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "d1d7e18e3dd1d31e0ee5e863a8091ffec2fcc271636586042452b656a22c8ee1"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3771,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow",
 ]
@@ -3810,7 +3810,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3902,9 +3902,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
@@ -3971,11 +3971,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4008,7 +4008,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4080,9 +4080,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4093,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4103,22 +4103,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -4151,7 +4151,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4159,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4225,7 +4225,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4236,7 +4236,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4524,7 +4524,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.114",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4540,7 +4540,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4552,7 +4552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "indexmap",
  "log",
  "serde",
@@ -4628,28 +4628,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4669,7 +4669,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4709,11 +4709,11 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -22,12 +22,16 @@ notify = { version = "8", default-features = false, features = [
   "macos_kqueue",
 ] }
 notify-debouncer-mini = "0.4"
+sea-orm = { version = "1", features = ["runtime-tokio-rustls"], optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+dotenvy = { version = "0.15", optional = true }
 ctrlc = "3"
 toml = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = "0.4"
-tokio = { version = "1", features = ["full"], optional = true }
+fastrand = { version = "2.3.0", optional = true }
+uuid = { version = "1", features = ["v4"], optional = true }
 sea-schema = { version = "0.16", optional = true, default-features = false }
 sqlx = { version = "0.8", optional = true }
 openapiv3 = { version = "2", optional = true }
@@ -35,7 +39,11 @@ serde_yaml_ng = { version = "0.10", optional = true }
 
 [features]
 default = []
-import = ["tokio"]
+seed = ["dep:sea-orm", "dep:tokio", "dep:dotenvy", "dep:fastrand", "dep:uuid"]
+seed-postgres = ["seed", "sea-orm/sqlx-postgres"]
+seed-mysql = ["seed", "sea-orm/sqlx-mysql"]
+seed-sqlite = ["seed", "sea-orm/sqlx-sqlite"]
+import = ["dep:tokio"]
 import-postgres = [
     "import",
     "sea-schema/postgres",
@@ -67,3 +75,5 @@ import-openapi = ["dep:openapiv3", "dep:serde_yaml_ng"]
 
 [dev-dependencies]
 tempfile = "3.27.0"
+tokio = { version = "1", features = ["rt", "macros"] }  # for #[tokio::test]
+sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-sqlite"] }

--- a/rapina-cli/src/commands/mod.rs
+++ b/rapina-cli/src/commands/mod.rs
@@ -10,6 +10,8 @@ pub mod migrate;
 pub mod new;
 pub mod openapi;
 pub mod routes;
+#[cfg(feature = "seed")]
+pub mod seed;
 pub mod templates;
 pub mod test;
 

--- a/rapina-cli/src/commands/seed.rs
+++ b/rapina-cli/src/commands/seed.rs
@@ -1,0 +1,1040 @@
+//! Database seeding commands for loading, dumping, and generating seed data.
+
+use colored::Colorize;
+use sea_orm::{
+    ConnectionTrait, DatabaseBackend, DatabaseConnection, FromQueryResult, Statement,
+    TransactionTrait,
+};
+use std::fs;
+use std::path::Path;
+
+const SEEDS_DIR: &str = "seeds";
+
+/// An entity definition: entity name paired with its fields (name, type).
+type EntitySchema = Vec<(String, Vec<(String, String)>)>;
+
+// -- Public API --
+
+/// Load seed data from JSON files in the `seeds/` directory into the database.
+///
+/// Reads each `.json` file, parses it as an array of objects, and inserts records
+/// using idempotent `ON CONFLICT DO NOTHING` (Postgres/SQLite) or `INSERT IGNORE` (MySQL).
+///
+/// **Note:** Without `--fresh`, rows whose primary key already exists in the
+/// database are silently skipped (not updated). Use `--fresh` to truncate all
+/// target tables before loading. Full upsert (update-on-conflict) requires
+/// per-table primary key discovery and is planned for a future iteration.
+///
+/// # Errors
+///
+/// Returns an error if the seeds directory is missing, the database is unreachable,
+/// or any seed file contains invalid JSON.
+pub async fn load(entity: Option<String>, fresh: bool) -> Result<(), String> {
+    let seeds_path = Path::new(SEEDS_DIR);
+    verify_seeds_dir(seeds_path)?;
+    let conn = connect_to_db().await?;
+    let seed_files = discover_seed_files(seeds_path, entity.as_deref())?;
+
+    // Use a transaction so FK disable + inserts share the same connection
+    let txn = conn
+        .begin()
+        .await
+        .map_err(|e| format!("Failed to begin transaction: {}", e))?;
+
+    disable_fk_checks(&txn).await?;
+
+    if fresh {
+        truncate_tables(&txn, &seed_files).await?;
+    }
+
+    for (table_name, file_path) in &seed_files {
+        let content = fs::read_to_string(file_path)
+            .map_err(|e| format!("Failed to read seed file '{}': {}", file_path.display(), e))?;
+
+        let records: Vec<serde_json::Value> = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse JSON in '{}': {}", file_path.display(), e))?;
+
+        insert_records(&txn, table_name, &records).await?;
+
+        println!(
+            "{}: Inserted {} records into '{}'",
+            "Success".green(),
+            records.len(),
+            table_name.cyan()
+        );
+    }
+
+    enable_fk_checks(&txn).await?;
+
+    txn.commit()
+        .await
+        .map_err(|e| format!("Failed to commit transaction: {}", e))?;
+
+    Ok(())
+}
+
+/// Dump all database tables (or a specific entity) to JSON seed files.
+///
+/// Queries each table and writes the rows as a pretty-printed JSON array
+/// to `seeds/{table_name}.json`.
+///
+/// # Errors
+///
+/// Returns an error if the database is unreachable or a table cannot be read.
+pub async fn dump(entity: Option<String>) -> Result<(), String> {
+    let seeds_path = Path::new(SEEDS_DIR);
+    if !seeds_path.exists() {
+        fs::create_dir_all(seeds_path)
+            .map_err(|e| format!("Failed to create seeds directory: {}", e))?;
+    }
+
+    let conn = connect_to_db().await?;
+    let tables = discover_tables(&conn, entity.as_deref()).await?;
+
+    for table_name in &tables {
+        let records = fetch_all_records(&conn, table_name).await?;
+        let json = serde_json::to_string_pretty(&records)
+            .map_err(|e| format!("Failed to serialize {}: {}", table_name, e))?;
+
+        let file_path = seeds_path.join(format!("{}.json", table_name));
+        fs::write(&file_path, &json)
+            .map_err(|e| format!("Failed to write {}: {}", file_path.display(), e))?;
+
+        println!(
+            "{}: Dumped {} records from '{}' to '{}'",
+            "Success".green(),
+            records.len(),
+            table_name.cyan(),
+            file_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Generate fake seed data based on `schema!` macro blocks in `src/entity.rs`.
+///
+/// Parses entity definitions, generates `count` records per entity with
+/// type-aware fake values, and writes them to `seeds/{table_name}.json`.
+///
+/// # Errors
+///
+/// Returns an error if `src/entity.rs` is missing or contains no `schema!` blocks.
+pub fn generate(count: u32, entity: Option<String>) -> Result<(), String> {
+    let seeds_path = Path::new(SEEDS_DIR);
+    if !seeds_path.exists() {
+        fs::create_dir_all(seeds_path)
+            .map_err(|e| format!("Failed to create seeds directory: {}", e))?;
+    }
+
+    let entities = parse_schema_entities()?;
+    let mut rng = fastrand::Rng::new();
+
+    for (entity_name, fields) in &entities {
+        if let Some(ref filter) = entity {
+            if entity_name.to_lowercase() != filter.to_lowercase() {
+                continue;
+            }
+        }
+
+        let records: Vec<serde_json::Value> = (0..count)
+            .map(|i| generate_record(fields, i, &mut rng))
+            .collect();
+
+        let table_name = pluralize(&entity_name.to_lowercase());
+        let json = serde_json::to_string_pretty(&records)
+            .map_err(|e| format!("Failed to serialize: {}", e))?;
+
+        let file_path = seeds_path.join(format!("{}.json", table_name));
+        fs::write(&file_path, &json)
+            .map_err(|e| format!("Failed to write {}: {}", file_path.display(), e))?;
+
+        println!(
+            "{}: Generated {} records for '{}' -> {}",
+            "Success".green(),
+            count,
+            table_name.cyan(),
+            file_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+// -- Identifier quoting --
+
+/// Quote a SQL identifier using the appropriate syntax for the given database backend.
+///
+/// - Postgres/SQLite: `"identifier"`
+/// - MySQL: `` `identifier` ``
+fn quote_ident(backend: DatabaseBackend, name: &str) -> String {
+    match backend {
+        DatabaseBackend::MySql => format!("`{}`", name.replace('`', "``")),
+        DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+            format!("\"{}\"", name.replace('"', "\"\""))
+        }
+    }
+}
+
+// -- Validation --
+
+fn verify_seeds_dir(seeds_path: &Path) -> Result<(), String> {
+    if !seeds_path.exists() {
+        return Err(format!(
+            "Seeds directory '{}' does not exist",
+            seeds_path.display()
+        ));
+    }
+    if !seeds_path.is_dir() {
+        return Err(format!(
+            "Seeds path '{}' is not a directory",
+            seeds_path.display()
+        ));
+    }
+    Ok(())
+}
+
+// -- Database --
+
+async fn connect_to_db() -> Result<DatabaseConnection, String> {
+    dotenvy::dotenv().ok();
+
+    let database_url = std::env::var("DATABASE_URL")
+        .map_err(|_| "DATABASE_URL environment variable is not set".to_string())?;
+
+    sea_orm::Database::connect(&database_url)
+        .await
+        .map_err(|e| format!("Failed to connect to database: {}", e))
+}
+
+async fn discover_tables(
+    conn: &DatabaseConnection,
+    entity: Option<&str>,
+) -> Result<Vec<String>, String> {
+    let sql = match conn.get_database_backend() {
+        DatabaseBackend::Sqlite => "SELECT name FROM sqlite_master WHERE type='table' \
+             AND name NOT LIKE 'seaql_%' AND name != 'sqlite_sequence' \
+             ORDER BY name"
+            .to_string(),
+        DatabaseBackend::Postgres => "SELECT tablename AS name FROM pg_tables \
+             WHERE schemaname = 'public' AND tablename NOT LIKE 'seaql_%' \
+             ORDER BY tablename"
+            .to_string(),
+        DatabaseBackend::MySql => "SELECT table_name AS name FROM information_schema.tables \
+             WHERE table_schema = DATABASE() AND table_name NOT LIKE 'seaql_%' \
+             ORDER BY table_name"
+            .to_string(),
+    };
+
+    let rows = conn
+        .query_all(Statement::from_string(conn.get_database_backend(), sql))
+        .await
+        .map_err(|e| format!("Failed to discover tables: {}", e))?;
+
+    let mut tables = Vec::new();
+    for row in rows {
+        let name: String = row
+            .try_get("", "name")
+            .map_err(|e| format!("Failed to read table name: {}", e))?;
+        if let Some(filter) = entity {
+            if name == filter {
+                tables.push(name);
+            }
+        } else {
+            tables.push(name);
+        }
+    }
+
+    Ok(tables)
+}
+
+async fn fetch_all_records(
+    conn: &DatabaseConnection,
+    table_name: &str,
+) -> Result<Vec<serde_json::Value>, String> {
+    let backend = conn.get_database_backend();
+    let quoted = quote_ident(backend, table_name);
+
+    let results: Vec<serde_json::Value> = serde_json::Value::find_by_statement(
+        Statement::from_string(backend, format!("SELECT * FROM {}", quoted)),
+    )
+    .all(conn)
+    .await
+    .map_err(|e| format!("Failed to fetch records from '{}': {}", table_name, e))?;
+
+    Ok(results)
+}
+
+async fn insert_records(
+    conn: &impl ConnectionTrait,
+    table_name: &str,
+    records: &[serde_json::Value],
+) -> Result<(), String> {
+    let backend = conn.get_database_backend();
+    let quoted_table = quote_ident(backend, table_name);
+
+    for record in records {
+        let obj = record
+            .as_object()
+            .ok_or_else(|| "Record is not a JSON object".to_string())?;
+
+        let columns: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+        let values: Vec<&serde_json::Value> = obj.values().collect();
+
+        let quoted_columns: Vec<String> = columns.iter().map(|c| quote_ident(backend, c)).collect();
+
+        let placeholders = build_placeholders(backend, columns.len());
+
+        let sql = build_insert_sql(backend, &quoted_table, &quoted_columns, &placeholders);
+
+        let sea_values: Vec<sea_orm::Value> = values.iter().map(|v| json_to_sea_value(v)).collect();
+
+        conn.execute(Statement::from_sql_and_values(backend, &sql, sea_values))
+            .await
+            .map_err(|e| format!("Failed to insert record into '{}': {}", table_name, e))?;
+    }
+    Ok(())
+}
+
+/// Build positional parameter placeholders appropriate for the database backend.
+fn build_placeholders(backend: DatabaseBackend, count: usize) -> String {
+    match backend {
+        DatabaseBackend::Postgres => (1..=count)
+            .map(|i| format!("${}", i))
+            .collect::<Vec<_>>()
+            .join(", "),
+        DatabaseBackend::Sqlite | DatabaseBackend::MySql => vec!["?"; count].join(", "),
+    }
+}
+
+/// Build a full INSERT statement with idempotent conflict handling.
+fn build_insert_sql(
+    backend: DatabaseBackend,
+    quoted_table: &str,
+    quoted_columns: &[String],
+    placeholders: &str,
+) -> String {
+    let cols = quoted_columns.join(", ");
+    match backend {
+        DatabaseBackend::MySql => {
+            format!(
+                "INSERT IGNORE INTO {} ({}) VALUES ({})",
+                quoted_table, cols, placeholders
+            )
+        }
+        DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+            format!(
+                "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO NOTHING",
+                quoted_table, cols, placeholders
+            )
+        }
+    }
+}
+
+async fn disable_fk_checks(conn: &impl ConnectionTrait) -> Result<(), String> {
+    let backend = conn.get_database_backend();
+    let sql = match backend {
+        DatabaseBackend::Sqlite => "PRAGMA foreign_keys = OFF",
+        DatabaseBackend::Postgres => "SET session_replication_role = 'replica'",
+        DatabaseBackend::MySql => "SET FOREIGN_KEY_CHECKS = 0",
+    };
+    conn.execute(Statement::from_string(backend, sql.to_string()))
+        .await
+        .map_err(|e| format!("Failed to disable foreign key checks: {}", e))?;
+    Ok(())
+}
+
+async fn enable_fk_checks(conn: &impl ConnectionTrait) -> Result<(), String> {
+    let backend = conn.get_database_backend();
+    let sql = match backend {
+        DatabaseBackend::Sqlite => "PRAGMA foreign_keys = ON",
+        DatabaseBackend::Postgres => "SET session_replication_role = 'origin'",
+        DatabaseBackend::MySql => "SET FOREIGN_KEY_CHECKS = 1",
+    };
+    conn.execute(Statement::from_string(backend, sql.to_string()))
+        .await
+        .map_err(|e| format!("Failed to re-enable foreign key checks: {}", e))?;
+    Ok(())
+}
+
+async fn truncate_tables(
+    conn: &impl ConnectionTrait,
+    seed_files: &[(String, std::path::PathBuf)],
+) -> Result<(), String> {
+    let backend = conn.get_database_backend();
+
+    for (table_name, _) in seed_files.iter().rev() {
+        let quoted = quote_ident(backend, table_name);
+        let sql = format!("DELETE FROM {}", quoted);
+
+        conn.execute(Statement::from_string(backend, sql))
+            .await
+            .map_err(|e| format!("Failed to truncate table '{}': {}", table_name, e))?;
+
+        println!(
+            "{}: Truncated table '{}'",
+            "Success".green(),
+            table_name.cyan()
+        );
+    }
+
+    Ok(())
+}
+
+// -- Seed file discovery --
+
+fn discover_seed_files(
+    seeds_path: &Path,
+    entity: Option<&str>,
+) -> Result<Vec<(String, std::path::PathBuf)>, String> {
+    let mut seed_files = Vec::new();
+    for entry in
+        fs::read_dir(seeds_path).map_err(|e| format!("Failed to read seeds directory: {}", e))?
+    {
+        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("json") {
+            if let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if let Some(entity_name) = entity {
+                    if file_stem == entity_name {
+                        seed_files.push((file_stem.to_string(), path));
+                    }
+                } else {
+                    seed_files.push((file_stem.to_string(), path));
+                }
+            }
+        }
+    }
+
+    seed_files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    if seed_files.is_empty() {
+        return Err("No seed files found.".to_string());
+    }
+
+    Ok(seed_files)
+}
+
+// -- JSON / SeaORM conversion --
+
+fn json_to_sea_value(v: &serde_json::Value) -> sea_orm::Value {
+    match v {
+        serde_json::Value::Null => sea_orm::Value::String(None),
+        serde_json::Value::Bool(b) => (*b).into(),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                i.into()
+            } else if let Some(f) = n.as_f64() {
+                f.into()
+            } else {
+                sea_orm::Value::String(None)
+            }
+        }
+        serde_json::Value::String(s) => s.clone().into(),
+        _ => sea_orm::Value::String(Some(Box::new(v.to_string()))),
+    }
+}
+
+// -- Schema parsing (for generate) --
+
+fn parse_schema_entities() -> Result<EntitySchema, String> {
+    let entity_path = Path::new("src/entity.rs");
+    if !entity_path.exists() {
+        return Err("src/entity.rs not found. Run 'rapina add resource' first.".to_string());
+    }
+
+    let content =
+        fs::read_to_string(entity_path).map_err(|e| format!("Failed to read entity.rs: {}", e))?;
+
+    parse_schema_content(&content)
+}
+
+/// Parse `schema!` macro blocks from source content.
+///
+/// Uses line-by-line matching against the known `schema!` format.
+/// This parser assumes clean `schema!` blocks without inline comments,
+/// field attributes, or multi-line type annotations. Sufficient for the
+/// standard output of `rapina add resource`.
+fn parse_schema_content(content: &str) -> Result<EntitySchema, String> {
+    let mut entities = Vec::new();
+    let mut lines = content.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+
+        if !trimmed.starts_with("schema!") {
+            continue;
+        }
+
+        let entity_name = loop {
+            match lines.next() {
+                Some(l) => {
+                    let t = l.trim();
+                    if t.is_empty() || t == "{" {
+                        continue;
+                    }
+                    if let Some(name) = t.strip_suffix('{') {
+                        break name.trim().to_string();
+                    }
+                    break t.to_string();
+                }
+                None => return Err("Unexpected end of schema! block".to_string()),
+            }
+        };
+
+        let mut fields = Vec::new();
+        let mut brace_depth = 1;
+
+        for line in lines.by_ref() {
+            let t = line.trim();
+
+            if t == "}" || t == "}}" {
+                brace_depth -= 1;
+                if brace_depth <= 0 {
+                    break;
+                }
+                continue;
+            }
+
+            if let Some((name, typ)) = t.trim_end_matches(',').split_once(':') {
+                let field_name = name.trim().to_string();
+                let field_type = typ.trim().to_string();
+                if !field_name.is_empty() && !field_type.is_empty() {
+                    fields.push((field_name, field_type));
+                }
+            }
+        }
+
+        if !fields.is_empty() {
+            entities.push((entity_name, fields));
+        }
+    }
+
+    if entities.is_empty() {
+        return Err("No schema! blocks found in src/entity.rs".to_string());
+    }
+
+    Ok(entities)
+}
+
+// -- Fake data generation --
+
+/// Pluralize an English noun for table name generation.
+///
+/// Handles common suffixes: -s/-x/-z/-ch/-sh -> -es, consonant + y -> -ies.
+/// Falls back to appending "s" for other cases.
+fn pluralize(s: &str) -> String {
+    if s.ends_with('s')
+        || s.ends_with('x')
+        || s.ends_with('z')
+        || s.ends_with("ch")
+        || s.ends_with("sh")
+    {
+        format!("{}es", s)
+    } else if let Some(prefix) = s.strip_suffix('y') {
+        let before_y = prefix.as_bytes().last().copied().unwrap_or(b'a');
+        if matches!(before_y, b'a' | b'e' | b'i' | b'o' | b'u') {
+            format!("{}s", s)
+        } else {
+            format!("{}ies", prefix)
+        }
+    } else {
+        format!("{}s", s)
+    }
+}
+
+fn generate_record(
+    fields: &[(String, String)],
+    index: u32,
+    rng: &mut fastrand::Rng,
+) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    for (name, typ) in fields {
+        obj.insert(name.clone(), generate_fake_value(name, typ, index, rng));
+    }
+    serde_json::Value::Object(obj)
+}
+
+fn generate_fake_value(
+    field_name: &str,
+    field_type: &str,
+    index: u32,
+    rng: &mut fastrand::Rng,
+) -> serde_json::Value {
+    let n: u32 = rng.u32(..);
+
+    match field_type {
+        "String" => {
+            if field_name.contains("email") {
+                serde_json::json!(format!("user{}@example.com", index))
+            } else if field_name.contains("name") {
+                let names = ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank"];
+                serde_json::json!(names[(n as usize) % names.len()])
+            } else if field_name.contains("url") || field_name.contains("link") {
+                serde_json::json!(format!("https://example.com/{}", n % 10000))
+            } else {
+                serde_json::json!(format!("{}_{}", field_name, index))
+            }
+        }
+        "i32" => serde_json::json!((n % 1000) as i32),
+        "i64" => serde_json::json!((n % 100000) as i64),
+        "f32" | "f64" => serde_json::json!((n % 10000) as f64 / 100.0),
+        "bool" => serde_json::json!(n % 2 == 0),
+        "Uuid" => serde_json::json!(uuid::Uuid::new_v4().to_string()),
+        "DateTime" => serde_json::json!(format!(
+            "2025-01-{:02}T{:02}:{:02}:00Z",
+            (n % 28) + 1,
+            n % 24,
+            n % 60
+        )),
+        "Date" => serde_json::json!(format!("2025-01-{:02}", (n % 28) + 1)),
+        "Text" => serde_json::json!(format!("Sample {} text for record {}", field_name, index)),
+        _ => serde_json::Value::Null,
+    }
+}
+
+// -- Tests --
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_seeds_dir(dir: &Path, files: &[(&str, &str)]) {
+        let seeds = dir.join("seeds");
+        fs::create_dir_all(&seeds).unwrap();
+        for (name, content) in files {
+            fs::write(seeds.join(name), content).unwrap();
+        }
+    }
+
+    // -- quote_ident --
+
+    #[test]
+    fn quote_ident_postgres_wraps_in_double_quotes() {
+        assert_eq!(quote_ident(DatabaseBackend::Postgres, "users"), "\"users\"");
+    }
+
+    #[test]
+    fn quote_ident_mysql_wraps_in_backticks() {
+        assert_eq!(quote_ident(DatabaseBackend::MySql, "users"), "`users`");
+    }
+
+    #[test]
+    fn quote_ident_escapes_embedded_quotes() {
+        assert_eq!(
+            quote_ident(DatabaseBackend::Postgres, "my\"table"),
+            "\"my\"\"table\""
+        );
+        assert_eq!(
+            quote_ident(DatabaseBackend::MySql, "my`table"),
+            "`my``table`"
+        );
+    }
+
+    // -- build_placeholders --
+
+    #[test]
+    fn build_placeholders_postgres_uses_dollar_notation() {
+        assert_eq!(
+            build_placeholders(DatabaseBackend::Postgres, 3),
+            "$1, $2, $3"
+        );
+    }
+
+    #[test]
+    fn build_placeholders_sqlite_uses_question_marks() {
+        assert_eq!(build_placeholders(DatabaseBackend::Sqlite, 3), "?, ?, ?");
+    }
+
+    #[test]
+    fn build_placeholders_mysql_uses_question_marks() {
+        assert_eq!(build_placeholders(DatabaseBackend::MySql, 2), "?, ?");
+    }
+
+    // -- build_insert_sql --
+
+    #[test]
+    fn build_insert_sql_postgres_uses_on_conflict() {
+        let sql = build_insert_sql(
+            DatabaseBackend::Postgres,
+            "\"users\"",
+            &["\"name\"".to_string(), "\"email\"".to_string()],
+            "$1, $2",
+        );
+        assert!(sql.contains("INSERT INTO \"users\""));
+        assert!(sql.contains("ON CONFLICT DO NOTHING"));
+    }
+
+    #[test]
+    fn build_insert_sql_mysql_uses_insert_ignore() {
+        let sql = build_insert_sql(
+            DatabaseBackend::MySql,
+            "`users`",
+            &["`name`".to_string(), "`email`".to_string()],
+            "?, ?",
+        );
+        assert!(sql.contains("INSERT IGNORE INTO `users`"));
+        assert!(!sql.contains("ON CONFLICT"));
+    }
+
+    // -- verify_seeds_dir --
+
+    #[test]
+    fn verify_seeds_dir_returns_error_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("seeds");
+        let result = verify_seeds_dir(&missing);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("does not exist"));
+    }
+
+    #[test]
+    fn verify_seeds_dir_returns_error_when_not_a_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("seeds");
+        fs::write(&file_path, "not a dir").unwrap();
+        let result = verify_seeds_dir(&file_path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not a directory"));
+    }
+
+    #[test]
+    fn verify_seeds_dir_returns_ok_when_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let seeds = tmp.path().join("seeds");
+        fs::create_dir(&seeds).unwrap();
+        assert!(verify_seeds_dir(&seeds).is_ok());
+    }
+
+    // -- discover_seed_files --
+
+    #[test]
+    fn discover_seed_files_finds_json_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_seeds_dir(
+            tmp.path(),
+            &[
+                ("users.json", "[]"),
+                ("posts.json", "[]"),
+                ("readme.txt", "ignore me"),
+            ],
+        );
+        let seeds = tmp.path().join("seeds");
+        let result = discover_seed_files(&seeds, None).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "posts");
+        assert_eq!(result[1].0, "users");
+    }
+
+    #[test]
+    fn discover_seed_files_filters_by_entity() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_seeds_dir(tmp.path(), &[("users.json", "[]"), ("posts.json", "[]")]);
+        let seeds = tmp.path().join("seeds");
+        let result = discover_seed_files(&seeds, Some("users")).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "users");
+    }
+
+    #[test]
+    fn discover_seed_files_returns_error_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let seeds = tmp.path().join("seeds");
+        fs::create_dir(&seeds).unwrap();
+        let result = discover_seed_files(&seeds, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No seed files found"));
+    }
+
+    #[test]
+    fn discover_seed_files_sorts_alphabetically() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_seeds_dir(
+            tmp.path(),
+            &[
+                ("zebras.json", "[]"),
+                ("apples.json", "[]"),
+                ("mangos.json", "[]"),
+            ],
+        );
+        let seeds = tmp.path().join("seeds");
+        let result = discover_seed_files(&seeds, None).unwrap();
+        let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["apples", "mangos", "zebras"]);
+    }
+
+    // -- json_to_sea_value --
+
+    #[test]
+    fn json_to_sea_value_converts_string() {
+        let v = serde_json::json!("hello");
+        let result = json_to_sea_value(&v);
+        assert_eq!(
+            result,
+            sea_orm::Value::String(Some(Box::new("hello".to_string())))
+        );
+    }
+
+    #[test]
+    fn json_to_sea_value_converts_integer() {
+        let v = serde_json::json!(42);
+        let result = json_to_sea_value(&v);
+        assert_eq!(result, sea_orm::Value::BigInt(Some(42)));
+    }
+
+    #[test]
+    fn json_to_sea_value_converts_bool() {
+        let v = serde_json::json!(true);
+        let result = json_to_sea_value(&v);
+        assert_eq!(result, sea_orm::Value::Bool(Some(true)));
+    }
+
+    #[test]
+    fn json_to_sea_value_converts_null() {
+        let v = serde_json::json!(null);
+        let result = json_to_sea_value(&v);
+        assert_eq!(result, sea_orm::Value::String(None));
+    }
+
+    #[test]
+    fn json_to_sea_value_converts_float() {
+        let v = serde_json::json!(2.72);
+        let result = json_to_sea_value(&v);
+        assert_eq!(result, sea_orm::Value::Double(Some(2.72)));
+    }
+
+    #[test]
+    fn json_to_sea_value_converts_array_to_string() {
+        let v = serde_json::json!([1, 2, 3]);
+        let result = json_to_sea_value(&v);
+        assert_eq!(
+            result,
+            sea_orm::Value::String(Some(Box::new("[1,2,3]".to_string())))
+        );
+    }
+
+    // -- pluralize --
+
+    #[test]
+    fn pluralize_regular_noun() {
+        assert_eq!(pluralize("user"), "users");
+        assert_eq!(pluralize("post"), "posts");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_s() {
+        assert_eq!(pluralize("address"), "addresses");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_x() {
+        assert_eq!(pluralize("box"), "boxes");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_ch() {
+        assert_eq!(pluralize("match"), "matches");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_sh() {
+        assert_eq!(pluralize("wish"), "wishes");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_consonant_y() {
+        assert_eq!(pluralize("category"), "categories");
+        assert_eq!(pluralize("company"), "companies");
+    }
+
+    #[test]
+    fn pluralize_noun_ending_in_vowel_y() {
+        assert_eq!(pluralize("key"), "keys");
+        assert_eq!(pluralize("day"), "days");
+    }
+
+    // -- parse_schema_content --
+
+    #[test]
+    fn parse_schema_content_extracts_entities_and_fields() {
+        let input = r#"
+schema! {
+    User {
+        name: String,
+        email: String,
+        age: i32,
+    }
+}
+"#;
+        let result = parse_schema_content(input).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "User");
+        assert_eq!(result[0].1.len(), 3);
+        assert_eq!(result[0].1[0], ("name".to_string(), "String".to_string()));
+        assert_eq!(result[0].1[1], ("email".to_string(), "String".to_string()));
+        assert_eq!(result[0].1[2], ("age".to_string(), "i32".to_string()));
+    }
+
+    #[test]
+    fn parse_schema_content_handles_multiple_entities() {
+        let input = r#"
+        schema! {
+            User {
+                name: String,
+            }
+        }
+
+        schema! {
+            Post {
+                title: String,
+                published: bool,
+            }
+        }
+        "#;
+
+        let result = parse_schema_content(input).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].0, "User");
+        assert_eq!(result[1].0, "Post");
+    }
+
+    #[test]
+    fn parse_schema_content_returns_error_when_no_schemas() {
+        let input = "// just a comment\nfn main() {}";
+        let result = parse_schema_content(input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No schema! blocks"));
+    }
+
+    // -- generate_fake_value --
+
+    #[test]
+    fn generate_fake_value_returns_string_for_string_type() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("title", "String", 0, &mut rng);
+        assert!(val.is_string());
+    }
+
+    #[test]
+    fn generate_fake_value_returns_email_format_for_email_field() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("email", "String", 5, &mut rng);
+        assert_eq!(val.as_str().unwrap(), "user5@example.com");
+    }
+
+    #[test]
+    fn generate_fake_value_returns_number_for_i32() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("count", "i32", 0, &mut rng);
+        assert!(val.is_number());
+    }
+
+    #[test]
+    fn generate_fake_value_returns_bool_for_bool_type() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("active", "bool", 0, &mut rng);
+        assert!(val.is_boolean());
+    }
+
+    #[test]
+    fn generate_fake_value_returns_uuid_string_for_uuid_type() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("id", "Uuid", 0, &mut rng);
+        let s = val.as_str().unwrap();
+        assert!(uuid::Uuid::parse_str(s).is_ok(), "Invalid UUID: {}", s);
+    }
+
+    #[test]
+    fn generate_fake_value_returns_null_for_unknown_type() {
+        let mut rng = fastrand::Rng::new();
+        let val = generate_fake_value("x", "CustomType", 0, &mut rng);
+        assert!(val.is_null());
+    }
+
+    // -- generate_record --
+
+    #[test]
+    fn generate_record_produces_object_with_all_fields() {
+        let fields = vec![
+            ("name".to_string(), "String".to_string()),
+            ("age".to_string(), "i32".to_string()),
+        ];
+        let mut rng = fastrand::Rng::new();
+        let record = generate_record(&fields, 0, &mut rng);
+        let obj = record.as_object().unwrap();
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("age"));
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement};
+
+    async fn setup_sqlite() -> DatabaseConnection {
+        let conn = Database::connect("sqlite::memory:").await.unwrap();
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)".to_string(),
+        ))
+        .await
+        .unwrap();
+        conn
+    }
+
+    #[tokio::test]
+    async fn insert_records_inserts_into_sqlite() {
+        let conn = setup_sqlite().await;
+        let records =
+            vec![serde_json::json!({"id": 1, "name": "Alice", "email": "alice@example.com"})];
+        insert_records(&conn, "users", &records).await.unwrap();
+
+        let rows: Vec<serde_json::Value> = serde_json::Value::find_by_statement(
+            Statement::from_string(DatabaseBackend::Sqlite, "SELECT * FROM users".to_string()),
+        )
+        .all(&conn)
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["name"], "Alice");
+    }
+
+    #[tokio::test]
+    async fn insert_records_skips_duplicates() {
+        let conn = setup_sqlite().await;
+        let records = vec![serde_json::json!({"id": 1, "name": "Alice", "email": "a@b.com"})];
+        insert_records(&conn, "users", &records).await.unwrap();
+        insert_records(&conn, "users", &records).await.unwrap(); // should not error
+
+        let rows: Vec<serde_json::Value> = serde_json::Value::find_by_statement(
+            Statement::from_string(DatabaseBackend::Sqlite, "SELECT * FROM users".to_string()),
+        )
+        .all(&conn)
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 1); // not 2
+    }
+
+    #[tokio::test]
+    async fn truncate_tables_deletes_all_rows() {
+        let conn = setup_sqlite().await;
+        let records = vec![serde_json::json!({"id": 1, "name": "Alice", "email": "a@b.com"})];
+        insert_records(&conn, "users", &records).await.unwrap();
+
+        let seed_files = vec![("users".to_string(), std::path::PathBuf::from("users.json"))];
+        truncate_tables(&conn, &seed_files).await.unwrap();
+
+        let rows: Vec<serde_json::Value> = serde_json::Value::find_by_statement(
+            Statement::from_string(DatabaseBackend::Sqlite, "SELECT * FROM users".to_string()),
+        )
+        .all(&conn)
+        .await
+        .unwrap();
+
+        assert_eq!(rows.len(), 0);
+    }
+}

--- a/rapina-cli/src/main.rs
+++ b/rapina-cli/src/main.rs
@@ -61,6 +61,11 @@ enum Commands {
         #[arg(long, default_value = "127.0.0.1")]
         host: String,
     },
+    /// Database seeding tools
+    Seed {
+        #[command(subcommand)]
+        command: SeedCommands,
+    },
     /// Database migration tools
     Migrate {
         #[command(subcommand)]
@@ -90,6 +95,34 @@ enum Commands {
         watch: bool,
         /// Filter tests by name
         filter: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum SeedCommands {
+    /// Load seed data from JSON files into the database
+    Load {
+        /// Load specific entity only
+        #[arg(long)]
+        entity: Option<String>,
+        /// Wipe database before loading (truncate + load)
+        #[arg(long)]
+        fresh: bool,
+    },
+    /// Dump database data to JSON seed files
+    Dump {
+        /// Dump specific entity only
+        #[arg(long)]
+        entity: Option<String>,
+    },
+    /// Generate fake seed data based on schema types
+    Generate {
+        /// Number of records per entity
+        #[arg(long, default_value = "10")]
+        count: u32,
+        /// Generate for specific entity only
+        #[arg(long)]
+        entity: Option<String>,
     },
 }
 
@@ -225,6 +258,35 @@ fn main() {
             };
             if let Err(e) = commands::dev::execute(config) {
                 eprintln!("{} {}", "Error:".red().bold(), e);
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Seed { command }) => {
+            #[cfg(feature = "seed")]
+            {
+                let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+                let result = rt.block_on(async {
+                    match command {
+                        SeedCommands::Load { entity, fresh } => {
+                            commands::seed::load(entity, fresh).await
+                        }
+                        SeedCommands::Dump { entity } => commands::seed::dump(entity).await,
+                        SeedCommands::Generate { count, entity } => {
+                            commands::seed::generate(count, entity)
+                        }
+                    }
+                });
+                if let Err(e) = result {
+                    eprintln!("{} {}", "Error:".red().bold(), e);
+                    std::process::exit(1);
+                }
+            }
+            #[cfg(not(feature = "seed"))]
+            {
+                let _ = command;
+                let msg = "The seed command requires a database feature. \
+                           Reinstall with: cargo install rapina-cli --features seed-postgres";
+                eprintln!("{} {}", "Error:".red().bold(), msg);
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
## Summary

Adds database seeding support to the Rapina CLI, closing #146.

Three new subcommands under `rapina seed`:

- **`rapina seed load [--entity NAME] [--fresh]`** - Load JSON seed files from `seeds/` into the database. Uses idempotent inserts (`ON CONFLICT DO NOTHING` for Postgres/SQLite, `INSERT IGNORE` for MySQL). The `--fresh` flag truncates tables before loading.
- **`rapina seed dump [--entity NAME]`** - Export database tables to JSON seed files in `seeds/`.
- **`rapina seed generate --count N [--entity NAME]`** - Generate fake seed data based on `schema!` macro definitions in `src/entity.rs`, with type-aware values (emails, names, UUIDs, dates).

### Key design decisions

- **Cross-database support**: All generated SQL is backend-aware (Postgres, SQLite, MySQL) for identifier quoting, placeholder syntax, conflict handling, and foreign key management.
- **SQL injection prevention**: All table/column names are quoted via `quote_ident()` with proper escaping per backend.
- **Foreign key safety**: `--fresh` disables FK checks before deletion (`PRAGMA foreign_keys = OFF` / `SET session_replication_role` / `SET FOREIGN_KEY_CHECKS`), deletes in reverse order, then re-enables.
- **Fake data generation**: Type-aware values using `fastrand`, with record index for sequential fields like emails.

### AI usage disclaimer

Parts of this PR were written with the help of an AI tool. I reviewed, adapted, and manually tested all changes. I also added the AI as a co-author here for transparency, since I was unsure if that was the preferred practice in this project.

## Related Issues

Closes #146

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)

