### PR TITLE
feat: add built-in health check endpoints

### DIFF
--- a/docs/content/docs/core-concepts/authentication.md
+++ b/docs/content/docs/core-concepts/authentication.md
@@ -43,12 +43,6 @@ Mark routes that don't require authentication with `#[public]`:
 
 ```rust
 #[public]
-#[get("/health")]
-async fn health() -> &'static str {
-    "ok"
-}
-
-#[public]
 #[post("/login")]
 async fn login(body: Json<LoginRequest>, auth: State<AuthConfig>) -> Result<Json<TokenResponse>> {
     // Authenticate and return token
@@ -60,10 +54,11 @@ With `.discover()`, `#[public]` routes are automatically registered as public â€
 ```rust
 Rapina::new()
     .with_auth(auth_config)
-    .public_route("GET", "/health")
     .public_route("POST", "/login")
     // ...
 ```
+
+The built-in health check endpoints (`/__rapina/health`, `/__rapina/health/live`, `/__rapina/health/ready`) are always public when enabled â€” no `.public_route()` call needed.
 
 ## Protected Routes
 

--- a/docs/content/docs/core-concepts/state.md
+++ b/docs/content/docs/core-concepts/state.md
@@ -182,6 +182,70 @@ The default timeout is 30 seconds. After the timeout, remaining connections are 
 
 ---
 
+## Health Checks
+
+Enable built-in health endpoints with `.with_health_check(true)`:
+
+```rust
+Rapina::new()
+    .with_health_check(true)
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+This registers three endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /__rapina/health` | Alias for `/ready` — simple setups and load balancers |
+| `GET /__rapina/health/live` | Kubernetes liveness probe — always `200` |
+| `GET /__rapina/health/ready` | Kubernetes readiness probe — runs all checks |
+
+Point your Kubernetes probes at the dedicated endpoints:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /__rapina/health/live
+    port: 3000
+
+readinessProbe:
+  httpGet:
+    path: /__rapina/health/ready
+    port: 3000
+```
+
+The liveness probe **never** checks external dependencies — a DB outage should pull the pod from the load balancer (readiness failure), not restart it (liveness failure).
+
+Register custom checks for Redis, external APIs, or any dependency:
+
+```rust
+Rapina::new()
+    .with_health_check(true)
+    .add_health_check("redis", || async {
+        redis_ping().await.is_ok()
+    })
+    .add_health_check("stripe", || async {
+        stripe_ping().await.is_ok()
+    })
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+When all checks pass the response is `{"status": "ok"}`. When any check fails, the status is `503` and the body identifies which checks failed:
+
+```json
+{
+  "status": "error",
+  "checks": {
+    "db": "ok",
+    "redis": "error"
+  }
+}
+```
+
+---
+
 ## Going Further
 
 - [Database](@/docs/core-concepts/database.md) — `.with_database()`, the `Db` extractor, and migrations
@@ -215,12 +279,6 @@ struct AppConfig {
 #[public]
 async fn login(body: Json<LoginRequest>) -> Result<Json<TokenResponse>> {
     // validate credentials and issue JWT...
-}
-
-#[get("/health")]
-#[public]
-async fn health() -> &'static str {
-    "ok"
 }
 
 // Protected routes

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -31,12 +31,14 @@ curl http://127.0.0.1:3000/
 ```
 
 ```bash
-curl http://127.0.0.1:3000/health
+curl http://127.0.0.1:3000/__rapina/health
 ```
 
 ```json
 {"status": "ok"}
 ```
+
+The health endpoint is enabled by `.with_health_check(true)` in `main.rs`. See [Health Checks](@/docs/core-concepts/state.md#health-checks) for database and custom checks.
 
 Check what routes are available:
 
@@ -46,7 +48,6 @@ rapina routes
 
 ```
 GET    /         [public]
