### PR TITLE
docs: add v0.11.0 release notes

### DIFF
--- a/docs/content/blog/2026-04-01-rapina-0-11-0.md
+++ b/docs/content/blog/2026-04-01-rapina-0-11-0.md
@@ -1,0 +1,238 @@
++++
+title = "Rapina 0.11.0"
+description = "Background jobs, multipart uploads, environment variable config for the dev server, and OpenAPI improvements"
+date = 2026-04-01
+
+[taxonomies]
+categories = ["release-notes"]
+tags = ["release", "jobs", "multipart", "openapi", "cli"]
+
+[extra]
+author = "uemuradevexe"
++++
+
+Rapina 0.11.0 shipped on April 1, 2026. This release introduced a full background jobs system — from handler definition to enqueueing to CLI visibility — along with multipart file upload support, environment-based server configuration, and automatic OpenAPI `requestBody` generation.
+
+---
+
+## Background jobs
+
+The biggest addition in 0.11.0 was a complete background jobs system. Jobs were defined with a macro, enqueued through a typed extractor, and persisted to the database — all without reaching for a separate queue service.
+
+### `#[job]` macro
+
+The `#[job]` macro marked an async function as a background job handler. It accepted attributes for queue routing and retry configuration:
+
+```rust
+use rapina::prelude::*;
+
+#[derive(Serialize, Deserialize)]
+struct WelcomeEmailPayload {
+    user_id: i64,
+    email: String,
+}
+
+#[job(queue = "emails", max_retries = 5, retry_policy = "exponential", retry_delay_secs = 2)]
+async fn send_welcome_email(payload: WelcomeEmailPayload) -> JobResult {
+    // send the email
+    println!("Sending welcome email to {}", payload.email);
+    Ok(())
+}
+```
+
+The macro generated a helper function with the same name that returned a `JobRequest`. That value was passed to `Jobs::enqueue()`. Handlers could also receive dependency-injected `State<T>` and `Db` parameters alongside the payload.
+
+### `Jobs` extractor
+
+The `Jobs` extractor gave handlers a way to enqueue jobs from within a request:
+
+```rust
+use rapina::jobs::Jobs;
+
+#[post("/users")]
+async fn create_user(body: Json<CreateUserRequest>, db: Db, jobs: Jobs) -> Result<StatusCode> {
+    // Simple enqueue
+    jobs.enqueue(send_welcome_email(WelcomeEmailPayload {
+        user_id: 42,
+        email: body.email.clone(),
+    }))
+    .await?;
+
+    Ok(StatusCode::CREATED)
+}
+```
+
+For transactional enqueues — where the job and the database write needed to commit together — `enqueue_with()` accepted a connection or transaction:
+
+```rust
+let txn = db.conn().begin().await?;
+let user = User::insert(&txn, &body).await?;
+jobs.enqueue_with(&txn, send_welcome_email(WelcomeEmailPayload {
+    user_id: user.id,
+    email: user.email.clone(),
+}))
+.await?;
+txn.commit().await?;
+```
+
+### RetryPolicy
+
+`RetryPolicy` was an enum with three variants. `exponential` and `fixed` took the max retry count and a base delay:
+
+```rust
+use rapina::jobs::RetryPolicy;
+use std::time::Duration;
+
+// Up to 5 retries, 2-second base delay, doubles each attempt
+RetryPolicy::exponential(5, Duration::from_secs(2));
+
+// Up to 3 retries, fixed 10-second gap
+RetryPolicy::fixed(3, Duration::from_secs(10));
+
+// No retries
+RetryPolicy::none();
+```
+
+Exponential backoff added deterministic jitter per job ID to prevent thundering herd after outages. Delay was capped at one week. Jobs that exhausted all retries moved to `failed` and remained in the table.
+
+### Background jobs table and migration
+
+Job state was stored in a `rapina_jobs` table created by Rapina's built-in migration. Calling `.run_migrations()` at startup created the table if it did not exist:
+
+```
+rapina_jobs
+  id            uuid primary key  (gen_random_uuid())
+  queue         varchar(255)      default 'default'
+  job_type      varchar(255)
+  payload       jsonb             default {}
+  status        varchar(32)       default 'pending'  -- pending | running | completed | failed
+  attempts      integer           default 0
+  max_retries   integer           default 3
+  run_at        timestamptz       default now()
+  started_at    timestamptz
+  locked_until  timestamptz
+  finished_at   timestamptz
+  last_error    text
+  trace_id      varchar(64)
+  created_at    timestamptz       default now()
+```
+
+A partial index on `(queue, run_at) WHERE status = 'pending'` kept polling efficient. The jobs system required PostgreSQL — SQLite and MySQL were not supported.
+
+### `rapina jobs list`
+
+The CLI gained a `rapina jobs list` command for inspecting job queue status:
+
+```
+$ rapina jobs list
+
+  STATUS     COUNT
+  ─────────  ─────
+  pending    3
+  running    1
+  completed  142
+  failed     2
+```
+
+Passing `--failed` showed a detailed table of failed jobs with the last error and retry counts:
+
+```
+$ rapina jobs list --failed
+
+  ID            QUEUE    JOB TYPE              ATTEMPTS  LAST ERROR
+  ────────────  ───────  ────────────────────  ────────  ──────────────────────────
+  3fa85f64...  emails   send_welcome_email    3/3       connection refused
+  7c9e6679...  default  sync_user_data        3/3       timeout after 30s
+```
+
+---
+
+## Multipart file upload
+
+The `Multipart` extractor added support for file upload handling. Fields arrived as a stream consumed one at a time:
+
+```rust
+use rapina::extract::Multipart;
+
+#[post("/upload")]
+async fn upload_file(mut multipart: Multipart) -> Result<String> {
+    while let Some(field) = multipart.next_field().await? {
+        let name = field.name().unwrap_or("unknown").to_string();
+        let file_name = field.file_name().map(|s| s.to_string());
+
+        if let Some(file_name) = file_name {
+            let data = field.bytes().await?;
+            println!("File '{}': {} bytes", file_name, data.len());
+        } else {
+            let text = field.text().await?;
+            println!("Field '{}': {}", name, text);
+        }
+    }
+
+    Ok("ok".to_string())
+}
+```
+
+`Field` exposed `name()`, `file_name()`, `content_type()`, `bytes()`, `text()`, and a streaming `chunk()` method for large files. Forms that mixed file uploads with text fields were handled through the same API.
+
+---
+
+## RAPINA_HOST and RAPINA_PORT
+
+When both `RAPINA_HOST` and `RAPINA_PORT` were set, they overrode the address passed to `.listen()`:
+
+```bash
+RAPINA_HOST=0.0.0.0 RAPINA_PORT=8080 rapina dev
+```
+
+The override applied at the `listen()` call level, so it worked in any environment — not only during `rapina dev`. The `rapina dev` command also passed these variables when spawning the compiled binary, making it straightforward to bind to a non-default address during development without changing code.
+
+---
+
+## OpenAPI requestBody auto-generation
+
+Handlers that accepted a body extractor now had their `requestBody` populated in the generated OpenAPI spec automatically. The following extractors were supported:
+
+| Extractor | Content-Type | Required |
+|-----------|-------------|----------|
+| `Json<T>` | `application/json` | yes |
+| `Form<T>` | `application/x-www-form-urlencoded` | yes |
+| `Validated<Json<T>>` | `application/json` | yes |
+| `Validated<Form<T>>` | `application/x-www-form-urlencoded` | yes |
+| `Option<Json<T>>` | `application/json` | no |
+| `Option<Form<T>>` | `application/x-www-form-urlencoded` | no |
+
+Schemas were derived from the type's `JsonSchema` impl. No attributes were required for the common case:
+
+```rust
+#[derive(Deserialize, JsonSchema)]
+struct CreateTodo {
+    title: String,
+    done: bool,
+}
+
+#[post("/todos")]
+async fn create_todo(body: Json<CreateTodo>) -> Result<Json<Todo>> {
+    // requestBody generated automatically from CreateTodo
+}
+```
+
+Explicit overrides remained available via `#[openapi(request_body = ...)]` for cases that needed more control.
+
+---
+
+## matchit 0.9.1
+
+The underlying router was upgraded from matchit 0.8 to 0.9.1. The new version brought performance improvements to route matching and expanded support for wildcard and catch-all patterns. No changes to route definitions were required.
+
+---
+
+Also: Juca made his quiet debut in this release.
+
+---
+
+Upgrade by bumping the version in your `Cargo.toml`:
+
+```toml
+rapina = "0.11.0"
+```

