### PR TITLE
feature/state arc builder

### DIFF
--- a/docs/content/docs/core-concepts/state.md
+++ b/docs/content/docs/core-concepts/state.md
@@ -83,6 +83,45 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 
+### Trait Objects
+
+`.state()` requires a concrete type at registration time. When you want handlers to depend on an **interface** rather than an implementation, use `.state_arc()` instead.
+
+`.state_arc()` accepts a pre-built `Arc<T>` where `T` can be an unsized trait object (`Arc<dyn MyTrait>`), with no newtype wrapper required:
+
+```rust
+use rapina::prelude::*;
+use std::sync::Arc;
+
+trait UserRepo: Send + Sync {
+    async fn find_all(&self) -> Vec<User>;
+}
+
+struct PgUserRepo { /* pool */ }
+
+impl UserRepo for PgUserRepo {
+    async fn find_all(&self) -> Vec<User> { /* ... */ }
+}
+
+#[get("/users")]
+async fn list_users(repo: State<Arc<dyn UserRepo>>) -> Json<Vec<User>> {
+    Json(repo.find_all().await)
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let repo: Arc<dyn UserRepo> = Arc::new(PgUserRepo { /* pool */ });
+
+    Rapina::new()
+        .state_arc(repo)
+        .discover()
+        .listen("127.0.0.1:3000")
+        .await
+}
+```
+
+Handlers receive `State<Arc<dyn UserRepo>>`. The `Deref` chain (`State` → `Arc` → `dyn UserRepo`) lets you call trait methods directly without any extra unwrapping.
+
 ### Mutable Shared State
 
 `AppState` already wraps every value in `Arc`, so nothing is copied per-request. When you need to **mutate** state at runtime — not just read it — use `Arc<RwLock<T>>` or `Arc<Mutex<T>>` for interior mutability:
@@ -120,7 +159,7 @@ async fn main() -> std::io::Result<()> {
 If a handler requests `State<T>` but `T` was never registered, the request returns `500 Internal Server Error`:
 
 ```
-State not registered for type 'my_crate::AppConfig'. Did you forget to call .state()?
+State not registered for type 'my_crate::AppConfig'. Did you forget to call .state() or .state_arc()?
 ```
 
 ### Overwriting State

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -184,6 +184,44 @@ impl Rapina {
         self
     }
 
+    /// Adds a pre-existing `Arc<T>` as shared state.
+    ///
+    /// This is the preferred way to register trait objects for dependency
+    /// injection.  Without this method, passing an `Arc<dyn MyTrait>` to
+    /// [`.state()`](Self::state) requires a newtype wrapper; with `state_arc`
+    /// you can register the arc directly.
+    ///
+    /// With `state_arc` the `Arc` is registered under its own [`TypeId`], so
+    /// no newtype wrapper is required.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use rapina::prelude::*;
+    /// use std::sync::Arc;
+    ///
+    /// trait MyRepo: Send + Sync {
+    ///     fn find_all(&self) -> Vec<String>;
+    /// }
+    ///
+    /// struct PgRepo;
+    /// impl MyRepo for PgRepo {
+    ///     fn find_all(&self) -> Vec<String> { vec![] }
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     Rapina::new()
+    ///         .state_arc(Arc::new(PgRepo) as Arc<dyn MyRepo>)
+    ///         .listen("127.0.0.1:3000")
+    ///         .await
+    /// }
+    /// ```
+    pub fn state_arc<T: ?Sized + Send + Sync + 'static>(mut self, value: std::sync::Arc<T>) -> Self {
+        self.state = self.state.with_arc(value);
+        self
+    }
+
     /// Adds a middleware to the application.
     pub fn middleware<M: Middleware>(mut self, middleware: M) -> Self {
         self.middlewares.add(middleware);

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -217,7 +217,10 @@ impl Rapina {
     ///         .await
     /// }
     /// ```
-    pub fn state_arc<T: ?Sized + Send + Sync + 'static>(mut self, value: std::sync::Arc<T>) -> Self {
+    pub fn state_arc<T: ?Sized + Send + Sync + 'static>(
+        mut self,
+        value: std::sync::Arc<T>,
+    ) -> Self {
         self.state = self.state.with_arc(value);
         self
     }

--- a/rapina/src/extract/mod.rs
+++ b/rapina/src/extract/mod.rs
@@ -541,7 +541,7 @@ impl<T: Send + Sync + 'static> FromRequestParts for State<T> {
     ) -> Result<Self, Error> {
         let arc = state.get_arc::<T>().ok_or_else(|| {
             Error::internal(format!(
-                "State not registered for type '{}'. Did you forget to call .state()?",
+                "State not registered for type '{}'. Did you forget to call .state() or .state_arc()?",
                 std::any::type_name::<T>()
             ))
         })?;
@@ -1237,6 +1237,34 @@ mod tests {
             State::<MissingState>::from_request_parts(&parts, &empty_params(), &state).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().status(), 500);
+    }
+
+    #[tokio::test]
+    async fn test_state_extractor_arc_trait_object() {
+        trait Greeter: Send + Sync {
+            fn greet(&self) -> &'static str;
+        }
+
+        struct Hello;
+        impl Greeter for Hello {
+            fn greet(&self) -> &'static str {
+                "hello"
+            }
+        }
+
+        let greeter: std::sync::Arc<dyn Greeter> = std::sync::Arc::new(Hello);
+        let state = std::sync::Arc::new(
+            crate::state::AppState::new().with_arc(greeter),
+        );
+        let (parts, _) = TestRequest::get("/").into_parts();
+
+        let result =
+            State::<std::sync::Arc<dyn Greeter>>::from_request_parts(&parts, &empty_params(), &state)
+                .await;
+
+        assert!(result.is_ok());
+        // Deref chain: State<Arc<dyn Greeter>> -> Arc<dyn Greeter> -> dyn Greeter
+        assert_eq!(result.unwrap().greet(), "hello");
     }
 
     // into_inner tests

