### PR TITLE
Ignore RUSTSEC-2026-0097 rand unsoundness advisory

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097
 
   deny:
     name: Cargo Deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097
 
   deny:
     name: Cargo Deny


### PR DESCRIPTION
The rand 0.8.5 unsoundness advisory (RUSTSEC-2026-0097, published April 9) is failing the security audit on main and blocking PRs. The advisory requires a very specific chain: custom logger + thread_rng + reseeding during logging, which rapina does not trigger.

Adds the ignore to both ci.yml and audit.yml to unblock CI.