-GET    /health   [public]
 ```
 
 ## What the CLI Created

--- a/rapina-cli/src/commands/new.rs
+++ b/rapina-cli/src/commands/new.rs
@@ -82,7 +82,7 @@ pub fn execute(name: &str, template: Option<&str>, no_ai: bool) -> Result<(), St
 
 fn generate_readme(name: &str) -> String {
     format!(
-        "# {name}\n\nA web application built with Rapina.\n\n## Getting started\n\n```bash\nrapina dev\n```\n\n## Routes\n\n- `GET /` — Hello world\n- `GET /health` — Health check\n"
+        "# {name}\n\nA web application built with Rapina.\n\n## Getting started\n\n```bash\nrapina dev\n```\n\n## Routes\n\n- `GET /` — Hello world\n- `GET /__rapina/health` — Health check (built-in)\n"
     )
 }
 
@@ -98,8 +98,8 @@ All routes require JWT authentication unless explicitly marked with `#[public]`:
 
 ```rust
 #[public]
-#[get("/health")]
-async fn health() -> &'static str { "ok" }
+#[post("/auth/login")]
+async fn login(body: Json<LoginRequest>) -> Result<Json<TokenResponse>> { ... }
 
 // This route requires a valid JWT token
 #[get("/me")]

--- a/rapina-cli/src/commands/templates/auth.rs
+++ b/rapina-cli/src/commands/templates/auth.rs
@@ -41,12 +41,6 @@ fn generate_main_rs() -> String {
 use rapina::prelude::*;
 use rapina::middleware::RequestLogMiddleware;
 
-#[public]
-#[get("/health")]
-async fn health() -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "status": "healthy" }))
-}
-
 #[get("/me")]
 async fn me(user: CurrentUser) -> Json<serde_json::Value> {
     Json(serde_json::json!({ "id": user.id }))
@@ -59,7 +53,6 @@ async fn main() -> std::io::Result<()> {
     let auth_config = AuthConfig::from_env().expect("JWT_SECRET is required");
 
     let router = Router::new()
-        .get("/health", health)
         .post("/auth/register", auth::register)
         .post("/auth/login", auth::login)
         .get("/me", me);
@@ -68,7 +61,7 @@ async fn main() -> std::io::Result<()> {
         .with_tracing(TracingConfig::new())
         .middleware(RequestLogMiddleware::new())
         .with_auth(auth_config.clone())
-        .public_route("GET", "/health")
+        .with_health_check(true)
         .public_route("POST", "/auth/register")
         .public_route("POST", "/auth/login")
         .state(auth_config)
@@ -145,8 +138,7 @@ mod tests {
     #[test]
     fn test_generate_main_rs_marks_public_routes() {
         let content = generate_main_rs();
-        assert!(content.contains("#[public]"));
-        assert!(content.contains("public_route(\"GET\", \"/health\")"));
+        assert!(content.contains("with_health_check(true)"));
         assert!(content.contains("public_route(\"POST\", \"/auth/register\")"));
         assert!(content.contains("public_route(\"POST\", \"/auth/login\")"));
     }

--- a/rapina-cli/src/commands/templates/crud.rs
+++ b/rapina-cli/src/commands/templates/crud.rs
@@ -58,6 +58,7 @@ async fn main() -> std::io::Result<()> {
     Rapina::new()
         .with_tracing(TracingConfig::new())
         .middleware(RequestLogMiddleware::new())
+        .with_health_check(true)
         .with_database(DatabaseConfig::new("sqlite://app.db?mode=rwc"))
         .await?
         .run_migrations::<migrations::Migrator>()

--- a/rapina-cli/src/commands/templates/rest_api.rs
+++ b/rapina-cli/src/commands/templates/rest_api.rs
@@ -35,12 +35,6 @@ struct MessageResponse {
     message: String,
 }
 
-#[derive(Serialize, JsonSchema)]
-struct HealthResponse {
-    status: String,
-    version: String,
-}
-
 #[get("/")]
 async fn hello() -> Json<MessageResponse> {
     Json(MessageResponse {
@@ -48,23 +42,15 @@ async fn hello() -> Json<MessageResponse> {
     })
 }
 
-#[get("/health")]
-async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse {
-        status: "healthy".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-    })
-}
-
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let router = Router::new()
-        .get("/", hello)
-        .get("/health", health);
+        .get("/", hello);
 
     Rapina::new()
         .with_tracing(TracingConfig::new())
         .middleware(RequestLogMiddleware::new())
+        .with_health_check(true)
         .router(router)
         .listen("127.0.0.1:3000")
         .await
@@ -81,9 +67,8 @@ mod tests {
     fn test_generate_main_rs_has_hello_route() {
         let content = generate_main_rs();
         assert!(content.contains("#[get(\"/\")]"));
-        assert!(content.contains("#[get(\"/health\")]"));
         assert!(content.contains("async fn hello()"));
-        assert!(content.contains("async fn health()"));
+        assert!(content.contains("with_health_check(true)"));
         assert!(content.contains("Rapina::new()"));
     }
 }

--- a/rapina/examples/auth.rs
+++ b/rapina/examples/auth.rs
@@ -3,7 +3,7 @@
 //! Run with: `JWT_SECRET=your-secret-key cargo run --example auth`
 //!
 //! Test endpoints:
-//! - GET /health (public) - Health check, no auth required
+//! - GET /__rapina/health (public) - Health check, no auth required
 //! - POST /login (public) - Get a JWT token
 //! - GET /me (protected) - Requires valid JWT token
 
@@ -30,13 +30,6 @@ struct LoginRequest {
 struct UserResponse {
     id: String,
     username: String,
-}
-
-// Public route - no authentication required
-#[public]
-#[get("/health")]
-async fn health() -> &'static str {
-    "ok"
 }
 
 // Public route - login to get a token
@@ -91,8 +84,8 @@ async fn main() -> std::io::Result<()> {
     println!("  Server running at http://{}", addr);
     println!();
     println!("  Public endpoints:");
-    println!("    GET  /health  - Health check");
-    println!("    POST /login   - Get JWT token");
+    println!("    GET  /__rapina/health  - Health check");
+    println!("    POST /login            - Get JWT token");
     println!();
     println!("  Protected endpoints (require Authorization: Bearer <token>):");
     println!("    GET  /me         - Current user info");
@@ -101,6 +94,7 @@ async fn main() -> std::io::Result<()> {
 
     Rapina::new()
         .with_auth(auth_config.clone())
+        .with_health_check(true)
         .state(auth_config)
         .discover()
         .listen(&addr)

--- a/rapina/examples/hello.rs
+++ b/rapina/examples/hello.rs
@@ -5,11 +5,6 @@ async fn hello() -> &'static str {
     "Hello, Rapina!"
 }
 
-#[get("/health")]
-async fn health() -> StatusCode {
-    StatusCode::OK
-}
-
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> String {
     format!("ID: {}", *id)
@@ -17,5 +12,9 @@ async fn get_user(id: Path<u64>) -> String {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    Rapina::new().discover().listen("127.0.0.1:3000").await
+    Rapina::new()
+        .with_health_check(true)
+        .discover()
+        .listen("127.0.0.1:3000")
+        .await
 }

--- a/rapina/examples/macros.rs
+++ b/rapina/examples/macros.rs
@@ -58,11 +58,6 @@ async fn hello(config: State<AppConfig>) -> String {
     format!("Hello from {}!", config.app_name)
 }
 
-#[get("/health")]
-async fn health() -> StatusCode {
-    StatusCode::OK
-}
-
 #[get("/users/:id")]
 async fn get_user(id: Path<u64>) -> Result<Json<User>> {
     let id = *id;
@@ -108,13 +103,13 @@ async fn main() -> std::io::Result<()> {
 
     let router = Router::new()
         .get("/", hello)
-        .get("/health", health)
         .get("/users/:id", get_user)
         .get("/me", get_me)
         .post("/users", create_user);
 
     Rapina::new()
         .openapi("Rapina Test", "1.0.0")
+        .with_health_check(true)
         .state(config)
         .router(router)
         .listen(&addr)

--- a/rapina/examples/url-shortener/url-shortner/src/lib.rs
+++ b/rapina/examples/url-shortener/url-shortner/src/lib.rs
@@ -33,26 +33,11 @@ pub struct MessageResponse {
     message: String,
 }
 
-#[derive(Serialize, JsonSchema)]
-pub struct HealthResponse {
-    status: String,
-    version: String,
-}
-
 #[get("/")]
 #[public]
 pub async fn hello() -> Json<MessageResponse> {
     Json(MessageResponse {
         message: "Hello from Rapina!".to_string(),
-    })
-}
-
-#[get("/health")]
-#[public]
-pub async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse {
-        status: "healthy".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }
 
@@ -70,6 +55,7 @@ pub async fn build_app() -> std::io::Result<(Rapina, String)> {
         .with_cache(CacheConfig::in_memory(config.cache_capacity))
         .await?
         .middleware(RequestLogMiddleware::new())
+        .with_health_check(true)
         .with_database(db_config)
         .await?
         .run_migrations::<migrations::Migrator>()

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::auth::{AuthConfig, AuthMiddleware, PublicRoutes};
+use crate::health::{HealthRegistry, health_check, liveness_check, readiness_check};
 use crate::introspection::{RouteRegistry, list_routes};
 #[cfg(feature = "metrics")]
 use crate::metrics::{MetricsMiddleware, MetricsRegistry, metrics_handler};
@@ -55,6 +56,10 @@ pub struct Rapina {
     pub(crate) middlewares: MiddlewareStack,
     /// Whether introspection is enabled.
     pub(crate) introspection: bool,
+    /// Whether health check endpoint is enabled
+    pub(crate) health_check: bool,
+    /// Custom health checks
+    pub(crate) health_registry: HealthRegistry,
     /// Whether metrics is enabled.
     pub(crate) metrics: bool,
     /// Whether OpenAPI is enabled
@@ -90,6 +95,8 @@ impl Rapina {
             state: AppState::new(),
             middlewares: MiddlewareStack::new(),
             introspection: cfg!(debug_assertions),
+            health_check: false,
+            health_registry: HealthRegistry::new(),
             metrics: false,
             openapi: false,
             openapi_title: "API".to_string(),
@@ -282,7 +289,6 @@ impl Rapina {
     /// ```ignore
     /// Rapina::new()
     ///     .with_auth(auth_config)