--- a/rapina/src/extract/mod.rs
+++ b/rapina/src/extract/mod.rs
@@ -1253,14 +1253,15 @@ mod tests {
         }
 
         let greeter: std::sync::Arc<dyn Greeter> = std::sync::Arc::new(Hello);
-        let state = std::sync::Arc::new(
-            crate::state::AppState::new().with_arc(greeter),
-        );
+        let state = std::sync::Arc::new(crate::state::AppState::new().with_arc(greeter));
         let (parts, _) = TestRequest::get("/").into_parts();
 
-        let result =
-            State::<std::sync::Arc<dyn Greeter>>::from_request_parts(&parts, &empty_params(), &state)
-                .await;
+        let result = State::<std::sync::Arc<dyn Greeter>>::from_request_parts(
+            &parts,
+            &empty_params(),
+            &state,
+        )
+        .await;
 
         assert!(result.is_ok());
         // Deref chain: State<Arc<dyn Greeter>> -> Arc<dyn Greeter> -> dyn Greeter

--- a/rapina/src/state.rs
+++ b/rapina/src/state.rs
@@ -295,9 +295,7 @@ mod tests {
         let concrete = Config { val: 1 };
         let arc = Arc::new(Config { val: 2 });
 
-        let state = AppState::new()
-            .with(concrete)
-            .with_arc(Arc::clone(&arc));
+        let state = AppState::new().with(concrete).with_arc(Arc::clone(&arc));
 
         assert_eq!(state.get::<Config>().unwrap().val, 1);
         assert_eq!(state.get_arc::<Arc<Config>>().unwrap().val, 2);
@@ -327,9 +325,7 @@ mod tests {
         let first: Arc<dyn Counter> = Arc::new(CounterImpl(1));
         let second: Arc<dyn Counter> = Arc::new(CounterImpl(2));
 
-        let state = AppState::new()
-            .with_arc(first)
-            .with_arc(second);
+        let state = AppState::new().with_arc(first).with_arc(second);
 
         let extracted = state.get_arc::<Arc<dyn Counter>>().unwrap();
         assert_eq!(extracted.count(), 2);

--- a/rapina/src/state.rs
+++ b/rapina/src/state.rs
@@ -80,7 +80,7 @@ impl AppState {
     /// Internally the value is stored under `TypeId::of::<Arc<T>>()` wrapped in
     /// one additional `Arc` (as required by the state map). Handlers receive
     /// `State<Arc<dyn MyTrait>>` and can call methods directly via auto-deref,
-    /// or clone the inner arc with `(*state).clone()`.
+    /// or clone the inner arc with `Arc::clone(&*state)`.
     ///
     /// # Examples
     ///

--- a/rapina/src/state.rs
+++ b/rapina/src/state.rs
@@ -71,6 +71,42 @@ impl AppState {
             .and_then(|arc| arc.downcast_ref::<T>())
     }
 
+    /// Registers a pre-existing `Arc<T>` as shared state.
+    ///
+    /// Use this when `T` is a trait object (e.g. `Arc<dyn MyTrait>`) and you
+    /// want to access it via [`State<Arc<dyn MyTrait>>`](crate::extract::State)
+    /// in handlers without needing a newtype wrapper.
+    ///
+    /// Internally the value is stored under `TypeId::of::<Arc<T>>()` wrapped in
+    /// one additional `Arc` (as required by the state map). Handlers receive
+    /// `State<Arc<dyn MyTrait>>` and can call methods directly via auto-deref,
+    /// or clone the inner arc with `(*state).clone()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rapina::state::AppState;
+    /// use std::sync::Arc;
+    ///
+    /// trait Greeter: Send + Sync {
+    ///     fn greet(&self) -> String;
+    /// }
+    ///
+    /// struct HelloGreeter;
+    /// impl Greeter for HelloGreeter {
+    ///     fn greet(&self) -> String { "hello".to_string() }
+    /// }
+    ///
+    /// let greeter: Arc<dyn Greeter> = Arc::new(HelloGreeter);
+    /// let state = AppState::new().with_arc(greeter);
+    ///
+    /// // Access via State<Arc<dyn Greeter>> in handlers; deref gives Arc<dyn Greeter>
+    /// ```
+    pub fn with_arc<T: ?Sized + Send + Sync + 'static>(mut self, value: Arc<T>) -> Self {
+        self.inner.insert(TypeId::of::<Arc<T>>(), Arc::new(value));
+        self
+    }
+
     /// Retrieves a shared `Arc<T>` for a value of type `T`, if registered.
     ///
     /// This is useful when you want to share state without cloning the
@@ -210,5 +246,92 @@ mod tests {
         assert_eq!(state.get::<i64>(), Some(&2));
         assert_eq!(state.get::<f64>(), Some(&3.0));
         assert_eq!(state.get::<String>(), Some(&"test".to_string()));
+    }
+
+    #[test]
+    fn test_with_arc_concrete_type() {
+        #[derive(Debug, PartialEq)]
+        struct Repo {
+            name: &'static str,
+        }
+
+        let arc = Arc::new(Repo { name: "pg" });
+        let state = AppState::new().with_arc(Arc::clone(&arc));
+
+        // Extracted via get_arc::<Arc<Repo>>()
+        let extracted = state.get_arc::<Arc<Repo>>().unwrap();
+        assert_eq!(extracted.name, "pg");
+    }
+
+    #[test]
+    fn test_with_arc_trait_object() {
+        trait Greeter: Send + Sync {
+            fn greet(&self) -> &'static str;
+        }
+
+        struct Hello;
+        impl Greeter for Hello {
+            fn greet(&self) -> &'static str {
+                "hello"
+            }
+        }
+
+        let greeter: Arc<dyn Greeter> = Arc::new(Hello);
+        let state = AppState::new().with_arc(greeter);
+
+        let extracted = state.get_arc::<Arc<dyn Greeter>>().unwrap();
+        assert_eq!(extracted.greet(), "hello");
+    }
+
+    #[test]
+    fn test_with_arc_does_not_conflict_with_with() {
+        // with() and with_arc() on same logical type use different TypeIds
+        // (TypeId::of::<T>() vs TypeId::of::<Arc<T>>()) so they coexist.
+        #[derive(Debug, PartialEq)]
+        struct Config {
+            val: i32,
+        }
+
+        let concrete = Config { val: 1 };
+        let arc = Arc::new(Config { val: 2 });
+
+        let state = AppState::new()
+            .with(concrete)
+            .with_arc(Arc::clone(&arc));
+
+        assert_eq!(state.get::<Config>().unwrap().val, 1);
+        assert_eq!(state.get_arc::<Arc<Config>>().unwrap().val, 2);
+    }
+
+    #[test]
+    fn test_with_arc_missing_returns_none() {
+        trait Repo: Send + Sync {}
+
+        let state = AppState::new();
+        assert!(state.get_arc::<Arc<dyn Repo>>().is_none());
+    }
+
+    #[test]
+    fn test_with_arc_overwrites_same_arc_type() {
+        trait Counter: Send + Sync {
+            fn count(&self) -> u32;
+        }
+
+        struct CounterImpl(u32);
+        impl Counter for CounterImpl {
+            fn count(&self) -> u32 {
+                self.0
+            }
+        }
+
+        let first: Arc<dyn Counter> = Arc::new(CounterImpl(1));
+        let second: Arc<dyn Counter> = Arc::new(CounterImpl(2));
+
+        let state = AppState::new()
+            .with_arc(first)
+            .with_arc(second);
+
+        let extracted = state.get_arc::<Arc<dyn Counter>>().unwrap();
+        assert_eq!(extracted.count(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Changes:                                                                                                                        
                                                                                                                                
  - AppState::with_arc<T: ?Sized>() — stores Arc<T> directly in the state map under TypeId::of::<Arc<T>>(), no newtype needed     
  - Rapina::state_arc() — builder method exposing with_arc on the public app API
  - State<Arc<dyn MyTrait>> extractor works without modification — deref chain gives direct access to trait methods               
  - State extractor error message updated to mention .state_arc()                                                               
                                                                                                                                  
  Tests added:                                                                                                                  
  - state.rs: concrete type, trait object, coexistence with .with(), missing state, overwrite
  - extract/mod.rs: end-to-end extraction of Arc<dyn Trait> via FromRequestParts

## Related Issues

Closes #495 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