--- a/docs/content/blog/2026-04-01-rapina-0-11-0.md
+++ b/docs/content/blog/2026-04-01-rapina-0-11-0.md
@@ -83,21 +83,28 @@ txn.commit().await?;
 use rapina::jobs::RetryPolicy;
 use std::time::Duration;
 
-// Up to 5 retries, 2-second base delay, doubles each attempt
+// Up to 5 retries: first is immediate, then 2s → 8s → 32s… (base × 4^(n-2) each step)
 RetryPolicy::exponential(5, Duration::from_secs(2));
 
-// Up to 3 retries, fixed 10-second gap
+// Up to 3 retries: first is also immediate, then uses the fixed 10-second gap
 RetryPolicy::fixed(3, Duration::from_secs(10));
 
 // No retries
 RetryPolicy::none();
 ```
 
-Exponential backoff added deterministic jitter per job ID to prevent thundering herd after outages. Delay was capped at one week. Jobs that exhausted all retries moved to `failed` and remained in the table.
+The first retry is always immediate for both policies; subsequent attempts follow the configured delay. Exponential backoff added deterministic jitter per job ID to prevent thundering herd after outages. Delay was capped at one week. Jobs that exhausted all retries moved to `failed` and remained in the table.
 
 ### Background jobs table and migration
 
-Job state was stored in a `rapina_jobs` table created by Rapina's built-in migration. Calling `.run_migrations()` at startup created the table if it did not exist:
+Job state was stored in a `rapina_jobs` table. To add it to your project, run `rapina jobs init` to register the migration, then apply it with `rapina migrate`:
+
+```
+$ rapina jobs init
+$ rapina migrate
+```
+
+`rapina jobs init` adds a `create_rapina_jobs` migration to your migrations list. `rapina migrate` (or `.run_migrations()` called at startup) then creates the table if it does not exist. The schema:
 
 ```
 rapina_jobs
