### PR TITLE
feat: generate BelongsTo/HasMany relationship fields from foreign keys during import

### DIFF
--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -124,6 +124,14 @@ cargo install rapina-cli --features import-sqlite
 
 For each valid table, the command generates the same files as `rapina add resource`: a feature module (`src/<plural>/`), a `schema!` block in `src/entity.rs`, and a timestamped migration.
 
+### Foreign key relationships
+
+When multiple tables are imported together, foreign keys are automatically converted into relationship fields. A FK column like `user_id` referencing the `users` table becomes a `BelongsTo` field (`author: User`), and the referenced table gets a `HasMany` field (`posts: Vec<Post>`). Nullable FK columns produce optional relationships (`author: Option<User>`). All imported tables are placed in a single `schema!` block so the macro can resolve relationships between them.
+
+This only applies when both sides of the FK are being imported. Single-column FKs are supported; composite FKs are skipped. SQLite imports do not detect foreign keys due to library limitations.
+
+### Skipped tables
+
 Tables are skipped if they have no primary key, a composite primary key, or are internal migration tables (`seaql_migrations`, `sqlx_migrations`, `__diesel_schema_migrations`).
 
 ### Re-importing with `--force`

--- a/rapina-cli/src/commands/codegen.rs
+++ b/rapina-cli/src/commands/codegen.rs
@@ -10,6 +10,27 @@ pub(crate) struct FieldInfo {
     pub nullable: bool,
 }
 
