### PR TITLE
Bump to 0.10.0, update changelog and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-03-16
+
+### Added
+- **Serde-based Path extraction**: `Path<T>` now uses a custom serde deserializer, supporting `Path<u64>`, `Path<(u64, String)>` tuples, and `Path<MyStruct>` structs from a single implementation
+- **Database seeding**: `rapina seed load`, `rapina seed dump`, and `rapina seed generate` commands behind `seed-*` feature flags
+- **Snapshot testing**: `response.assert_snapshot("name")` with automatic UUID/timestamp redaction, `--bless` mode for updating golden files
+- **RFC 7807 Problem Details**: Standardized error responses with configurable `ErrorConfig`, per-request scoping via `task_local!`
+- **Three-layer router**: Static route map for O(1) parameterless lookup, hot cache, and frozen radix trie
+- **Router benchmarks**: Criterion benchmarks for router resolution performance
+- **Configurable request logging**: Verbose mode with header/query/body-size logging, header redaction for sensitive values
+- **`--force` flag for `import database`**: Re-import over existing generated files
+- **Irregular plurals in codegen**: Handles words like `status`, `address`, `child` correctly in singularize/pluralize
+- **UUID primary key support** in `schema!` macro
+- **`put_named` and `delete_named`** convenience methods on Router
+- **URL shortener example**: Full CRUD example with database, migrations, and tests
+
+### Changed
+- **`State<T>` wrapped in `Arc<T>`**: Removes the `Clone` bound on state types, `into_inner()` returns `Arc<T>`
+- **Positional extractor convention**: Last handler argument uses `FromRequest` (consumes body), all others use `FromRequestParts` — replaces string-based classification
+- **`PathParams` backed by `SmallVec`**: Stack-allocated for up to 4 parameters, zero heap allocation for typical routes
+- **Compression gated behind feature flag**: `compression` feature (enabled by default)
+- **Macro preserves `mut` on handler arguments**: Enables mutable extractors like `mut form: Multipart`
+
 ## [0.6.0] - 2026-02-22
 
 ### Added
@@ -69,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized error handling with `trace_id`
 - CLI (`rapina new`, `rapina dev`)
 
-[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/rapina-rs/rapina/compare/v0.9.0...v0.10.0
 [0.6.0]: https://github.com/rapina-rs/rapina/compare/v0.5.0...v0.6.0
 [0.2.0]: https://github.com/rapina-rs/rapina/compare/v0.1.0-alpha.3...v0.2.0
 [0.1.0-alpha.3]: https://github.com/rapina-rs/rapina/compare/v0.1.0-alpha.2...v0.1.0-alpha.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "rapina"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/docs/templates/roadmap.html
+++ b/docs/templates/roadmap.html
@@ -55,22 +55,15 @@ block content %}
                     </div>
                 </div>
                 <div class="roadmap-card">
-                    <h4>Snapshot Testing</h4>
-                    <p><code>rapina test --bless</code> for snapshot-based API response testing.</p>
-                    <div class="card-tags">
-                        <span class="card-tag">CLI</span>
-                    </div>
-                </div>
-                <div class="roadmap-card">
                     <h4>Schema Improvements</h4>
-                    <p>UUID primary keys, relationship fields from foreign keys, <code>--diff</code> mode against live databases, and nullable <code>Option&lt;T&gt;</code> columns in generated DTOs.</p>
+                    <p>Relationship fields from foreign keys, <code>--diff</code> mode against live databases, and nullable <code>Option&lt;T&gt;</code> columns in generated DTOs.</p>
                     <div class="card-tags">
                         <span class="card-tag">Feature</span>
                     </div>
                 </div>
                 <div class="roadmap-card">
-                    <h4>RFC 7807 Problem Details</h4>
-                    <p>Standard error format for HTTP APIs.</p>
+                    <h4>Multipart File Uploads</h4>
+                    <p>Streaming multipart extractor with <code>multer</code> for file uploads and form data.</p>
                     <div class="card-tags">
                         <span class="card-tag">Feature</span>
                     </div>
@@ -84,16 +77,6 @@ block content %}
                 <h3>In Progress</h3>
             </div>
             <div class="column-cards">
-                <div class="roadmap-card">
-                    <h4>Feature Flags for Middleware</h4>
-                    <p>
-                        Gate rate limiting and compression behind feature flags
-                        to keep the default build lean.
-                    </p>
-                    <div class="card-tags">
-                        <span class="card-tag">Chore</span>
-                    </div>
-                </div>
                 <div class="roadmap-card">
                     <h4>Redis TLS Support</h4>
                     <p>
@@ -113,12 +96,21 @@ block content %}
                     </div>
                 </div>
                 <div class="roadmap-card">
-                    <h4>Import CLI Improvements</h4>
+                    <h4>Scalar OpenAPI UI</h4>
                     <p>
-                        Auto-wire mod declarations after import, <code>--force</code> flag for re-importing, and fix broken JsonSchema derives in generated DTOs.
+                        Built-in Scalar API documentation UI served from the framework.
                     </p>
                     <div class="card-tags">
-                        <span class="card-tag">CLI</span>
+                        <span class="card-tag">Feature</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Health Check Endpoints</h4>
+                    <p>
+                        Built-in health check routes for readiness and liveness probes.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">Feature</span>
                     </div>
                 </div>
             </div>
@@ -130,6 +122,66 @@ block content %}
                 <h3>Done</h3>
             </div>
             <div class="column-cards">
+                <div class="roadmap-card">
+                    <h4>Serde-based Path Extraction</h4>
+                    <p>
+                        <code>Path&lt;T&gt;</code> supports scalars, tuples, and structs
+                        via a custom serde deserializer.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Database Seeding</h4>
+                    <p>
+                        <code>rapina seed load</code>, <code>dump</code>, and
+                        <code>generate</code> for managing seed data.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Snapshot Testing</h4>
+                    <p>
+                        Golden-file testing with <code>--bless</code> mode and automatic
+                        UUID/timestamp redaction.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>RFC 7807 Problem Details</h4>
+                    <p>
+                        Standardized error responses with configurable base URI
+                        and per-request scoping.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Three-layer Router</h4>
+                    <p>
+                        O(1) static route lookup, SmallVec path params, and
+                        criterion benchmarks.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
+                <div class="roadmap-card">
+                    <h4>Compression Feature Flag</h4>
+                    <p>
+                        Compression gated behind <code>compression</code> feature,
+                        <code>--force</code> flag for import, and improved codegen pluralization.
+                    </p>
+                    <div class="card-tags">
+                        <span class="card-tag">v0.10.0</span>
+                    </div>
+                </div>
                 <div class="roadmap-card">
                     <h4>WebSocket &amp; Relay</h4>
                     <p>

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI tool for Rapina web framework - create and run Rapina projects"

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-macros"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Procedural macros for the Rapina web framework"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A fast, type-safe web framework for Rust inspired by FastAPI"
@@ -64,7 +64,7 @@ smallvec = "1"
 flate2 =  { version = "1.1", optional = true }
 
 # Our macros
-rapina-macros = { version = "0.9.0", path = "../rapina-macros/" }
+rapina-macros = { version = "0.10.0", path = "../rapina-macros/" }
 
 # Auto-discovery
 inventory = "0.3"


### PR DESCRIPTION
Version bump for the 0.10.0 release across all three crates (rapina, rapina-macros, rapina-cli), updated changelog with all 0.10.0 changes, and roadmap board updated to reflect completed items.