@@ -139,10 +146,10 @@ Passing `--failed` showed a detailed table of failed jobs with the last error an
 ```
 $ rapina jobs list --failed
 
-  ID            QUEUE    JOB TYPE              ATTEMPTS  LAST ERROR
-  ────────────  ───────  ────────────────────  ────────  ──────────────────────────
-  3fa85f64...  emails   send_welcome_email    3/3       connection refused
-  7c9e6679...  default  sync_user_data        3/3       timeout after 30s
+  ID            QUEUE    JOB TYPE              ATT.    LAST ERROR
+  ────────────  ───────  ────────────────────  ──────  ──────────────────────────
+  3fa85f64...  emails   send_welcome_email    3/3     connection refused
+  7c9e6679...  default  sync_user_data        3/3     timeout after 30s
 ```
 
 ---
@@ -185,7 +192,7 @@ When both `RAPINA_HOST` and `RAPINA_PORT` were set, they overrode the address pa
 RAPINA_HOST=0.0.0.0 RAPINA_PORT=8080 rapina dev
 ```
 
-The override applied at the `listen()` call level, so it worked in any environment — not only during `rapina dev`. The `rapina dev` command also passed these variables when spawning the compiled binary, making it straightforward to bind to a non-default address during development without changing code.
+The override applied at the `listen()` call level, so it worked in any environment — not only during `rapina dev`. The `rapina dev` command also passed these variables when spawning the compiled binary, making it straightforward to bind to a non-default address during development without changing code. If neither variable is set, the address passed to `.listen()` is used as-is.
 
 ---
 

--- a/docs/content/blog/2026-04-01-rapina-0-11-0.md
+++ b/docs/content/blog/2026-04-01-rapina-0-11-0.md
@@ -21,7 +21,7 @@ The biggest addition in 0.11.0 was a complete background jobs system. Jobs were 
 
 ### `#[job]` macro
 
