### PR TITLE
Feat: add enable/disable wrappers methods

### DIFF
--- a/docs/content/docs/core-concepts/metrics.md
+++ b/docs/content/docs/core-concepts/metrics.md
@@ -24,7 +24,7 @@ use rapina::prelude::*;
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     Rapina::new()
-        .with_metrics(true)
+        .enable_metrics()
         .router(router)
         .listen("127.0.0.1:3000")
         .await
@@ -32,6 +32,22 @@ async fn main() -> std::io::Result<()> {
 ```
 
 That's all. A `GET /metrics` route is registered automatically and returns the collected metrics in Prometheus text format.
+
+## Dynamic configuration
+
+When the value comes from a config struct or environment variable, use `with_metrics(bool)` to keep the builder chain intact:
+
+```rust
+let cfg = Config::from_env();
+
+Rapina::new()
+    .with_metrics(cfg.metrics_enabled)
+    .router(router)
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+Both forms are equivalent, `enable_metrics()` and `disable_metrics()` are convenience wrappers around `with_metrics(true/false)`.
 
 ## Collected Metrics
 

--- a/docs/content/docs/core-concepts/state.md
+++ b/docs/content/docs/core-concepts/state.md
@@ -184,11 +184,22 @@ The default timeout is 30 seconds. After the timeout, remaining connections are 
 
 ## Health Checks
 
-Enable built-in health endpoints with `.with_health_check(true)`:
+Enable built-in health endpoints with `.enable_health_check()`:
 
 ```rust
 Rapina::new()
-    .with_health_check(true)
+    .enable_health_check()
+    .listen("127.0.0.1:3000")
+    .await
+```
+
+When the value comes from config or environment, use `.with_health_check(bool)` to keep the builder chain intact:
+
+```rust
+let cfg = Config::from_env();
+
+Rapina::new()
+    .with_health_check(cfg.health_check_enabled)
     .listen("127.0.0.1:3000")
     .await
 ```
@@ -217,11 +228,16 @@ readinessProbe:
 
 The liveness probe **never** checks external dependencies — a DB outage should pull the pod from the load balancer (readiness failure), not restart it (liveness failure).
 
-Register custom checks for Redis, external APIs, or any dependency:
+Custom checks
+
+`.enable_health_check()` registers the HTTP endpoints. `.add_health_check()` registers a function that runs inside those endpoints — they do different things:
+
+- **`.enable_health_check()`** (or `.with_health_check(bool)` for dynamic config) — turns on the `/__rapina/health` routes. Without it, those paths return 404.
+- **`.add_health_check("name", fn)`** — adds a dependency check (Redis, Stripe, etc.) that runs on every `/ready` request. Optional — the endpoint works fine without any custom checks.
 
 ```rust
 Rapina::new()
-    .with_health_check(true)
+    .enable_health_check()                          // or: .with_health_check(cfg.health_check_enabled)
     .add_health_check("redis", || async {
         redis_ping().await.is_ok()
     })

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -38,7 +38,7 @@ curl http://127.0.0.1:3000/__rapina/health
 {"status": "ok"}
 ```
 
-The health endpoint is enabled by `.with_health_check(true)` in `main.rs`. See [Health Checks](@/docs/core-concepts/state.md#health-checks) for database and custom checks.
+The health endpoint is enabled by `.with_health_check(true)` or `.enable_health_check()` in `main.rs`. See [Health Checks](@/docs/core-concepts/state.md#health-checks) for database and custom checks.
 
 Check what routes are available:
 

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -385,15 +385,35 @@ impl Rapina {
 
     /// Enables or disables the introspection endpoint.
     ///
-    /// When enabled, a `GET /.__rapina/routes` endpoint is registered
+    /// When enabled, a `GET /__rapina/routes` endpoint is registered
     /// that returns all routes as JSON.
     ///
     /// Introspection is enabled by default in debug builds.
+    /// Use this when the value is dynamic (e.g. read from config/env).
+    /// For literal call sites, prefer [`enable_introspection`](Self::enable_introspection)
+    /// or [`disable_introspection`](Self::disable_introspection).
     pub fn with_introspection(mut self, enabled: bool) -> Self {
         self.introspection = enabled;
         self
     }
 
+    /// Enables the introspection endpoint.
+    ///
+    /// Convenience wrapper for `.with_introspection(true)`.
+    pub fn enable_introspection(self) -> Self {
+        self.with_introspection(true)
+    }
+
+    /// Disables the introspection endpoint.
+    ///
+    /// Convenience wrapper for `.with_introspection(false)`.
+    /// Useful in tests or production builds where introspection should be
+    /// suppressed even when debug assertions are active.
+    pub fn disable_introspection(self) -> Self {
+        self.with_introspection(false)
+    }
+
+    /// Health check is disabled by default.
     /// Enables or disables the built-in health check endpoints.
     ///
     /// When enabled, registers readiness and liveness health check endpoints:
@@ -401,10 +421,38 @@ impl Rapina {
     /// - `GET /__rapina/health/live` — liveness probe, always returns `200 OK`
     /// - `GET /__rapina/health/ready` — readiness probe, runs DB and custom checks
     ///
-    /// Health check is disabled by default.
+    /// Prefer this when the value is dynamic (e.g. read from config/env):
+    ///
+    /// ```ignore
+    /// let cfg = Config::from_env();
+    /// Rapina::new().with_health_check(cfg.health_check_enabled);
+    /// ```
+    ///
+    /// For fixed call sites, [`enable_health_check`](Self::enable_health_check) reads more clearly:
+    ///
+    /// ```rust,no_run
+    /// # use rapina::prelude::*;
+    /// Rapina::new().enable_health_check();
+    /// ```
     pub fn with_health_check(mut self, enabled: bool) -> Self {
         self.health_check = enabled;
         self
+    }
+
+    /// Enables the built-in health check endpoints.
+    ///
+    /// Convenience wrapper for `.with_health_check(true)`. See
+    /// [`with_health_check`](Self::with_health_check) for the dynamic-config form.
+    pub fn enable_health_check(self) -> Self {
+        self.with_health_check(true)
+    }
+
+    /// Disables the built-in health check endpoints.
+    ///
+    /// Convenience wrapper for `.with_health_check(false)`. See
+    /// [`with_health_check`](Self::with_health_check) for the dynamic-config form.
+    pub fn disable_health_check(self) -> Self {
+        self.with_health_check(false)
     }
 
     /// Registers a new scheduled cronjob.
@@ -479,12 +527,19 @@ impl Rapina {
         self
     }
 
+    /// The function is called on every `GET /__rapina/health` request.
     /// Registers a custom health check function.
     ///
-    /// The function is called on every `GET /__rapina/health` request.
-    /// Return `true` if healthy, `false` if not.
+    /// Registers a named async health check function.
     ///
-    /// Requires `.with_health_check(true)` to be set.
+    /// The function is called on every `GET /__rapina/health/ready` request.
+    /// Return `true` if the dependency is healthy, `false` otherwise.
+    ///
+    /// Note: this registers a check function — it does **not** enable the health
+    /// endpoints. You still need to call `.enable_health_check()` (or
+    /// `.with_health_check(true)` for dynamic config) to activate the endpoints.
+    /// A warning is emitted at startup if checks are registered but the endpoint
+    /// is disabled.
     pub fn add_health_check<F, Fut>(mut self, name: &'static str, f: F) -> Self
     where
         F: Fn() -> Fut + Send + Sync + 'static,
@@ -560,15 +615,32 @@ impl Rapina {
         self
     }
 
+    /// Metrics is disabled by default unless you call `with_metrics(true)`.
     /// Enables or disables the metrics endpoint.
     ///
     /// When enabled, a `GET /metrics` endpoint is registered
     /// that returns all metrics to Prometheus.
     ///
-    /// Metrics is disabled by default unless you call `with_metrics(true)`.
+    /// Use this when the value is dynamic (e.g. read from config/env).
+    /// For literal call sites, prefer [`enable_metrics`](Self::enable_metrics)
+    /// or [`disable_metrics`](Self::disable_metrics).
     pub fn with_metrics(mut self, enabled: bool) -> Self {
         self.metrics = enabled;
         self
+    }
+
+    /// Enables the metrics endpoint.
+    ///
+    /// Convenience wrapper for `.with_metrics(true)`.
+    pub fn enable_metrics(self) -> Self {
+        self.with_metrics(true)
+    }
+
+    /// Disables the metrics endpoint.
+    ///
+    /// Convenience wrapper for `.with_metrics(false)`.
+    pub fn disable_metrics(self) -> Self {
+        self.with_metrics(false)
     }
 
     /// Enables or disables openapi endpoint
@@ -766,6 +838,13 @@ impl Rapina {
             self.router = self
                 .router
                 .get_named("/__rapina/routes", "list_routes", list_routes);
+        }
+
+        if !self.health_check && !self.health_registry.checks.is_empty() {
+            tracing::warn!(
+                "add_health_check() was called but the health check endpoint is disabled. \
+                Call .enable_health_check() or .with_health_check(true) to activate it."
+            );
         }
 
         if self.health_check {
@@ -1070,6 +1149,18 @@ mod tests {
     fn test_rapina_with_introspection_disabled() {
         let app = Rapina::new().with_introspection(false);
         assert!(!app.introspection);
+    }
+
+    #[test]
+    fn test_rapina_with_health_check_enabled() {
+        let app = Rapina::new().with_health_check(true);
+        assert!(app.health_check);
+    }
+
+    #[test]
+    fn test_rapina_with_health_check_disabled() {
+        let app = Rapina::new().with_health_check(false);
+        assert!(!app.health_check);
     }
 
     #[test]

--- a/rapina/src/health/config.rs
+++ b/rapina/src/health/config.rs
@@ -16,7 +16,7 @@ pub type HealthCheckFn = Box<dyn Fn() -> Pin<Box<dyn Future<Output = bool> + Sen
 ///
 /// Each check is an async function that returns `true` when healthy.
 /// The registry is populated via [`Rapina::add_health_check`](crate::app::Rapina::add_health_check)
-/// and automatically placed in state when `.with_health_check(true)` is set.
+/// and automatically placed in state when `.enable_health_check()`/`.with_health_check(true)` is set.
 ///
 /// On each request to `/__rapina/health`, all registered checks are called
 /// and their results are included in the response under the `"checks"` key.


### PR DESCRIPTION
## Summary

Adds new enable/disable Rapina app methods that wraps around the .with_* methods

## Related Issues

Closes #476

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
