### PR TITLE
fix: gate singularize and SINGULAR_US behind import features

### DIFF
--- a/rapina-cli/src/commands/codegen.rs
+++ b/rapina-cli/src/commands/codegen.rs
@@ -100,6 +100,7 @@ const UNCOUNTABLE: &[&str] = &[
     "shrimp",
 ];
 
+#[cfg(any(feature = "import", feature = "import-openapi"))]
 /// Words ending in -us where the singular should not have -s stripped,
 /// and the plural is formed by adding -es (e.g. status → statuses).
 const SINGULAR_US: &[&str] = &[
@@ -150,6 +151,7 @@ pub(crate) fn pluralize(s: &str) -> String {
     format!("{}s", s)
 }
 
+#[cfg(any(feature = "import", feature = "import-openapi"))]
 pub(crate) fn singularize(s: &str) -> String {
     if UNCOUNTABLE.contains(&s) {
         return s.to_string();
@@ -973,6 +975,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(any(feature = "import", feature = "import-openapi"))]
     fn test_singularize() {
         // Regular plurals (already working)
         assert_eq!(singularize("users"), "user");


### PR DESCRIPTION
## Summary

Fixes #419

When building without the `import` or `import-openapi` features, the compiler emits warnings:

```
warning: constant SINGULAR_US is never used
warning: function singularize is never used
```

Both `singularize` and `SINGULAR_US` are defined unconditionally in `codegen.rs`, but their only callers are in `import.rs` and `import_openapi.rs`, which are gated behind their respective features.

## Changes

Added `#[cfg(any(feature = "import", feature = "import-openapi"))]` to:
- `SINGULAR_US` constant
- `singularize` function
- `test_singularize` test

## Verification

- `cargo build` (no features) -- zero singularize/SINGULAR_US warnings
- `cargo build --features import-openapi` -- compiles cleanly
- `cargo fmt -- --check` -- passes
- `cargo clippy` -- passes
