### PR TITLE
fix: update rapina version in docs

### DIFF
--- a/docs/content/docs/core-concepts/caching.md
+++ b/docs/content/docs/core-concepts/caching.md
@@ -111,7 +111,7 @@ For multi-instance deployments where all instances need to share the same cache 
 
 ```toml
 [dependencies]
-rapina = { version = "0.7", features = ["cache-redis"] }
+rapina = { version = "0.10.0", features = ["cache-redis"] }
 ```
 
 ```rust

--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -13,7 +13,7 @@ Add the database feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.6.0", features = ["postgres"] }
+rapina = { version = "0.10.0", features = ["postgres"] }
 # or "mysql", "sqlite"
 ```
 

--- a/docs/content/docs/core-concepts/metrics.md
+++ b/docs/content/docs/core-concepts/metrics.md
@@ -13,7 +13,7 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.6.0", features = ["metrics"] }
+rapina = { version = "0.10.0", features = ["metrics"] }
 ```
 
 Enable the endpoint in your application:

--- a/docs/content/docs/core-concepts/migrations.md
+++ b/docs/content/docs/core-concepts/migrations.md
@@ -15,7 +15,7 @@ Your `Cargo.toml` needs the `database` feature and a database driver:
 
 ```toml
 [dependencies]
-rapina = { version = "0.8", features = ["sqlite"] }
+rapina = { version = "0.10.0", features = ["sqlite"] }
 ```
 
 Replace `sqlite` with `postgres` or `mysql` depending on your database. You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page if you haven't set that up yet.

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -115,7 +115,7 @@ If you prefer not to use the CLI, add Rapina to an existing project:
 
 ```toml
 [dependencies]
-rapina = "0.8"
+rapina = "0.10.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```


### PR DESCRIPTION
## Summary
Update the rapina version referenced in the Setup and Prerequisites sections of the documentation to reflect the latest release.

## Related Issues
Closes #421

## Checklist
- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)