-The `#[job]` macro marked an async function as a background job handler. It accepted attributes for queue routing and retry configuration:
+The `#[job]` macro marks an async function as a background job handler. It accepts attributes for queue routing and retry configuration:
 
 ```rust
 use rapina::prelude::*;
@@ -40,11 +40,11 @@ async fn send_welcome_email(payload: WelcomeEmailPayload) -> JobResult {
 }
 ```
 
-The macro generated a helper function with the same name that returned a `JobRequest`. That value was passed to `Jobs::enqueue()`. Handlers could also receive dependency-injected `State<T>` and `Db` parameters alongside the payload.
+The macro generates a helper function with the same name that returns a `JobRequest`. That value is passed to `Jobs::enqueue()`. Handlers can also receive dependency-injected `State<T>` and `Db` parameters alongside the payload.
 
 ### `Jobs` extractor
 
-The `Jobs` extractor gave handlers a way to enqueue jobs from within a request:
+The `Jobs` extractor gives handlers a way to enqueue jobs from within a request:
 
 ```rust
 use rapina::jobs::Jobs;
@@ -62,7 +62,7 @@ async fn create_user(body: Json<CreateUserRequest>, db: Db, jobs: Jobs) -> Resul
 }
 ```
 
-For transactional enqueues — where the job and the database write needed to commit together — `enqueue_with()` accepted a connection or transaction:
+For transactional enqueues — where the job and the database write need to commit together — `enqueue_with()` accepts a connection or transaction:
 
 ```rust
 let txn = db.conn().begin().await?;
@@ -77,7 +77,7 @@ txn.commit().await?;
 
 ### RetryPolicy
 
-`RetryPolicy` was an enum with three variants. `exponential` and `fixed` took the max retry count and a base delay:
+`RetryPolicy` is an enum with three variants. `exponential` and `fixed` take the max retry count and a base delay:
 
 ```rust
 use rapina::jobs::RetryPolicy;
@@ -93,11 +93,11 @@ RetryPolicy::fixed(3, Duration::from_secs(10));
 RetryPolicy::none();
 ```
 
-The first retry is always immediate for both policies; subsequent attempts follow the configured delay. Exponential backoff added deterministic jitter per job ID to prevent thundering herd after outages. Delay was capped at one week. Jobs that exhausted all retries moved to `failed` and remained in the table.
+The first retry is always immediate for both policies; subsequent attempts follow the configured delay. Exponential backoff adds deterministic jitter per job ID to prevent thundering herd after outages. Delay is capped at one week. Jobs that exhaust all retries move to `failed` and remain in the table.
 
 ### Background jobs table and migration
 
-Job state was stored in a `rapina_jobs` table. To add it to your project, run `rapina jobs init` to register the migration, then apply it with `rapina migrate`:
+Job state is stored in a `rapina_jobs` table. To add it to your project, run `rapina jobs init` to register the migration, then apply it with `rapina migrate`:
 
 ```
 $ rapina jobs init
@@ -124,7 +124,7 @@ rapina_jobs
   created_at    timestamptz       default now()
 ```
 
-A partial index on `(queue, run_at) WHERE status = 'pending'` kept polling efficient. The jobs system required PostgreSQL — SQLite and MySQL were not supported.
+A partial index on `(queue, run_at) WHERE status = 'pending'` keeps polling efficient. The jobs system requires PostgreSQL — SQLite and MySQL are not supported.
 
 ### `rapina jobs list`
 
@@ -141,7 +141,7 @@ $ rapina jobs list
   failed     2
 ```
 
-Passing `--failed` showed a detailed table of failed jobs with the last error and retry counts:
+Passing `--failed` shows a detailed table of failed jobs with the last error and retry counts:
 
 ```
 $ rapina jobs list --failed
@@ -156,7 +156,7 @@ $ rapina jobs list --failed
 
 ## Multipart file upload
 
-The `Multipart` extractor added support for file upload handling. Fields arrived as a stream consumed one at a time:
+The `Multipart` extractor added support for file upload handling. Fields arrive as a stream consumed one at a time:
 
 ```rust
 use rapina::extract::Multipart;
