### PR TITLE
feat: add Tower compatibility layer with bidirectional adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Tower compatibility layer**: `tower` feature flag with `TowerLayerMiddleware` (tower Layer → rapina Middleware adapter), `RapinaService` (rapina stack → tower Service adapter), and `.layer()` builder method
+- **NextService Clone support**: Tower layers requiring `Clone` on the inner service (e.g. tower-resilience, retry, circuit breaker) now work out of the box
+
 ## [0.10.0] - 2026-03-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,9 @@ dependencies = [
  "tokio",
  "tokio-cron-scheduler",
  "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -4141,6 +4144,26 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -389,6 +389,59 @@ impl Middleware for SecurityHeadersMiddleware {
 
 ---
 
+## Tower Compatibility
+
+Rapina can interop with the [Tower](https://docs.rs/tower) ecosystem via the `tower` feature flag. This lets you use battle-tested Tower layers (retry, circuit breakers, concurrency limits, etc.) as Rapina middleware.
+
+```toml
+rapina = { version = "0.11.0", features = ["tower"] }
+```
+
+### Using Tower layers as middleware
+
+Use `.layer()` to add any Tower `Layer` to the middleware stack:
+
+```rust
+use rapina::prelude::*;
+use tower::timeout::TimeoutLayer;
+use std::time::Duration;
+
+Rapina::new()
+    .layer(TimeoutLayer::new(Duration::from_secs(30)))
+    .discover()
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+Or wrap it explicitly with `TowerLayerMiddleware`:
+
+```rust
+use rapina::middleware::TowerLayerMiddleware;
+use tower::timeout::TimeoutLayer;
+use std::time::Duration;
+
+Rapina::new()
+    .middleware(TowerLayerMiddleware::new(TimeoutLayer::new(Duration::from_secs(30))))
+    .discover()
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+Tower layers that preserve the response body type (`Response<BoxBody>`) work directly. Errors from Tower services are logged and converted to `500 Internal Server Error` responses.
+
+### Rapina as a Tower Service
+
+`RapinaService` wraps Rapina's middleware + router stack as a `tower::Service`, useful for embedding Rapina in Tower-based infrastructure:
+
+```rust
+use rapina::middleware::RapinaService;
+
+let service = RapinaService::new(router, state, middlewares);
+// `service` implements tower::Service<Request<Incoming>>
+```
+
+---
+
 ## Middleware ordering
 
 Middleware executes in **FIFO order** — first registered, first to run on the request and last to run on the response.

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -89,6 +89,10 @@ prometheus = { version = '0.13', optional = true }
 # Redis cache backend (optional)
 redis = { version = "1.1", optional = true, features = ["tokio-comp"] }
 
+# Tower compatibility (optional)
+tower-service = { version = "0.3", optional = true }
+tower-layer = { version = "0.3", optional = true }
+
 # WebSocket (optional)
 hyper-tungstenite = { version = "0.19", optional = true }
 tokio-tungstenite = { version = "0.28", optional = true }
@@ -104,6 +108,7 @@ matchit = "0.9"
 nix = { version = "0.31", features = ["signal"] }
 serial_test = "3"
 tempfile = "3"
+tower = { version = "0.5", features = ["limit"] }
 
 [[bench]]
 name = "router"
@@ -132,6 +137,7 @@ sqlite = ["database", "sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]
 metrics = ["prometheus"]
 cache-redis = ["redis"]
 multipart = ["multer", "futures-util"]
+tower = ["tower-service", "tower-layer"]
 websocket = ["hyper-tungstenite", "tokio-tungstenite", "futures-util"]
 cron-scheduler = ["tokio-cron-scheduler", "tokio-util"]
 jwks = ["cron-scheduler", "hyper-rustls"]

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -190,6 +190,32 @@ impl Rapina {
         self
     }
 
+    /// Adds a tower layer as middleware.
+    ///
+    /// This is a convenience method equivalent to
+    /// `.middleware(TowerLayerMiddleware::new(layer))`.
+    ///
+    /// Requires the `tower` feature.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use rapina::prelude::*;
+    ///
+    /// Rapina::new()
+    ///     .layer(my_tower_layer)
+    ///     .listen("127.0.0.1:3000")
+    ///     .await
+    /// ```
+    #[cfg(feature = "tower")]
+    pub fn layer<L>(self, layer: L) -> Self
+    where
+        L: tower_layer::Layer<crate::middleware::NextService>,
+        crate::middleware::TowerLayerMiddleware<L>: Middleware,
+    {
+        self.middleware(crate::middleware::TowerLayerMiddleware::new(layer))
+    }
+
     /// Enables CORS for the application.
     ///
     /// Use `CorsConfig::permisive()` for development (it allows all origins),

--- a/rapina/src/error.rs
+++ b/rapina/src/error.rs
@@ -276,6 +276,11 @@ impl Error {
         Self::new(500, "INTERNAL_ERROR", message)
     }
 
+    /// Creates a 503 Service Unavailable error.
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::new(503, "SERVICE_UNAVAILABLE", message)
+    }
+
     /// Converts this error to a ProblemDetails response with the given trace ID and base URI.
     pub fn to_rfc7807_response(&self, trace_id: String, base_uri: &str) -> rfc7807::ProblemDetails {
         rfc7807::ProblemDetails {

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -152,6 +152,8 @@ pub mod prelude {
     #[cfg(feature = "rate-limit")]
     pub use crate::middleware::{KeyExtractor, RateLimitConfig};
     pub use crate::middleware::{Middleware, Next, RequestLogConfig};
+    #[cfg(feature = "tower")]
+    pub use crate::middleware::{RapinaService, TowerLayerMiddleware};
     pub use crate::observability::TracingConfig;
     #[cfg(feature = "database")]
     pub use crate::pagination::{Paginate, Paginated, PaginationConfig};

--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -18,6 +18,8 @@ mod cors;
 mod rate_limit;
 mod request_log;
 mod timeout;
+#[cfg(feature = "tower")]
+mod tower;
 mod trace_id;
 
 pub use body_limit::BodyLimitMiddleware;
@@ -28,6 +30,12 @@ pub use cors::{AllowedHeaders, AllowedMethods, AllowedOrigins, CorsConfig, CorsM
 pub use rate_limit::{KeyExtractor, RateLimitConfig, RateLimitMiddleware};
 pub use request_log::{RequestLogConfig, RequestLogMiddleware};
 pub use timeout::TimeoutMiddleware;
+#[cfg(feature = "tower")]
+pub use tower::{RapinaService, TowerLayerMiddleware};
+// NextService intentionally not re-exported — it is an implementation detail.
+// Users interact through .layer() and never need to name NextService directly.
+#[cfg(feature = "tower")]
+pub(crate) use tower::NextService;
 pub use trace_id::{TRACE_ID_HEADER, TraceIdMiddleware};
 
 use std::future::Future;
@@ -82,18 +90,19 @@ pub trait Middleware: Send + Sync + 'static {
 }
 
 /// Represents the next middleware or handler in the chain.
+#[derive(Clone)]
 pub struct Next<'a> {
     middlewares: &'a [Arc<dyn Middleware>],
-    router: &'a Router,
-    state: &'a Arc<AppState>,
+    router: Arc<Router>,
+    state: Arc<AppState>,
     ctx: &'a RequestContext,
 }
 
 impl<'a> Next<'a> {
     pub(crate) fn new(
         middlewares: &'a [Arc<dyn Middleware>],
-        router: &'a Router,
-        state: &'a Arc<AppState>,
+        router: Arc<Router>,
+        state: Arc<AppState>,
         ctx: &'a RequestContext,
     ) -> Self {
         Self {
@@ -109,13 +118,13 @@ impl<'a> Next<'a> {
         if let Some((current, rest)) = self.middlewares.split_first() {
             let next = Next {
                 middlewares: rest,
-                router: self.router,
-                state: self.state,
+                router: self.router.clone(),
+                state: self.state.clone(),
                 ctx: self.ctx,
             };
             current.handle(req, self.ctx, next).await
         } else {
-            self.router.handle(req, self.state).await
+            self.router.handle(req, &self.state).await
         }
     }
 }
@@ -140,11 +149,11 @@ impl MiddlewareStack {
         self.middlewares.push(middleware);
     }
 
-    pub async fn execute(
+    pub(crate) async fn execute(
         &self,
         req: Request<Incoming>,
-        router: &Router,
-        state: &Arc<AppState>,
+        router: Arc<Router>,
+        state: Arc<AppState>,
         ctx: &RequestContext,
     ) -> Response<BoxBody> {
         let config = state

--- a/rapina/src/middleware/tower.rs
+++ b/rapina/src/middleware/tower.rs
@@ -1,0 +1,324 @@
+//! Tower compatibility adapters for Rapina middleware.
+//!
+//! Provides two adapters for interop between Rapina's middleware system
+//! and the Tower ecosystem:
+//!
+//! - [`TowerLayerMiddleware`] wraps a `tower::Layer` for use as a Rapina
+//!   [`Middleware`](super::Middleware).
+//! - [`RapinaService`] wraps Rapina's middleware + router stack as a
+//!   `tower::Service`.
+
+use std::convert::Infallible;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
+use std::task::{Context, Poll};
+
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+use tower_layer::Layer;
+use tower_service::Service;
+
+use crate::context::RequestContext;
+use crate::middleware::{BoxFuture, Middleware, MiddlewareStack, Next};
+use crate::response::{BoxBody, IntoResponse};
+use crate::router::Router;
+use crate::state::AppState;
+
+// ─── Direction A: Tower Layer → Rapina Middleware ────────────────────────────
+
+/// A [`tower::Service`] that delegates to the Rapina middleware chain.
+///
+/// Owns all data needed to execute the chain, with no lifetime parameter.
+/// This makes it compatible with any Tower layer — including those requiring
+/// `Clone` (e.g. tower-resilience, retry, circuit breaker).
+#[derive(Clone)]
+pub struct NextService {
+    middlewares: Arc<[Arc<dyn Middleware>]>,
+    router: Arc<Router>,
+    state: Arc<AppState>,
+}
+
+impl Service<Request<Incoming>> for NextService {
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<BoxBody>, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<Incoming>) -> Self::Future {
+        let middlewares = self.middlewares.clone();
+        let router = self.router.clone();
+        let state = self.state.clone();
+
+        Box::pin(async move {
+            let ctx = req
+                .extensions()
+                .get::<RequestContext>()
+                .cloned()
+                .unwrap_or_default();
+            let next = Next::new(&middlewares, router, state, &ctx);
+            Ok(next.run(req).await)
+        })
+    }
+}
+
+/// Wraps a [`tower::Layer`] so it can be added to a Rapina middleware stack.
+///
+/// The tower service is built once on the first request and cached. Each
+/// subsequent request clones the cached service — since tower layers store
+/// shared state behind `Arc` internally, all requests share the same state.
+/// This means stateful layers like rate limiters, circuit breakers, and
+/// bulkheads work correctly across concurrent requests.
+///
+/// # Body type
+///
+/// Tower layers that preserve the response body type (`Response<BoxBody>`)
+/// work directly. Layers that change the body type (e.g. tower-http
+/// compression) are not compatible without an additional body adapter.
+///
+/// # Example
+///
+/// ```ignore
+/// use rapina::middleware::TowerLayerMiddleware;
+///
+/// // Any tower Layer that accepts NextService works:
+/// Rapina::new()
+///     .middleware(TowerLayerMiddleware::new(my_tower_layer))
+///     .listen("127.0.0.1:3000")
+///     .await
+/// ```
+pub struct TowerLayerMiddleware<L: Layer<NextService>> {
+    layer: L,
+    service: OnceLock<L::Service>,
+}
+
+impl<L: Layer<NextService>> TowerLayerMiddleware<L> {
+    pub fn new(layer: L) -> Self {
+        Self {
+            layer,
+            service: OnceLock::new(),
+        }
+    }
+}
+
+impl<L> fmt::Debug for TowerLayerMiddleware<L>
+where
+    L: Layer<NextService> + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TowerLayerMiddleware")
+            .field("layer", &self.layer)
+            .finish()
+    }
+}
+
+impl<L> Middleware for TowerLayerMiddleware<L>
+where
+    L: Layer<NextService> + Send + Sync + 'static,
+    <L as Layer<NextService>>::Service:
+        Service<Request<Incoming>, Response = Response<BoxBody>> + Clone + Send + Sync + 'static,
+    <<L as Layer<NextService>>::Service as Service<Request<Incoming>>>::Error:
+        fmt::Display + Send + 'static,
+    <<L as Layer<NextService>>::Service as Service<Request<Incoming>>>::Future: Send + 'static,
+{
+    fn handle<'a>(
+        &'a self,
+        mut req: Request<Incoming>,
+        ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        Box::pin(async move {
+            req.extensions_mut().insert(ctx.clone());
+            let template = self.service.get_or_init(|| {
+                let next_svc = NextService {
+                    middlewares: next.middlewares.iter().cloned().collect(),
+                    router: next.router.clone(),
+                    state: next.state.clone(),
+                };
+                self.layer.layer(next_svc)
+            });
+            let mut svc = template.clone();
+
+            if let Err(e) = std::future::poll_fn(|cx| svc.poll_ready(cx)).await {
+                tracing::error!("tower service not ready: {}", e);
+                return crate::error::Error::service_unavailable("service unavailable")
+                    .into_response();
+            }
+
+            match svc.call(req).await {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::error!("tower service error: {}", e);
+                    crate::error::Error::internal("internal server error").into_response()
+                }
+            }
+        })
+    }
+}
+
+// ─── Direction B: Rapina Stack → Tower Service ──────────────────────────────
+
+/// Wraps Rapina's middleware + router stack as a [`tower::Service`].
+///
+/// This allows embedding a fully-configured Rapina application inside
+/// tower-based infrastructure or using tower testing utilities.
+///
+/// The service is always ready (`poll_ready` returns `Poll::Ready(Ok(()))`)
+/// and never errors (`Error = Infallible`), matching Rapina's infallible
+/// response model.
+///
+/// # Example
+///
+/// ```ignore
+/// use rapina::middleware::RapinaService;
+///
+/// let service = RapinaService::new(router, state, middlewares);
+/// // `service` implements tower::Service<Request<Incoming>>
+/// ```
+#[derive(Clone)]
+pub struct RapinaService {
+    router: Arc<Router>,
+    state: Arc<AppState>,
+    middlewares: Arc<MiddlewareStack>,
+}
+
+impl RapinaService {
+    pub fn new(mut router: Router, state: AppState, middlewares: MiddlewareStack) -> Self {
+        router.freeze();
+        Self {
+            router: Arc::new(router),
+            state: Arc::new(state),
+            middlewares: Arc::new(middlewares),
+        }
+    }
+}
+
+impl Service<Request<Incoming>> for RapinaService {
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<BoxBody>, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, mut req: Request<Incoming>) -> Self::Future {
+        let router = self.router.clone();
+        let state = self.state.clone();
+        let middlewares = self.middlewares.clone();
+
+        Box::pin(async move {
+            let ctx = match req.extensions().get::<RequestContext>() {
+                Some(existing) => existing.clone(),
+                None => {
+                    let new_ctx = RequestContext::default();
+                    req.extensions_mut().insert(new_ctx.clone());
+                    new_ctx
+                }
+            };
+
+            let response = middlewares.execute(req, router, state, &ctx).await;
+            Ok(response)
+        })
+    }
+}
+
+impl fmt::Debug for RapinaService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RapinaService").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::MiddlewareStack;
+    use crate::router::Router;
+    use crate::state::AppState;
+
+    #[test]
+    fn test_rapina_service_is_clone() {
+        let svc = RapinaService::new(Router::new(), AppState::new(), MiddlewareStack::new());
+        let _clone = svc.clone();
+    }
+
+    #[test]
+    fn test_rapina_service_debug() {
+        let svc = RapinaService::new(Router::new(), AppState::new(), MiddlewareStack::new());
+        let debug = format!("{:?}", svc);
+        assert!(debug.contains("RapinaService"));
+    }
+
+    #[tokio::test]
+    async fn test_rapina_service_poll_ready() {
+        let mut svc = RapinaService::new(Router::new(), AppState::new(), MiddlewareStack::new());
+        let ready = std::future::poll_fn(|cx| svc.poll_ready(cx)).await;
+        assert!(ready.is_ok());
+    }
+
+    #[test]
+    fn test_tower_layer_middleware_debug() {
+        let mw = TowerLayerMiddleware::new(tower_layer::Identity::new());
+        let debug = format!("{:?}", mw);
+        assert!(debug.contains("TowerLayerMiddleware"));
+    }
+
+    #[tokio::test]
+    async fn test_identity_layer_passes_through() {
+        use crate::app::Rapina;
+        use crate::testing::TestClient;
+
+        let app = Rapina::new()
+            .with_introspection(false)
+            .middleware(TowerLayerMiddleware::new(tower_layer::Identity::new()))
+            .router(Router::new().route(http::Method::GET, "/", |_, _, _| async { "hello tower" }));
+
+        let client = TestClient::new(app).await;
+        let response = client.get("/").send().await;
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert_eq!(response.text(), "hello tower");
+    }
+
+    #[tokio::test]
+    async fn test_concurrency_limit_shared_state() {
+        use crate::app::Rapina;
+        use crate::testing::TestClient;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tower::limit::ConcurrencyLimitLayer;
+
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_c = max_concurrent.clone();
+        let cur = current.clone();
+
+        let app = Rapina::new()
+            .with_introspection(false)
+            .layer(ConcurrencyLimitLayer::new(1))
+            .router(
+                Router::new().route(http::Method::GET, "/slow", move |_, _, _| {
+                    let max_c = max_c.clone();
+                    let cur = cur.clone();
+                    async move {
+                        let c = cur.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_c.fetch_max(c, Ordering::SeqCst);
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        cur.fetch_sub(1, Ordering::SeqCst);
+                        "done"
+                    }
+                }),
+            );
+
+        let client = TestClient::new(app).await;
+
+        let (r1, r2) = tokio::join!(client.get("/slow").send(), client.get("/slow").send());
+
+        assert_eq!(r1.status(), http::StatusCode::OK);
+        assert_eq!(r2.status(), http::StatusCode::OK);
+        assert_eq!(max_concurrent.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rapina/src/server.rs
+++ b/rapina/src/server.rs
@@ -81,7 +81,7 @@ pub(crate) async fn serve(
                     req.extensions_mut().insert(ctx.clone());
 
                     async move {
-                        let mut response = middlewares.execute(req, &router, &state, &ctx).await;
+                        let mut response = middlewares.execute(req, router, state, &ctx).await;
                         response
                             .headers_mut()
                             .insert(http::header::DATE, date_cache.header_value());

--- a/rapina/src/testing/client.rs
+++ b/rapina/src/testing/client.rs
@@ -95,7 +95,7 @@ impl TestClient {
                                         req.extensions_mut().insert(ctx.clone());
 
                                         async move {
-                                            let response = middlewares.execute(req, &router, &state, &ctx).await;
+                                            let response = middlewares.execute(req, router, state, &ctx).await;
                                             Ok::<_, std::convert::Infallible>(response)
                                         }
                                     });

--- a/rapina/tests/middleware.rs
+++ b/rapina/tests/middleware.rs
@@ -3,6 +3,8 @@
 use http::StatusCode;
 #[cfg(feature = "compression")]
 use rapina::middleware::CompressionConfig;
+#[cfg(feature = "tower")]
+use rapina::middleware::TowerLayerMiddleware;
 use rapina::middleware::{
     BodyLimitMiddleware, CorsConfig, TRACE_ID_HEADER, TimeoutMiddleware, TraceIdMiddleware,
 };
@@ -556,4 +558,83 @@ async fn test_trace_id_middleware_preserves_incoming_trace_id() {
 
     let header_value = response.headers().get(TRACE_ID_HEADER).unwrap();
     assert_eq!(header_value.to_str().unwrap(), custom_trace_id);
+}
+
+#[cfg(feature = "tower")]
+#[tokio::test]
+async fn test_tower_layer_with_rapina_middleware() {
+    let app = Rapina::new()
+        .with_introspection(false)
+        .middleware(TraceIdMiddleware::new())
+        .middleware(TowerLayerMiddleware::new(tower_layer::Identity::new()))
+        .router(
+            Router::new().route(http::Method::GET, "/mixed", |_, _, _| async {
+                "tower + rapina"
+            }),
+        );
+
+    let client = TestClient::new(app).await;
+    let response = client.get("/mixed").send().await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.text(), "tower + rapina");
+    assert!(response.headers().get(TRACE_ID_HEADER).is_some());
+}
+
+#[cfg(feature = "tower")]
+#[tokio::test]
+async fn test_rapina_service_direct_construction() {
+    use rapina::middleware::{MiddlewareStack, RapinaService};
+    use tower_service::Service;
+
+    let router = Router::new().route(http::Method::GET, "/direct", |_, _, _| async {
+        "from service"
+    });
+    let state = rapina::state::AppState::new();
+    let middlewares = MiddlewareStack::new();
+
+    let mut svc = RapinaService::new(router, state, middlewares);
+
+    let _cloned = svc.clone();
+
+    let ready = std::future::poll_fn(|cx| svc.poll_ready(cx)).await;
+    assert!(ready.is_ok());
+}
+
+#[cfg(feature = "tower")]
+#[tokio::test]
+async fn test_tower_concurrency_limit_integration() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::limit::ConcurrencyLimitLayer;
+
+    let max_concurrent = Arc::new(AtomicUsize::new(0));
+    let current = Arc::new(AtomicUsize::new(0));
+    let max_c = max_concurrent.clone();
+    let cur = current.clone();
+
+    let app = Rapina::new()
+        .with_introspection(false)
+        .layer(ConcurrencyLimitLayer::new(1))
+        .router(
+            Router::new().route(http::Method::GET, "/slow", move |_, _, _| {
+                let max_c = max_c.clone();
+                let cur = cur.clone();
+                async move {
+                    let c = cur.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_c.fetch_max(c, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    cur.fetch_sub(1, Ordering::SeqCst);
+                    "done"
+                }
+            }),
+        );
+
+    let client = TestClient::new(app).await;
+
+    let (r1, r2) = tokio::join!(client.get("/slow").send(), client.get("/slow").send());
+
+    assert_eq!(r1.status(), StatusCode::OK);
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(max_concurrent.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Summary

Adds optional Tower ecosystem interop behind the `tower` feature flag:

- **`TowerLayerMiddleware<L>`** — wraps any `tower::Layer` for use as rapina `Middleware`. Supports layers requiring `Clone` on the inner service (retry, circuit breaker, tower-resilience, etc.) via owned `NextService` without lifetime parameters.
- **`RapinaService`** — wraps rapina's middleware + router stack as a `tower::Service<Request<Incoming>>`, enabling rapina apps to sit behind `ServiceBuilder` and tower combinators.
- **`.layer()`** builder method — convenience shorthand matching the axum/hyper/tonic convention.

### Design decisions

- `NextService` owns its data (`Vec<Arc<dyn Middleware>>`, `Arc<Router>`, `Arc<AppState>`) instead of borrowing with lifetimes. This avoids higher-ranked trait bounds (HRTB) and makes it compatible with any Tower layer.
- `Next<'a>` stores `Arc<Router>` and `Arc<AppState>` instead of references, so `NextService` can be constructed from `Next` without lifetime issues. The cost is an `Arc::clone` per middleware step (atomic increment, negligible).
- Errors from Tower services are logged via `tracing::error!` and converted to generic 500 responses — no internal details leak to clients.

### Tested with

| Crate | Layer | 
|-------|-------|
| `tower` 0.5 | `TimeoutLayer` |
| `tower-resilience` 0.9 | `TimeLimiterLayer`, `BulkheadLayer` |
| `tower-http` 0.6 | `SetResponseHeaderLayer` |

Plus custom hand-written Tower layers (`SecurityHeadersLayer`, `ResponseTimeLayer`).

### Feature gating

```toml
rapina = { version = "0.11.0", features = ["tower"] }
```

When disabled, zero impact — no deps pulled, no code compiled.

Closes #328

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --features tower` — 0 warnings
- [x] `cargo check --no-default-features` — OK
- [x] `cargo check --all-features` — OK
- [x] `cargo test --features tower` — 372+ tests pass, 0 failures
- [x] External project test with tower, tower-resilience, tower-http layers