+pub(crate) struct RelationFieldInfo {
+    pub name: String,
+    /// e.g., "User", "Post"
+    pub target_entity: String,
+    pub kind: RelationFieldKind,
+}
+
+pub(crate) enum RelationFieldKind {
+    BelongsTo,
+    OptionalBelongsTo,
+    HasMany,
+}
+
+pub(crate) struct EntityBlock {
+    pub pascal_name: String,
+    pub fields: Vec<FieldInfo>,
+    pub relations: Vec<RelationFieldInfo>,
+    pub timestamps: Option<String>,
+    pub primary_key: Option<Vec<String>>,
+}
+
 pub(crate) fn to_pascal_case(s: &str) -> String {
     s.split('_')
         .map(|part| {
@@ -448,6 +469,98 @@ schema! {{
         attrs = attrs,
         fields = schema_fields.join("\n"),
     )
+}
+
+pub(crate) fn generate_combined_schema_block(entities: &[EntityBlock]) -> String {
+    let mut entity_sections = Vec::new();
+
+    for entity in entities {
+        let mut attrs = String::new();
+
+        if let Some(ref pk_cols) = entity.primary_key {
+            attrs.push_str(&format!("\n    #[primary_key({})]", pk_cols.join(", ")));
+        }
+
+        if let Some(ref ts) = entity.timestamps {
+            attrs.push_str(&format!("\n    #[timestamps({})]", ts));
+        }
+
+        // Scalar fields
+        let mut field_lines: Vec<String> = entity
+            .fields
+            .iter()
+            .map(|f| format!("        {}: {},", f.name, f.schema_type))
+            .collect();
+
+        // Relationship fields
+        for rel in &entity.relations {
+            let line = match rel.kind {
+                RelationFieldKind::BelongsTo => {
+                    format!("        {}: {},", rel.name, rel.target_entity)
+                }
+                RelationFieldKind::OptionalBelongsTo => {
+                    format!("        {}: Option<{}>,", rel.name, rel.target_entity)
+                }
+                RelationFieldKind::HasMany => {
+                    format!("        {}: Vec<{}>,", rel.name, rel.target_entity)
+                }
+            };
+            field_lines.push(line);
+        }
+
+        entity_sections.push(format!(
+            "{attrs}    {pascal} {{\n{fields}\n    }}",
+            attrs = attrs,
+            pascal = entity.pascal_name,
+            fields = field_lines.join("\n"),
+        ));
+    }
+
+    format!("\nschema! {{\n{}\n}}\n", entity_sections.join("\n\n"))
+}
+
+pub(crate) fn write_combined_entity_file(
+    entities: &[EntityBlock],
+    force: bool,
+) -> Result<(), String> {
+    write_combined_entity_file_in(entities, force, Path::new("src/entity.rs"))
+}
+
+fn write_combined_entity_file_in(
+    entities: &[EntityBlock],
+    force: bool,
+    entity_path: &Path,
+) -> Result<(), String> {
+    let schema_block = generate_combined_schema_block(entities);
+
+    if entity_path.exists() {
+        let mut content = fs::read_to_string(entity_path)
+            .map_err(|e| format!("Failed to read entity.rs: {}", e))?;
+
+        if force {
+            for entity in entities {
+                content = remove_schema_block(&content, &entity.pascal_name);
+            }
+        }
+
+        let needs_import =
+            !content.contains("use rapina::prelude::*") && !content.contains("use rapina::schema");
+        let prefix = if needs_import {
+            "use rapina::schema;\n"
+        } else {
+            ""
+        };
+
+        let updated = format!("{}{}{}", prefix, content.trim_end(), schema_block);
+        fs::write(entity_path, updated).map_err(|e| format!("Failed to write entity.rs: {}", e))?;
+    } else {
+        let content = format!("use rapina::prelude::*;\n{}", schema_block);
+        fs::write(entity_path, content)
+            .map_err(|e| format!("Failed to create entity.rs: {}", e))?;
+    }
+
+    println!("  {} Updated {}", "✓".green(), "src/entity.rs".cyan());
+    Ok(())
 }
 
 pub(crate) fn generate_migration(
@@ -1371,5 +1484,161 @@ schema! {
         let result = remove_schema_block(content, "UsersRole");
         assert!(!result.contains("UsersRole"));
         assert!(!result.contains("schema!"));
+    }
+
+    #[test]
+    fn test_generate_combined_schema_block_with_relationships() {
+        let entities = vec![
+            EntityBlock {
+                pascal_name: "User".to_string(),
+                fields: vec![FieldInfo {
+                    name: "email".to_string(),
+                    rust_type: "String".to_string(),
+                    schema_type: "String".to_string(),
+                    column_method: String::new(),
+                    nullable: false,
+                }],
+                relations: vec![RelationFieldInfo {
+                    name: "posts".to_string(),
+                    target_entity: "Post".to_string(),
+                    kind: RelationFieldKind::HasMany,
+                }],
+                timestamps: None,
+                primary_key: None,
+            },
+            EntityBlock {
+                pascal_name: "Post".to_string(),
+                fields: vec![FieldInfo {
+                    name: "title".to_string(),
+                    rust_type: "String".to_string(),
+                    schema_type: "String".to_string(),
+                    column_method: String::new(),
+                    nullable: false,
+                }],
+                relations: vec![RelationFieldInfo {
+                    name: "author".to_string(),
+                    target_entity: "User".to_string(),
+                    kind: RelationFieldKind::BelongsTo,
+                }],
+                timestamps: None,
+                primary_key: None,
+            },
+        ];
+
+        let block = generate_combined_schema_block(&entities);
+        assert!(block.contains("schema! {"));
+        assert!(block.contains("User {"));
+        assert!(block.contains("email: String,"));
+        assert!(block.contains("posts: Vec<Post>,"));
+        assert!(block.contains("Post {"));
+        assert!(block.contains("title: String,"));
+        assert!(block.contains("author: User,"));
+        // Only one schema! block
+        assert_eq!(block.matches("schema! {").count(), 1);
+    }
+
+    #[test]
+    fn test_generate_combined_schema_block_optional_belongs_to() {
+        let entities = vec![EntityBlock {
+            pascal_name: "Comment".to_string(),
+            fields: vec![FieldInfo {
+                name: "body".to_string(),
+                rust_type: "String".to_string(),
+                schema_type: "Text".to_string(),
+                column_method: String::new(),
+                nullable: false,
+            }],
+            relations: vec![RelationFieldInfo {
+                name: "author".to_string(),
+                target_entity: "User".to_string(),
+                kind: RelationFieldKind::OptionalBelongsTo,
+            }],
+            timestamps: None,
+            primary_key: None,
+        }];
+
+        let block = generate_combined_schema_block(&entities);
+        assert!(block.contains("author: Option<User>,"));
+    }
+
+    #[test]
+    fn test_generate_combined_schema_block_no_relations() {
+        let entities = vec![EntityBlock {
+            pascal_name: "Setting".to_string(),
+            fields: vec![FieldInfo {
+                name: "key".to_string(),
+                rust_type: "String".to_string(),
+                schema_type: "String".to_string(),
+                column_method: String::new(),
+                nullable: false,
+            }],
+            relations: vec![],
+            timestamps: Some("none".to_string()),
+            primary_key: None,
+        }];
+
+        let block = generate_combined_schema_block(&entities);
+        assert!(block.contains("Setting {"));
+        assert!(block.contains("key: String,"));
+        assert!(block.contains("#[timestamps(none)]"));
+        assert!(!block.contains("Vec<"));
+        assert!(!block.contains("Option<"));
+    }
+
+    #[test]
+    fn test_write_combined_entity_file_creates_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let entity_path = dir.path().join("entity.rs");
+
+        let entities = vec![EntityBlock {
+            pascal_name: "User".to_string(),
+            fields: vec![FieldInfo {
+                name: "email".to_string(),
+                rust_type: "String".to_string(),
+                schema_type: "String".to_string(),
+                column_method: String::new(),
+                nullable: false,
+            }],
+            relations: vec![],
+            timestamps: None,
+            primary_key: None,
+        }];
+
+        write_combined_entity_file_in(&entities, false, &entity_path).unwrap();
+        let content = fs::read_to_string(&entity_path).unwrap();
+        assert!(content.contains("use rapina::prelude::*;"));
+        assert!(content.contains("schema! {"));
+        assert!(content.contains("User {"));
+    }
+
+    #[test]
+    fn test_write_combined_entity_file_force_replaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let entity_path = dir.path().join("entity.rs");
+        fs::write(
+            &entity_path,
+            "use rapina::prelude::*;\n\nschema! {\n    User {\n        name: String,\n    }\n}\n",
+        )
+        .unwrap();
+
+        let entities = vec![EntityBlock {
+            pascal_name: "User".to_string(),
+            fields: vec![FieldInfo {
+                name: "email".to_string(),
+                rust_type: "String".to_string(),
+                schema_type: "String".to_string(),
+                column_method: String::new(),
+                nullable: false,
+            }],
+            relations: vec![],
+            timestamps: None,
+            primary_key: None,
+        }];
+
+        write_combined_entity_file_in(&entities, true, &entity_path).unwrap();
+        let content = fs::read_to_string(&entity_path).unwrap();
+        assert_eq!(content.matches("User {").count(), 1);
+        assert!(content.contains("email: String,"));
+        assert!(!content.contains("name: String,"));
     }
 }

--- a/rapina-cli/src/commands/import.rs
+++ b/rapina-cli/src/commands/import.rs
@@ -493,21 +493,10 @@ fn detect_timestamps(table: &IntrospectedTable) -> Option<&'static str> {
 // Per-table generation
 // ---------------------------------------------------------------------------
 
-fn generate_for_table(
-    table: &IntrospectedTable,
-    _relationships: &HashMap<String, Vec<RelationshipInfo>>,
-    force: bool,
-) -> Result<(), String> {
-    let singular = codegen::singularize(&table.name);
-    let plural = &table.name;
-    let pascal = codegen::to_pascal_case(&singular);
-    let pascal_plural = codegen::to_pascal_case(plural);
-
+/// Build all scalar fields for a table (including FK columns), for use by
+/// migration and feature-module generation which need the raw database columns.
+fn build_all_scalar_fields(table: &IntrospectedTable) -> (Vec<codegen::FieldInfo>, usize) {
     let is_composite_pk = table.primary_key_columns.len() > 1;
-
-    // For composite PK, skip only timestamps. PK columns become regular fields.
-    // For single PK, skip id if it's i32 (default) and timestamps.
-    // If single PK is NOT i32 (e.g. Uuid), don't skip it, so it can be marked as PK in codegen.
     let is_default_pk = !is_composite_pk
         && table
             .columns
@@ -527,7 +516,6 @@ fn generate_for_table(
         if skip_columns.contains(&col.name.as_str()) {
             continue;
         }
-
         match normalized_to_field_info(&col.name, &col.col_type, col.is_nullable) {
             Some(fi) => fields.push(fi),
             None => {
@@ -545,40 +533,123 @@ fn generate_for_table(
         }
     }
 
-    let timestamps = detect_timestamps(table);
+    (fields, skipped)
+}
 
-    let primary_key = if is_composite_pk {
-        Some(table.primary_key_columns.clone())
-    } else if !is_default_pk {
-        // Special case: single PK that is NOT the default i32 "id"
+/// Build an EntityBlock for use in the combined schema! block, replacing FK
+/// columns with BelongsTo fields and appending HasMany fields.
+fn build_entity_block(
+    table: &IntrospectedTable,
+    relationships: &HashMap<String, Vec<RelationshipInfo>>,
+) -> Result<codegen::EntityBlock, String> {
+    let singular = codegen::singularize(&table.name);
+    let pascal = codegen::to_pascal_case(&singular);
+
+    let is_composite_pk = table.primary_key_columns.len() > 1;
+    let is_default_pk = !is_composite_pk
+        && table
+            .columns
+            .iter()
+            .any(|c| c.name == "id" && c.col_type == NormalizedType::I32);
+
+    let skip_columns: Vec<&str> = if is_composite_pk || !is_default_pk {
+        vec!["created_at", "updated_at"]
+    } else {
+        vec!["id", "created_at", "updated_at"]
+    };
+
+    // Collect FK column names so we can skip them as scalar fields
+    let fk_columns: std::collections::HashSet<String> = relationships
+        .get(&table.name)
+        .map(|rels| {
+            rels.iter()
+                .filter(|r| matches!(r.kind, RelationKind::BelongsTo))
+                .map(|r| format!("{}_id", r.field_name))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut fields = Vec::new();
+    let mut skipped = 0;
+
+    for col in &table.columns {
+        if skip_columns.contains(&col.name.as_str()) {
+            continue;
+        }
+        // Skip FK columns — they'll be replaced by BelongsTo fields
+        if fk_columns.contains(&col.name) {
+            continue;
+        }
+        match normalized_to_field_info(&col.name, &col.col_type, col.is_nullable) {
+            Some(fi) => fields.push(fi),
+            None => {
+                if let NormalizedType::Unmappable(ref type_name) = col.col_type {
+                    eprintln!(
+                        "    {} column {:?}.{:?} ({}) has no schema! equivalent -- skipped",
+                        "warn:".yellow(),
+                        table.name,
+                        col.name,
+                        type_name
+                    );
+                }
+                skipped += 1;
+            }
+        }
+    }
+
+    // Build relationship fields
+    let mut relations = Vec::new();
+    if let Some(rels) = relationships.get(&table.name) {
+        for rel in rels {
+            let kind = match &rel.kind {
+                RelationKind::BelongsTo => {
+                    let fk_col_name = format!("{}_id", rel.field_name);
+                    let is_nullable = table
+                        .columns
+                        .iter()
+                        .find(|c| c.name == fk_col_name)
+                        .map(|c| c.is_nullable)
+                        .unwrap_or(false);
+                    if is_nullable {
+                        codegen::RelationFieldKind::OptionalBelongsTo
+                    } else {
+                        codegen::RelationFieldKind::BelongsTo
+                    }
+                }
+                RelationKind::HasMany => codegen::RelationFieldKind::HasMany,
+            };
+            relations.push(codegen::RelationFieldInfo {
+                name: rel.field_name.clone(),
+                target_entity: rel.related_pascal.clone(),
+                kind,
+            });
+        }
+    }
+
+    let timestamps = detect_timestamps(table).map(|s| s.to_string());
+    let primary_key = if is_composite_pk || !is_default_pk {
         Some(table.primary_key_columns.clone())
     } else {
         None
     };
 
-    let pk_type = if let Some(pk_col) = table.columns.iter().find(|c| c.name == "id") {
-        match &pk_col.col_type {
-            NormalizedType::Uuid => "Uuid",
-            _ => "i32",
-        }
-    } else {
-        "i32"
-    };
-
-    codegen::update_entity_file(&pascal, &fields, timestamps, primary_key.as_deref(), force)?;
-    codegen::create_migration_file(plural, &pascal_plural, &fields, pk_type)?;
-    codegen::create_feature_module(&singular, plural, &pascal, &fields, pk_type, force)?;
-
     println!(
-        "  {} Imported table {:?} as {} ({} columns, {} skipped)",
+        "  {} Imported table {:?} as {} ({} columns, {} relations, {} skipped)",
         "✓".green(),
         table.name,
         pascal.bright_cyan(),
         fields.len(),
+        relations.len(),
         skipped
     );
 
-    Ok(())
+    Ok(codegen::EntityBlock {
+        pascal_name: pascal,
+        fields,
+        relations,
+        timestamps,
+        primary_key,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -667,14 +738,38 @@ pub fn database(
     }
 
     let relationships = resolve_relationships(&tables);
+    let mut entity_blocks = Vec::new();
     let mut imported = Vec::new();
 
     for table in &tables {
         let singular = codegen::singularize(&table.name);
+        let plural = &table.name;
         let pascal = codegen::to_pascal_case(&singular);
-        generate_for_table(table, &relationships, force)?;
+        let pascal_plural = codegen::to_pascal_case(plural);
+
+        let block = build_entity_block(table, &relationships)?;
+        entity_blocks.push(block);
+
+        // Migration and feature module still use all scalar fields (including FK columns)
+        let (all_fields, _) = build_all_scalar_fields(table);
+
+        let pk_type = if let Some(pk_col) = table.columns.iter().find(|c| c.name == "id") {
+            match &pk_col.col_type {
+                NormalizedType::Uuid => "Uuid",
+                _ => "i32",
+            }
+        } else {
+            "i32"
+        };
+
+        codegen::create_migration_file(plural, &pascal_plural, &all_fields, pk_type)?;
+        codegen::create_feature_module(&singular, plural, &pascal, &all_fields, pk_type, force)?;
+
         imported.push((table.name.clone(), pascal));
     }
+
+    // Write all entities into a single combined schema! block
+    codegen::write_combined_entity_file(&entity_blocks, force)?;
 
     // Auto-wire mod declarations into src/main.rs
     let plural_names: Vec<&str> = imported.iter().map(|(name, _)| name.as_str()).collect();
@@ -1037,6 +1132,158 @@ mod tests {
         assert_eq!(user_rels[0].field_name, "posts");
         assert_eq!(user_rels[0].related_pascal, "Post");
         assert!(matches!(user_rels[0].kind, RelationKind::HasMany));
+    }
+
+    #[test]
+    fn test_build_entity_block_replaces_fk_with_belongs_to() {
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: NormalizedType::I32,
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "posts".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "title".into(),
+                        col_type: NormalizedType::Str,
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "user_id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: false,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![IntrospectedForeignKey {
+                    columns: vec!["user_id".into()],
+                    referenced_table: "users".into(),
+                    referenced_columns: vec!["id".into()],
+                }],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+        let block = build_entity_block(&tables[1], &rels).unwrap();
+
+        // Should NOT have user_id as a scalar field
+        assert!(!block.fields.iter().any(|f| f.name == "user_id"));
+        // Should have title as a scalar field
+        assert!(block.fields.iter().any(|f| f.name == "title"));
+        // Should have a BelongsTo relation
+        assert_eq!(block.relations.len(), 1);
+        assert_eq!(block.relations[0].name, "user");
+        assert_eq!(block.relations[0].target_entity, "User");
+        assert!(matches!(
+            block.relations[0].kind,
+            codegen::RelationFieldKind::BelongsTo
+        ));
+    }
+
+    #[test]
+    fn test_build_entity_block_nullable_fk_becomes_optional() {
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: NormalizedType::I32,
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "posts".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "user_id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: true,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![IntrospectedForeignKey {
+                    columns: vec!["user_id".into()],
+                    referenced_table: "users".into(),
+                    referenced_columns: vec!["id".into()],
+                }],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+        let block = build_entity_block(&tables[1], &rels).unwrap();
+
+        assert!(matches!(
+            block.relations[0].kind,
+            codegen::RelationFieldKind::OptionalBelongsTo
+        ));
+    }
+
+    #[test]
+    fn test_build_entity_block_has_many_on_referenced_side() {
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: NormalizedType::I32,
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "posts".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "user_id".into(),
+                        col_type: NormalizedType::I32,
+                        is_nullable: false,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![IntrospectedForeignKey {
+                    columns: vec!["user_id".into()],
+                    referenced_table: "users".into(),
+                    referenced_columns: vec!["id".into()],
+                }],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+        let block = build_entity_block(&tables[0], &rels).unwrap();
+
+        // Users should have a HasMany relation to Post
+        assert_eq!(block.relations.len(), 1);
+        assert_eq!(block.relations[0].name, "posts");
+        assert_eq!(block.relations[0].target_entity, "Post");
+        assert!(matches!(
+            block.relations[0].kind,
+            codegen::RelationFieldKind::HasMany
+        ));
     }
 
     #[cfg(feature = "import-postgres")]


### PR DESCRIPTION
## Summary

The import command now converts FK columns into proper relationship fields in the schema! block when both sides of the FK are being imported. All imported tables are placed in a single combined schema! block.

- FK columns (e.g., user_id) replaced with BelongsTo fields (e.g., user: User)
- Nullable FKs become Option<Entity> (optional BelongsTo)
- Referenced tables get HasMany fields (e.g., posts: Vec<Post>)
- Migrations still use raw scalar columns as before

## Related Issues

Closes #244

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
