### PR TITLE
feat: add OTLP telemetry export with W3C traceparent propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1116,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1146,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1172,7 +1231,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1351,6 +1410,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tungstenite"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1443,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1378,9 +1451,11 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1526,6 +1601,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1585,6 +1670,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1756,6 +1857,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2014,9 +2121,91 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -2137,6 +2326,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2318,6 +2527,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,9 +2679,12 @@ dependencies = [
  "hyper-util",
  "inventory",
  "jsonwebtoken",
- "matchit",
+ "matchit 0.8.6",
  "multer",
  "nix",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus",
  "rapina-macros",
  "redis",
@@ -2467,6 +2702,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
  "validator",
@@ -2545,7 +2781,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.6.1",
  "tokio",
  "tokio-util",
  "url",
@@ -2626,6 +2862,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3114,7 +3384,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -3251,6 +3521,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -3311,7 +3591,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -3551,6 +3831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,7 +3996,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3765,7 +4054,7 @@ version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1d7e18e3dd1d31e0ee5e863a8091ffec2fcc271636586042452b656a22c8ee1"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -3798,7 +4087,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -3818,6 +4107,95 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3867,6 +4245,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4127,6 +4523,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,7 +4585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4188,7 +4598,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -4197,6 +4607,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4557,7 +4977,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.114",
  "wasm-metadata",
@@ -4588,7 +5008,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -4607,7 +5027,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -243,6 +243,40 @@ async fn handler(ctx: Context) -> String {
 }
 ```
 
+### W3C Traceparent (requires `telemetry` feature)
+
+Propagates W3C `traceparent` headers for distributed tracing with OpenTelemetry-compatible backends (Jaeger, Datadog, etc.).
+
+- Parses incoming `traceparent` headers and creates child spans linked to the upstream trace
+- Echoes the `traceparent` header back in the response
+- Works independently of `TraceIdMiddleware` — both can be used simultaneously
+
+```rust
+use rapina::middleware::TraceparentMiddleware;
+
+Rapina::new()
+    .with_telemetry(TelemetryConfig::new("http://jaeger:4317", "my-api"))
+    .middleware(TraceparentMiddleware::new())
+    .discover()
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+`TelemetryConfig` supports both gRPC (port 4317, default) and HTTP/protobuf (port 4318) transports:
+
+```rust
+// gRPC (default)
+TelemetryConfig::new("http://collector:4317", "my-api")
+
+// HTTP/protobuf
+TelemetryConfig::new("http://collector:4318", "my-api").http()
+
+// With custom sampling
+TelemetryConfig::new("http://collector:4317", "my-api").sample_rate(0.5)
+```
+
+A shutdown hook is automatically registered to flush pending spans when the server shuts down.
+
 ---
 
 ## Custom Middleware
@@ -403,6 +437,7 @@ Response ←  [A]  ←  [B]  ←  [C]  ←  Handler
 | Middleware | Position | Reason |
 |------------|----------|--------|
 | Trace ID | First | All downstream logs carry the request ID |
