### PR TITLE
fix: correct routes URL in dev banner

### DIFF
--- a/rapina-cli/src/commands/dev.rs
+++ b/rapina-cli/src/commands/dev.rs
@@ -214,7 +214,7 @@ fn get_binary_name(parsed: toml::Value) -> Result<String, String> {
 /// Print the development server banner.
 fn print_banner(config: &DevConfig) {
     let url = format!("http://{}:{}", config.host, config.port);
-    let routes_url = format!("{}/.__rapina/routes", url);
+    let routes_url = format!("{}/__rapina/routes", url);
 
     // Box is 61 chars wide total, 59 chars inner content
     let b = "│".custom_color(colors::mauve());


### PR DESCRIPTION
Closes #410

## Summary
- fix the `rapina dev` banner so it prints the correct routes URL at `/__rapina/routes`

## Testing
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails on pre-existing dead_code warnings in `rapina-cli/src/commands/codegen.rs`, unrelated to this change)*
- manual QA: created a temporary app with `rapina new demo-app` and ran `rapina dev --no-reload`; the banner printed `http://127.0.0.1:3000/__rapina/routes`