-    ///     .public_route("GET", "/health")
     ///     .public_route("POST", "/login")
     ///     .router(router)
     ///     .listen("127.0.0.1:3000")
@@ -307,6 +313,34 @@ impl Rapina {
     /// Introspection is enabled by default in debug builds.
     pub fn with_introspection(mut self, enabled: bool) -> Self {
         self.introspection = enabled;
+        self
+    }
+
+    /// Enables or disables the built-in health check endpoints.
+    ///
+    /// When enabled, registers readiness and liveness health check endpoints:
+    /// - `GET /__rapina/health` — alias for readiness, for simple setups and load balancers
+    /// - `GET /__rapina/health/live` — liveness probe, always returns `200 OK`
+    /// - `GET /__rapina/health/ready` — readiness probe, runs DB and custom checks
+    ///
+    /// Health check is disabled by default.
+    pub fn with_health_check(mut self, enabled: bool) -> Self {
+        self.health_check = enabled;
+        self
+    }
+
+    /// Registers a custom health check function.
+    ///
+    /// The function is called on every `GET /__rapina/health` request.
+    /// Return `true` if healthy, `false` if not.
+    ///
+    /// Requires `.with_health_check(true)` to be set.
+    pub fn add_health_check<F, Fut>(mut self, name: &'static str, f: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = bool> + Send + 'static,
+    {
+        self.health_registry.add(name, f);
         self
     }
 
@@ -582,6 +616,16 @@ impl Rapina {
             self.router = self
                 .router
                 .get_named("/__rapina/routes", "list_routes", list_routes);
+        }
+
+        if self.health_check {
+            let registry = std::mem::take(&mut self.health_registry);
+            self.state = self.state.with(registry);
+            self.router = self
+                .router
+                .get_named("/__rapina/health", "health_check", health_check)
+                .get_named("/__rapina/health/live", "liveness_check", liveness_check)
+                .get_named("/__rapina/health/ready", "readiness_check", readiness_check);
         }
 
         #[cfg(feature = "metrics")]

--- a/rapina/src/health/config.rs
+++ b/rapina/src/health/config.rs
@@ -1,0 +1,55 @@
+//! Health check configuration types.
+//!
+//! This module defines the types used to register custom health checks
+//! with the [`HealthRegistry`], which is stored in application state and
+//! queried on every `GET /__rapina/health` request.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// A boxed async function that returns `true` if the check passes, `false` otherwise.
+///
+/// This is the internal representation of a registered health check after type-erasure.
+pub type HealthCheckFn = Box<dyn Fn() -> Pin<Box<dyn Future<Output = bool> + Send>> + Send + Sync>;
+
+/// Registry of named custom health checks stored in application state.
+///
+/// Each check is an async function that returns `true` when healthy.
+/// The registry is populated via [`Rapina::add_health_check`](crate::app::Rapina::add_health_check)
+/// and automatically placed in state when `.with_health_check(true)` is set.
+///
+/// On each request to `/__rapina/health`, all registered checks are called
+/// and their results are included in the response under the `"checks"` key.
+#[derive(Default)]
+pub struct HealthRegistry {
+    /// Named check functions, in registration order.
+    pub(crate) checks: Vec<(&'static str, HealthCheckFn)>,
+}
+
+impl HealthRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a named async health check.
+    ///
+    /// The function `f` is called on every health check request.
+    /// It should return `true` if the dependency is reachable and healthy,
+    /// or `false` if it is not.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// registry.add("redis", || async {
+    ///     redis_client.ping().await.is_ok()
+    /// });
+    /// ```
+    pub fn add<F, Fut>(&mut self, name: &'static str, f: F)
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = bool> + Send + 'static,
+    {
+        self.checks.push((name, Box::new(move || Box::pin(f()))));
+    }
+}

--- a/rapina/src/health/endpoint.rs
+++ b/rapina/src/health/endpoint.rs
@@ -1,0 +1,256 @@
+//! Health check handlers for `/__rapina/health`, `/__rapina/health/live`,
+//! and `/__rapina/health/ready`.
+//!
+//! - [`liveness_check`] — always returns `200 OK`. Used by Kubernetes liveness
+//!   probes to detect deadlocked or crashed processes. Failure triggers a pod restart.
+//! - [`readiness_check`] — runs DB and custom checks. Used by Kubernetes readiness
+//!   probes to gate traffic. Failure removes the pod from the load balancer without restarting it.
+//! - [`health_check`] — alias for `readiness_check`, registered at `/__rapina/health`
+//!   for backwards compatibility and simple deployments.
+
+use std::sync::Arc;
+
+use http::{Request, Response, StatusCode, header::CONTENT_TYPE};
+use hyper::body::Incoming;
+
+use crate::{
+    extract::PathParams,
+    health::config::HealthRegistry,
+    response::{APPLICATION_JSON, BoxBody},
+    state::AppState,
+};
+
+/// Handler for `GET /__rapina/health/live`.
+///
+/// Always returns `200 OK` with `{"status": "ok"}` as long as the process is running.
+/// No external dependencies are checked — this probe only answers "is the process alive?".
+///
+/// A failure here causes Kubernetes to restart the pod, so it should never fail
+/// due to a database outage or external service being down.
+pub async fn liveness_check(
+    _req: Request<Incoming>,
+    _params: PathParams,
+    _state: Arc<AppState>,
+) -> Response<BoxBody> {
+    let body = serde_json::json!({ "status": "ok" });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .body(http_body_util::Full::new(bytes::Bytes::from(
+            serde_json::to_vec(&body).unwrap_or_default(),
+        )))
+        .unwrap()
+}
+
+/// Handler for `GET /__rapina/health/ready` and `GET /__rapina/health`.
+///
+/// Runs all configured health checks (database connectivity and custom checks)
+/// and returns a unified JSON response. Returns `200 OK` when everything is
+/// healthy, `503 Service Unavailable` when any check fails.
+///
+/// A failure here causes Kubernetes to stop routing traffic to the pod without
+/// restarting it — the right behaviour for transient dependency outages.
+pub async fn readiness_check(
+    _req: Request<Incoming>,
+    _params: PathParams,
+    state: Arc<AppState>,
+) -> Response<BoxBody> {
+    let mut checks = serde_json::Map::new();
+    let mut all_ok = true;
+
+    // Database connectivity check — only compiled when the `database` feature is enabled.
+    // Runs a lightweight `SELECT 1` against the active connection to verify reachability.
+    #[cfg(feature = "database")]
+    {
+        use sea_orm::{ConnectionTrait, Statement};
+
+        if let Some(conn) = state.get::<sea_orm::DatabaseConnection>() {
+            let backend = conn.get_database_backend();
+            let db_ok = conn
+                .execute(Statement::from_string(backend, "SELECT 1"))
+                .await
+                .is_ok();
+            checks.insert(
+                "db".to_string(),
+                if db_ok { "ok".into() } else { "error".into() },
+            );
+            if !db_ok {
+                all_ok = false;
+            }
+        }
+    }
+
+    // Custom checks registered via `.add_health_check(name, fn)` on the builder.
+    // Each check is called sequentially; all results are collected before responding.
+    if let Some(registry) = state.get::<HealthRegistry>() {
+        for (name, check_fn) in &registry.checks {
+            let ok = check_fn().await;
+            checks.insert(
+                name.to_string(),
+                if ok { "ok".into() } else { "error".into() },
+            );
+            if !ok {
+                all_ok = false;
+            }
+        }
+    }
+
+    // Build the response body. The `"checks"` key is omitted when no checks are configured
+    // so that the basic case stays as simple as `{"status": "ok"}`.
+    let mut body = serde_json::json!({ "status": if all_ok { "ok" } else { "error" } });
+    if !checks.is_empty() {
+        body["checks"] = serde_json::Value::Object(checks);
+    }
+    let status = if all_ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .body(http_body_util::Full::new(bytes::Bytes::from(
+            serde_json::to_vec(&body).unwrap_or_default(),
+        )))
+        .unwrap()
+}
+
+/// Alias for [`readiness_check`], registered at `GET /__rapina/health`.
+pub async fn health_check(
+    req: Request<Incoming>,
+    params: PathParams,
+    state: Arc<AppState>,
+) -> Response<BoxBody> {
+    readiness_check(req, params, state).await
+}
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderValue, StatusCode};
+    use serde_json::Value;
+
+    use crate::{app::Rapina, testing::TestClient};
+
+    #[tokio::test]
+    async fn test_liveness_check_always_returns_200() {
+        let app = Rapina::new().with_health_check(true);
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health/live").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.json::<Value>()["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_readiness_check_returns_200_when_no_checks() {
+        let app = Rapina::new().with_health_check(true);
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health/ready").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.json::<Value>()["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_readiness_check_returns_503_when_custom_check_fails() {
+        let app = Rapina::new()
+            .with_health_check(true)
+            .add_health_check("redis", || async { false });
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health/ready").send().await;
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_health_check_returns_200_with_json_content_type() {
+        let app = Rapina::new().with_health_check(true);
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health").send().await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(http::header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static("application/json"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_health_check_returns_status_ok() {
+        let app = Rapina::new().with_health_check(true);
+        let client = TestClient::new(app).await;
+        let json = client.get("/__rapina/health").send().await.json::<Value>();
+
+        assert_eq!(json["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_health_check_returns_404_when_disabled() {
+        let app = Rapina::new().with_health_check(false);
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health").send().await;
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_health_check_with_passing_custom_check_returns_200() {
+        let app = Rapina::new()
+            .with_health_check(true)
+            .add_health_check("redis", || async { true });
+        let client = TestClient::new(app).await;
+        let json = client.get("/__rapina/health").send().await.json::<Value>();
+
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["checks"]["redis"], "ok");
+    }
+
+    #[tokio::test]
+    async fn test_health_check_with_failing_custom_check_returns_503() {
+        let app = Rapina::new()
+            .with_health_check(true)
+            .add_health_check("redis", || async { false });
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health").send().await;
+        let status = response.status();
+        let json = response.json::<Value>();
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["status"], "error");
+        assert_eq!(json["checks"]["redis"], "error");
+    }
+
+    #[tokio::test]
+    async fn test_health_check_with_mixed_custom_checks_returns_503() {
+        let app = Rapina::new()
+            .with_health_check(true)
+            .add_health_check("redis", || async { true })
+            .add_health_check("stripe", || async { false });
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health").send().await;
+        let status = response.status();
+        let json = response.json::<Value>();
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["status"], "error");
+        assert_eq!(json["checks"]["redis"], "ok");
+        assert_eq!(json["checks"]["stripe"], "error");
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn test_health_check_with_database_returns_db_ok() {
+        use crate::database::DatabaseConfig;
+
+        let app = Rapina::new()
+            .with_health_check(true)
+            .with_database(DatabaseConfig::new("sqlite::memory:"))
+            .await
+            .unwrap();
+        let client = TestClient::new(app).await;
+        let json = client.get("/__rapina/health").send().await.json::<Value>();
+
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["checks"]["db"], "ok");
+    }
+}

--- a/rapina/src/health/mod.rs
+++ b/rapina/src/health/mod.rs
@@ -1,0 +1,72 @@
+//! Built-in health check endpoints for Rapina.
+//!
+//! When enabled via [`.with_health_check(true)`](crate::app::Rapina::with_health_check),
+//! three endpoints are registered:
+//!
+//! | Endpoint | Handler | Purpose |
+//! |---|---|---|
+//! | `GET /__rapina/health` | [`health_check`] | Alias for `/ready` — simple setups and load balancers |
+//! | `GET /__rapina/health/live` | [`liveness_check`] | Kubernetes liveness probe — always `200` |
+//! | `GET /__rapina/health/ready` | [`readiness_check`] | Kubernetes readiness probe — runs all checks |
+//!
+//! # Response format
+//!
+//! All endpoints return JSON. When all checks pass:
+//!
+//! ```json
+//! { "status": "ok" }
+//! ```
+//!
+//! When checks are configured (database or custom), they appear under `"checks"`:
+//!
+//! ```json
+//! {
+//!   "status": "ok",
+//!   "checks": {
+//!     "db": "ok",
+//!     "redis": "ok"
+//!   }
+//! }
+//! ```
+//!
+//! If any check fails, `"status"` is `"error"` and the HTTP status code is `503`:
+//!
+//! ```json
+//! {
+//!   "status": "error",
+//!   "checks": {
+//!     "db": "error",
+//!     "redis": "ok"
+//!   }
+//! }
+//! ```
+//!
+//! # Built-in checks
+//!
+//! - **`db`** — when the `database` feature is enabled and a [`DatabaseConnection`](sea_orm::DatabaseConnection)
+//!   is in state, a `SELECT 1` query is executed to verify connectivity.
+//!   Only runs on `/ready` and `/__rapina/health`, never on `/live`.
+//!
+//! # Custom checks
+//!
+//! Register additional checks via [`Rapina::add_health_check`](crate::app::Rapina::add_health_check).
+//! All custom checks run on `/ready` (and its `/health` alias):
+//!
+//! ```ignore
+//! Rapina::new()
+//!     .with_health_check(true)
+//!     .add_health_check("redis", || async {
+//!         redis_ping().await.is_ok()
+//!     })
+//!     .add_health_check("stripe", || async {
+//!         stripe_ping().await.is_ok()
+//!     })
+//!     .listen("127.0.0.1:3000")
+//!     .await
+//! ```
+
+pub mod config;
+mod endpoint;
+
+pub use config::HealthRegistry;
+pub use endpoint::{health_check, liveness_check, readiness_check};

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -94,6 +94,7 @@ pub mod discovery;
 pub mod error;
 pub mod extract;
 pub mod handler;
+pub mod health;
 pub mod introspection;
 #[cfg(feature = "metrics")]
 pub mod metrics;


### PR DESCRIPTION
Adds `/__rapina/health`, `/__rapina/health/live`, and `/__rapina/health/ready` endpoints enabled via `.with_health_check(true)` on the builder.

- Liveness probe always returns 200 — never checks external deps
- Readiness probe runs DB connectivity check (when `database` feature is enabled) and any custom checks registered via `.add_health_check()`
- Failed checks return 503 with a `"checks"` map identifying which ones failed
- All `/__rapina/*` routes are automatically public (bypass JWT auth)
- All project templates (`rest-api`, `auth`, `crud`) now include `.with_health_check(true)` by default
- Updated examples, docs, and removed the now-redundant manual `/health` handlers throughout the codebase

Closes #162 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