+| Traceparent | After Trace ID | Links spans to upstream distributed traces |
 | Request Log | After Trace ID | Captures the trace ID in the log span |
 | CORS | Before rate limit | Preflights are answered before consuming any quota |
 | Rate limit | Before auth | No JWT work done for clients that will be blocked |

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -38,7 +38,13 @@ validator = { version = "0.20.0", features = ["derive"] }
 
 # Observability
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "registry"] }
+
+# OpenTelemetry (optional — enabled by `telemetry` feature)
+opentelemetry = { version = "0.28", optional = true }
+opentelemetry_sdk = { version = "0.28", optional = true, features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.28", optional = true, features = ["grpc-tonic", "http-proto"] }
+tracing-opentelemetry = { version = "0.29", optional = true }
 
 uuid = { version = "1", features = ["v4"] }
 # FIXME: move behind a `snapshot` feature flag
@@ -120,3 +126,4 @@ metrics = ["prometheus"]
 cache-redis = ["redis"]
 multipart = ["multer", "futures-util"]
 websocket = ["hyper-tungstenite", "tokio-tungstenite", "futures-util"]
+telemetry = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -299,6 +299,39 @@ impl Rapina {
         self
     }
 
+    /// Configures OpenTelemetry OTLP trace export.
+    ///
+    /// Sets up a tracing pipeline that exports spans to the configured OTLP
+    /// endpoint. A shutdown hook is automatically registered to flush pending
+    /// spans on graceful shutdown.
+    ///
+    /// Requires the `telemetry` feature.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use rapina::prelude::*;
+    ///
+    /// Rapina::new()
+    ///     .with_telemetry(TelemetryConfig {
+    ///         endpoint: "http://jaeger:4317".into(),
+    ///         service_name: "my-api".into(),
+    ///         sample_rate: 1.0,
+    ///     })
+    ///     .router(router)
+    ///     .listen("127.0.0.1:3000")
+    ///     .await
+    /// ```
+    #[cfg(feature = "telemetry")]
+    pub fn with_telemetry(self, config: crate::observability::TelemetryConfig) -> Self {
+        let provider = config.init();
+        self.on_shutdown(move || async move {
+            if let Err(e) = provider.shutdown() {
+                eprintln!("OpenTelemetry shutdown error: {e}");
+            }
+        })
+    }
+
     /// Enables or disables the introspection endpoint.
     ///
     /// When enabled, a `GET /.__rapina/routes` endpoint is registered

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -13,6 +13,7 @@
 //! - **Structured errors** - Standardized error responses with `trace_id` for debugging
 //! - **Validation** - Built-in request validation using the `validator` crate
 //! - **Observability** - Integrated tracing for structured logging
+//! - **Telemetry** - OpenTelemetry OTLP trace export (optional `telemetry` feature)
 //!
 //! ## Quick Start
 //!
@@ -136,10 +137,14 @@ pub mod prelude {
     #[cfg(feature = "multipart")]
     pub use crate::extract::{Field, Multipart};
     pub use crate::introspection::RouteInfo;
+    #[cfg(feature = "telemetry")]
+    pub use crate::middleware::TraceparentMiddleware;
     pub use crate::middleware::{
         KeyExtractor, Middleware, Next, RateLimitConfig, RequestLogConfig,
     };
     pub use crate::observability::TracingConfig;
+    #[cfg(feature = "telemetry")]
+    pub use crate::observability::{OtlpProtocol, SamplerConfig, TelemetryConfig};
     #[cfg(feature = "database")]
     pub use crate::pagination::{Paginate, Paginated, PaginationConfig};
     #[cfg(feature = "websocket")]

--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -18,6 +18,8 @@ mod rate_limit;
 mod request_log;
 mod timeout;
 mod trace_id;
+#[cfg(feature = "telemetry")]
+mod traceparent;
 
 pub use body_limit::BodyLimitMiddleware;
 #[cfg(feature = "compression")]
@@ -27,6 +29,8 @@ pub use rate_limit::{KeyExtractor, RateLimitConfig, RateLimitMiddleware};
 pub use request_log::{RequestLogConfig, RequestLogMiddleware};
 pub use timeout::TimeoutMiddleware;
 pub use trace_id::{TRACE_ID_HEADER, TraceIdMiddleware};
+#[cfg(feature = "telemetry")]
+pub use traceparent::TraceparentMiddleware;
 
 use std::future::Future;
 use std::pin::Pin;

--- a/rapina/src/middleware/traceparent.rs
+++ b/rapina/src/middleware/traceparent.rs
@@ -1,0 +1,262 @@
+//! W3C Trace Context propagation middleware.
+
+use hyper::body::Incoming;
+use hyper::header::HeaderValue;
+use hyper::{Request, Response};
+
+use crate::context::RequestContext;
+use crate::response::BoxBody;
+
+use super::{BoxFuture, Middleware, Next};
+
+const TRACEPARENT_HEADER: &str = "traceparent";
+
+/// Middleware that propagates W3C `traceparent` headers for distributed tracing.
+///
+/// When an incoming request carries a `traceparent` header, this middleware
+/// creates a child span linked to the upstream trace. The `traceparent`
+/// header is echoed back in the response so downstream services can
+/// continue the trace chain.
+///
+/// This middleware is independent of [`TraceIdMiddleware`](super::TraceIdMiddleware)
+/// and both can be used simultaneously.
+///
+/// Requires the `telemetry` feature.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use rapina::prelude::*;
+/// use rapina::middleware::TraceparentMiddleware;
+///
+/// Rapina::new()
+///     .with_telemetry(TelemetryConfig::new("http://jaeger:4317", "my-api"))
+///     .middleware(TraceparentMiddleware::new())
+///     .router(router)
+///     .listen("127.0.0.1:3000")
+///     .await
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct TraceparentMiddleware;
+
+impl TraceparentMiddleware {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TraceparentMiddleware {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parsed W3C traceparent header fields.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Traceparent {
+    pub version: u8,
+    pub trace_id: String,
+    pub parent_id: String,
+    pub trace_flags: u8,
+}
+
+impl Traceparent {
+    /// Parses a `traceparent` header value.
+    ///
+    /// Format: `{version}-{trace_id}-{parent_id}-{flags}`
+    /// Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        let parts: Vec<&str> = value.split('-').collect();
+        if parts.len() != 4 {
+            return None;
+        }
+
+        let version = u8::from_str_radix(parts[0], 16).ok()?;
+        let trace_id = parts[1];
+        let parent_id = parts[2];
+        let trace_flags = u8::from_str_radix(parts[3], 16).ok()?;
+
+        // Validate lengths per W3C spec
+        if trace_id.len() != 32 || parent_id.len() != 16 {
+            return None;
+        }
+
+        // Validate hex characters
+        if !trace_id.chars().all(|c| c.is_ascii_hexdigit())
+            || !parent_id.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return None;
+        }
+
+        // All-zero trace_id or parent_id is invalid
+        if trace_id.chars().all(|c| c == '0') || parent_id.chars().all(|c| c == '0') {
+            return None;
+        }
+
+        Some(Self {
+            version,
+            trace_id: trace_id.to_string(),
+            parent_id: parent_id.to_string(),
+            trace_flags,
+        })
+    }
+
+    /// Formats the traceparent header value.
+    pub(crate) fn to_header_value(&self) -> String {
+        format!(
+            "{:02x}-{}-{}-{:02x}",
+            self.version, self.trace_id, self.parent_id, self.trace_flags
+        )
+    }
+}
+
+impl Middleware for TraceparentMiddleware {
+    fn handle<'a>(
+        &'a self,
+        req: Request<Incoming>,
+        _ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        Box::pin(async move {
+            let incoming_traceparent = req
+                .headers()
+                .get(TRACEPARENT_HEADER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(Traceparent::parse);
+
+            let span = if let Some(ref tp) = incoming_traceparent {
+                tracing::info_span!(
+                    "http.request",
+                    otel.kind = "server",
+                    trace_id = %tp.trace_id,
+                    parent_id = %tp.parent_id,
+                )
+            } else {
+                tracing::info_span!("http.request", otel.kind = "server")
+            };
+
+            let mut response = {
+                let _guard = span.enter();
+                next.run(req).await
+            };
+
+            // Echo traceparent back in response
+            if let Some(tp) = incoming_traceparent {
+                if let Ok(val) = HeaderValue::from_str(&tp.to_header_value()) {
+                    response.headers_mut().insert(TRACEPARENT_HEADER, val);
+                }
+            }
+
+            response
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Traceparent parsing tests ---
+
+    #[test]
+    fn test_parse_valid_traceparent() {
+        let tp =
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").unwrap();
+        assert_eq!(tp.version, 0);
+        assert_eq!(tp.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(tp.parent_id, "00f067aa0ba902b7");
+        assert_eq!(tp.trace_flags, 1);
+    }
+
+    #[test]
+    fn test_parse_unsampled_traceparent() {
+        let tp =
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00").unwrap();
+        assert_eq!(tp.trace_flags, 0);
+    }
+
+    #[test]
+    fn test_parse_invalid_too_few_parts() {
+        assert!(Traceparent::parse("00-abc-01").is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_too_many_parts() {
+        assert!(Traceparent::parse("00-a-b-c-d-e").is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_trace_id_length() {
+        assert!(
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0e473-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_parent_id_length() {
+        assert!(
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_all_zero_trace_id_invalid() {
+        assert!(
+            Traceparent::parse("00-00000000000000000000000000000000-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_all_zero_parent_id_invalid() {
+        assert!(
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_non_hex_trace_id() {
+        assert!(
+            Traceparent::parse("00-4bf92f3577b34da6a3ce929d0e0eXXXX-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_non_hex_version() {
+        assert!(
+            Traceparent::parse("zz-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01").is_none()
+        );
+    }
+
+    #[test]
+    fn test_to_header_value_roundtrip() {
+        let original = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let tp = Traceparent::parse(original).unwrap();
+        assert_eq!(tp.to_header_value(), original);
+    }
+
+    #[test]
+    fn test_to_header_value_preserves_flags() {
+        let tp = Traceparent {
+            version: 0,
+            trace_id: "4bf92f3577b34da6a3ce929d0e0e4736".into(),
+            parent_id: "00f067aa0ba902b7".into(),
+            trace_flags: 0,
+        };
+        assert_eq!(
+            tp.to_header_value(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+        );
+    }
+
+    // --- Middleware construction tests ---
+
+    #[test]
+    fn test_traceparent_middleware_new() {
+        let _mw = TraceparentMiddleware::new();
+    }
+
+    #[test]
+    fn test_traceparent_middleware_default() {
+        let _mw: TraceparentMiddleware = Default::default();
+    }
+}

--- a/rapina/src/observability/mod.rs
+++ b/rapina/src/observability/mod.rs
@@ -1,7 +1,16 @@
 //! Observability utilities for Rapina applications.
 //!
 //! This module provides tools for logging, tracing, and monitoring.
+//!
+//! - [`TracingConfig`] — stdout/JSON logging via `tracing-subscriber`
+//! - [`TelemetryConfig`] — OTLP trace export to Jaeger, Datadog, etc. (requires `telemetry` feature)
 
 mod tracing;
 
+#[cfg(feature = "telemetry")]
+mod telemetry;
+
 pub use self::tracing::TracingConfig;
+
+#[cfg(feature = "telemetry")]
+pub use self::telemetry::{OtlpProtocol, SamplerConfig, TelemetryConfig};

--- a/rapina/src/observability/telemetry.rs
+++ b/rapina/src/observability/telemetry.rs
@@ -1,0 +1,260 @@
+//! OpenTelemetry OTLP export configuration.
+
+/// The transport protocol for OTLP export.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OtlpProtocol {
+    /// gRPC transport (typically port 4317).
+    Grpc,
+    /// HTTP/protobuf transport (typically port 4318).
+    HttpProto,
+}
+
+/// Controls how traces are sampled before export.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SamplerConfig {
+    /// Export every trace.
+    AlwaysOn,
+    /// Export no traces.
+    AlwaysOff,
+    /// Export a fraction of traces based on trace ID.
+    /// Value must be between 0.0 and 1.0.
+    TraceIdRatio(f64),
+}
+
+/// Configuration for OpenTelemetry OTLP trace export.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rapina::prelude::*;
+///
+/// Rapina::new()
+///     .with_telemetry(TelemetryConfig {
+///         endpoint: "http://jaeger:4317".into(),
+///         service_name: "my-api".into(),
+///         sample_rate: 1.0,
+///     })
+/// ```
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    /// The OTLP collector endpoint (e.g. "http://jaeger:4317").
+    pub endpoint: String,
+    /// The service name reported in traces.
+    pub service_name: String,
+    /// Sample rate between 0.0 and 1.0. Convenience field that maps to
+    /// `SamplerConfig::TraceIdRatio`. Defaults to 1.0 (export all).
+    pub sample_rate: f64,
+    /// The transport protocol. Defaults to `Grpc`.
+    pub(crate) protocol: OtlpProtocol,
+    /// Override sampler config. When set, takes precedence over `sample_rate`.
+    pub(crate) sampler: Option<SamplerConfig>,
+}
+
+impl TelemetryConfig {
+    /// Creates a new telemetry config with the given endpoint and service name.
+    pub fn new(endpoint: impl Into<String>, service_name: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            service_name: service_name.into(),
+            sample_rate: 1.0,
+            protocol: OtlpProtocol::Grpc,
+            sampler: None,
+        }
+    }
+
+    /// Sets the sample rate (0.0 to 1.0).
+    pub fn sample_rate(mut self, rate: f64) -> Self {
+        self.sample_rate = rate;
+        self
+    }
+
+    /// Uses HTTP/protobuf protocol instead of gRPC.
+    pub fn http(mut self) -> Self {
+        self.protocol = OtlpProtocol::HttpProto;
+        self
+    }
+
+    /// Uses gRPC protocol (default).
+    pub fn grpc(mut self) -> Self {
+        self.protocol = OtlpProtocol::Grpc;
+        self
+    }
+
+    /// Sets an explicit sampler, overriding `sample_rate`.
+    pub fn sampler(mut self, sampler: SamplerConfig) -> Self {
+        self.sampler = Some(sampler);
+        self
+    }
+
+    /// Returns the effective sampler configuration.
+    pub(crate) fn effective_sampler(&self) -> SamplerConfig {
+        if let Some(ref s) = self.sampler {
+            return s.clone();
+        }
+        if self.sample_rate >= 1.0 {
+            SamplerConfig::AlwaysOn
+        } else if self.sample_rate <= 0.0 {
+            SamplerConfig::AlwaysOff
+        } else {
+            SamplerConfig::TraceIdRatio(self.sample_rate)
+        }
+    }
+
+    /// Initializes the OpenTelemetry tracing pipeline and installs it as the
+    /// global subscriber.
+    ///
+    /// Returns a `TracerProvider` handle that must be shut down on exit to
+    /// flush pending spans. Use `Rapina::with_telemetry()` which handles
+    /// this automatically via a shutdown hook.
+    pub fn init(self) -> opentelemetry_sdk::trace::SdkTracerProvider {
+        use opentelemetry::trace::TracerProvider;
+        use opentelemetry_otlp::WithExportConfig;
+        use opentelemetry_sdk::Resource;
+        use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+        use tracing_subscriber::EnvFilter;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        let sampler = match self.effective_sampler() {
+            SamplerConfig::AlwaysOn => Sampler::AlwaysOn,
+            SamplerConfig::AlwaysOff => Sampler::AlwaysOff,
+            SamplerConfig::TraceIdRatio(r) => Sampler::TraceIdRatioBased(r),
+        };
+
+        let resource = Resource::builder()
+            .with_attribute(opentelemetry::KeyValue::new(
+                "service.name",
+                self.service_name.clone(),
+            ))
+            .build();
+
+        let exporter = match self.protocol {
+            OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(&self.endpoint)
+                .build()
+                .expect("failed to create gRPC OTLP exporter"),
+            OtlpProtocol::HttpProto => opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(&self.endpoint)
+                .build()
+                .expect("failed to create HTTP OTLP exporter"),
+        };
+
+        let provider = SdkTracerProvider::builder()
+            .with_sampler(sampler)
+            .with_resource(resource)
+            .with_batch_exporter(exporter)
+            .build();
+
+        let tracer = provider.tracer(self.service_name);
+        let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(otel_layer)
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+
+        provider
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_telemetry_config_new() {
+        let config = TelemetryConfig::new("http://localhost:4317", "test-svc");
+        assert_eq!(config.endpoint, "http://localhost:4317");
+        assert_eq!(config.service_name, "test-svc");
+        assert_eq!(config.sample_rate, 1.0);
+        assert_eq!(config.protocol, OtlpProtocol::Grpc);
+        assert!(config.sampler.is_none());
+    }
+
+    #[test]
+    fn test_telemetry_config_struct_literal() {
+        let config = TelemetryConfig {
+            endpoint: "http://jaeger:4317".into(),
+            service_name: "my-api".into(),
+            sample_rate: 0.5,
+            ..TelemetryConfig::new("", "")
+        };
+        assert_eq!(config.endpoint, "http://jaeger:4317");
+        assert_eq!(config.sample_rate, 0.5);
+    }
+
+    #[test]
+    fn test_telemetry_config_http_protocol() {
+        let config = TelemetryConfig::new("http://localhost:4318", "svc").http();
+        assert_eq!(config.protocol, OtlpProtocol::HttpProto);
+    }
+
+    #[test]
+    fn test_telemetry_config_grpc_protocol() {
+        let config = TelemetryConfig::new("http://localhost:4317", "svc")
+            .http()
+            .grpc();
+        assert_eq!(config.protocol, OtlpProtocol::Grpc);
+    }
+
+    #[test]
+    fn test_telemetry_config_sample_rate() {
+        let config = TelemetryConfig::new("http://localhost:4317", "svc").sample_rate(0.25);
+        assert_eq!(config.sample_rate, 0.25);
+    }
+
+    #[test]
+    fn test_effective_sampler_always_on() {
+        let config = TelemetryConfig::new("ep", "svc").sample_rate(1.0);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOn);
+    }
+
+    #[test]
+    fn test_effective_sampler_always_on_above_one() {
+        let config = TelemetryConfig::new("ep", "svc").sample_rate(1.5);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOn);
+    }
+
+    #[test]
+    fn test_effective_sampler_always_off() {
+        let config = TelemetryConfig::new("ep", "svc").sample_rate(0.0);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOff);
+    }
+
+    #[test]
+    fn test_effective_sampler_always_off_negative() {
+        let config = TelemetryConfig::new("ep", "svc").sample_rate(-0.1);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOff);
+    }
+
+    #[test]
+    fn test_effective_sampler_ratio() {
+        let config = TelemetryConfig::new("ep", "svc").sample_rate(0.5);
+        assert_eq!(config.effective_sampler(), SamplerConfig::TraceIdRatio(0.5));
+    }
+
+    #[test]
+    fn test_explicit_sampler_overrides_rate() {
+        let config = TelemetryConfig::new("ep", "svc")
+            .sample_rate(0.5)
+            .sampler(SamplerConfig::AlwaysOn);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOn);
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let config = TelemetryConfig::new("http://collector:4317", "my-api")
+            .sample_rate(0.75)
+            .http()
+            .sampler(SamplerConfig::AlwaysOff);
+        assert_eq!(config.endpoint, "http://collector:4317");
+        assert_eq!(config.service_name, "my-api");
+        assert_eq!(config.protocol, OtlpProtocol::HttpProto);
+        assert_eq!(config.effective_sampler(), SamplerConfig::AlwaysOff);
+    }
+}

--- a/rapina/tests/middleware.rs
+++ b/rapina/tests/middleware.rs
@@ -546,3 +546,115 @@ async fn test_trace_id_middleware_preserves_incoming_trace_id() {
     let header_value = response.headers().get(TRACE_ID_HEADER).unwrap();
     assert_eq!(header_value.to_str().unwrap(), custom_trace_id);
 }
+
+#[cfg(feature = "telemetry")]
+mod traceparent_tests {
+    use rapina::middleware::TraceparentMiddleware;
+    use rapina::prelude::*;
+    use rapina::testing::TestClient;
+
+    #[get("/tp-ping")]
+    async fn ping() -> &'static str {
+        "pong"
+    }
+
+    #[tokio::test]
+    async fn test_traceparent_echoed_in_response() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .middleware(TraceparentMiddleware::new())
+            .router(Router::new().get("/tp-ping", ping));
+
+        let client = TestClient::new(app).await;
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let response = client
+            .get("/tp-ping")
+            .header("traceparent", traceparent)
+            .send()
+            .await;
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response
+                .headers()
+                .get("traceparent")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            traceparent
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_traceparent_header_when_not_provided() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .middleware(TraceparentMiddleware::new())
+            .router(Router::new().get("/tp-ping", ping));
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/tp-ping").send().await;
+
+        assert_eq!(response.status(), 200);
+        assert!(response.headers().get("traceparent").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_traceparent_ignored() {
+        let app = Rapina::new()
+            .with_introspection(false)
+            .middleware(TraceparentMiddleware::new())
+            .router(Router::new().get("/tp-ping", ping));
+
+        let client = TestClient::new(app).await;
+        let response = client
+            .get("/tp-ping")
+            .header("traceparent", "invalid-header-value")
+            .send()
+            .await;
+
+        assert_eq!(response.status(), 200);
+        assert!(response.headers().get("traceparent").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_traceparent_coexists_with_trace_id() {
+        use rapina::middleware::TraceIdMiddleware;
+
+        let app = Rapina::new()
+            .with_introspection(false)
+            .middleware(TraceIdMiddleware::new())
+            .middleware(TraceparentMiddleware::new())
+            .router(Router::new().get("/tp-ping", ping));
+
+        let client = TestClient::new(app).await;
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let response = client
+            .get("/tp-ping")
+            .header("traceparent", traceparent)
+            .header("x-trace-id", "custom-id-123")
+            .send()
+            .await;
+
+        assert_eq!(response.status(), 200);
+        // Both headers should be present
+        assert_eq!(
+            response
+                .headers()
+                .get("traceparent")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            traceparent
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-trace-id")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "custom-id-123"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add TelemetryConfig for OpenTelemetry OTLP trace export behind a `telemetry` feature flag. Supports gRPC and HTTP/protobuf transports, configurable sampling (AlwaysOn/AlwaysOff/TraceIdRatio), and automatic shutdown flush via a registered hook.

Add TraceparentMiddleware for W3C traceparent header propagation, coexisting with the existing x-trace-id middleware.

## Related Issues

Closes #93

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