@@ -180,25 +180,25 @@ async fn upload_file(mut multipart: Multipart) -> Result<String> {
 }
 ```
 
-`Field` exposed `name()`, `file_name()`, `content_type()`, `bytes()`, `text()`, and a streaming `chunk()` method for large files. Forms that mixed file uploads with text fields were handled through the same API.
+`Field` exposes `name()`, `file_name()`, `content_type()`, `bytes()`, `text()`, and a streaming `chunk()` method for large files. Forms that mix file uploads with text fields are handled through the same API.
 
 ---
 
 ## RAPINA_HOST and RAPINA_PORT
 
-When both `RAPINA_HOST` and `RAPINA_PORT` were set, they overrode the address passed to `.listen()`:
+When both `RAPINA_HOST` and `RAPINA_PORT` are set, they override the address passed to `.listen()`:
 
 ```bash
 RAPINA_HOST=0.0.0.0 RAPINA_PORT=8080 rapina dev
 ```
 
-The override applied at the `listen()` call level, so it worked in any environment — not only during `rapina dev`. The `rapina dev` command also passed these variables when spawning the compiled binary, making it straightforward to bind to a non-default address during development without changing code. If neither variable is set, the address passed to `.listen()` is used as-is.
+The override applies at the `listen()` call level, so it works in any environment — not only during `rapina dev`. The `rapina dev` command also passes these variables when spawning the compiled binary, making it straightforward to bind to a non-default address during development without changing code. If neither variable is set, the address passed to `.listen()` is used as-is.
 
 ---
 
 ## OpenAPI requestBody auto-generation
 
-Handlers that accepted a body extractor now had their `requestBody` populated in the generated OpenAPI spec automatically. The following extractors were supported:
+Handlers that accept a body extractor have their `requestBody` populated in the generated OpenAPI spec automatically. The following extractors are supported:
 
 | Extractor | Content-Type | Required |
 |-----------|-------------|----------|
@@ -209,7 +209,7 @@ Handlers that accepted a body extractor now had their `requestBody` populated in
 | `Option<Json<T>>` | `application/json` | no |
 | `Option<Form<T>>` | `application/x-www-form-urlencoded` | no |
 
-Schemas were derived from the type's `JsonSchema` impl. No attributes were required for the common case:
+Schemas are derived from the type's `JsonSchema` impl. No attributes are required for the common case:
 
 ```rust
 #[derive(Deserialize, JsonSchema)]
@@ -224,13 +224,13 @@ async fn create_todo(body: Json<CreateTodo>) -> Result<Json<Todo>> {
 }
 ```
 
-Explicit overrides remained available via `#[openapi(request_body = ...)]` for cases that needed more control.
+Explicit overrides remain available via `#[openapi(request_body = ...)]` for cases that need more control.
 
 ---
 
 ## matchit 0.9.1
 
-The underlying router was upgraded from matchit 0.8 to 0.9.1. The new version brought performance improvements to route matching and expanded support for wildcard and catch-all patterns. No changes to route definitions were required.
+The underlying router was upgraded from matchit 0.8 to 0.9.1. The new version brought performance improvements to route matching and expanded support for wildcard and catch-all patterns. No changes to route definitions are required.
 
 ---
 


### PR DESCRIPTION
## Summary

`Covers all items from #455`:
- `#[job]` macro
- `Jobs` extractor with `enqueue` and `enqueue_with`
- `RetryPolicy` with `exponential`, `fixed`, and `none`
- background jobs table schema and migration (PostgreSQL only)
- `rapina jobs list` with `--failed` flag
- multipart file upload extractor
- `RAPINA_HOST` / `RAPINA_PORT` env var support
- OpenAPI `requestBody` auto-generation for `Json`, `Form`, `Validated`, and `Option` variants
- `matchit` upgrade to `0.9.1`
- Juca's quiet debut

## Related Issues

Closes #455 

## Checklist


- [x] Documentation updated (if needed)