### PR TITLE
Remove docs/ from Check version consistency in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           VERSION=$(grep '^version' rapina/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           MINOR="${VERSION%.*}"
-          BAD=$(grep -rn 'rapina = { version = "' docs/ rapina/examples/ \
+          BAD=$(grep -rn 'rapina = { version = "' docs/ rapina/examples/ --exclude-dir="blog" \
             --include="*.md" --include="*.toml" \
             | grep -v "\"$VERSION\"\|\"$MINOR\"\|\"\.\.\.\"" || true)
           if [ -n "$BAD" ]; then


### PR DESCRIPTION
## Summary

Remove "docs/" from the "Check version consistency" in the ci.tml so the new release notes doesn't get blocked by
the outdated versions documented in there

## Related Issues

Closes #490

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
