### PR TITLE
feat: emit sensible defaults and timestamp columns for add resource

### DIFF
--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -52,21 +52,33 @@ src/migrations/mod.rs      # Updated with mod + migrations! macro entry
 
 Fields use a `name:type` format. Supported types:
 
-| Type | Aliases | Rust Type | Column |
-|------|---------|-----------|--------|
-| `string` | | `String` | VARCHAR |
-| `text` | | `String` | TEXT |
-| `i32` | `integer` | `i32` | INTEGER |
-| `i64` | `bigint` | `i64` | BIGINT |
-| `f32` | `float` | `f32` | FLOAT |
-| `f64` | `double` | `f64` | DOUBLE |
-| `bool` | `boolean` | `bool` | BOOLEAN |
-| `uuid` | | `Uuid` | UUID |
-| `datetime` | `timestamptz` | `DateTime` | TIMESTAMPTZ (timezone-aware) |
-| `naivedatetime` | `timestamp` | `NaiveDateTime` | TIMESTAMP (without timezone) |
-| `date` | | `Date` | DATE |
-| `decimal` | | `Decimal` | DECIMAL |
-| `json` | | `Json` | JSON |
+| Type | Aliases | Rust Type | Column | Default |
+|------|---------|-----------|--------|---------|
+| `string` | | `String` | VARCHAR | none |
+| `text` | | `String` | TEXT | none |
+| `i32` | `integer` | `i32` | INTEGER | none |
+| `i64` | `bigint` | `i64` | BIGINT | none |
+| `f32` | `float` | `f32` | FLOAT | none |
+| `f64` | `double` | `f64` | DOUBLE | none |
+| `bool` | `boolean` | `bool` | BOOLEAN | `false` |
+| `uuid` | | `Uuid` | UUID | none |
+| `datetime` | `timestamptz` | `DateTime` | TIMESTAMPTZ (timezone-aware) | none |
+| `naivedatetime` | `timestamp` | `NaiveDateTime` | TIMESTAMP (without timezone) | none |
+| `date` | | `Date` | DATE | none |
+| `decimal` | | `Decimal` | DECIMAL | none |
+| `json` | | `Json` | JSON | none |
+
+### Sensible defaults
+
+`bool`/`boolean` columns always emit `DEFAULT FALSE` in the migration. This avoids requiring every insert to explicitly set the field when `false` is the natural starting state.
+
+`created_at` and `updated_at` (`TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP`) are injected automatically into every generated migration and the entity's `schema!` block. These columns are required for SeaORM's `ActiveModelBehavior` and `before_save` hooks to work correctly.
+
+To skip the timestamp columns (e.g., for a join table or audit log with custom timestamp logic):
+
+```bash
+rapina add resource user name:string email:string --no-timestamps
+```
 
 The generated handlers follow Rapina conventions and are ready to wire into your router. The command prints the exact code you need to add to `main.rs`:
 

--- a/rapina-cli/src/commands/add.rs
+++ b/rapina-cli/src/commands/add.rs
@@ -36,7 +36,11 @@ fn parse_field(input: &str) -> Result<FieldInfo, String> {
         "i64" | "bigint" => ("i64", "i64", ".big_integer().not_null()"),
         "f32" | "float" => ("f32", "f32", ".float().not_null()"),
         "f64" | "double" => ("f64", "f64", ".double().not_null()"),
-        "bool" | "boolean" => ("bool", "bool", ".boolean().not_null()"),
+        "bool" | "boolean" => (
+            "bool",
+            "bool",
+            ".boolean().not_null().default(Expr::value(false))",
+        ),
         "uuid" => ("Uuid", "Uuid", ".uuid().not_null()"),
         "datetime" | "timestamptz" => (
             "DateTimeUtc",
@@ -107,7 +111,7 @@ fn print_next_steps(pascal: &str) {
     println!();
 }
 
-pub fn resource(name: &str, field_args: &[String]) -> Result<(), String> {
+pub fn resource(name: &str, field_args: &[String], with_timestamps: bool) -> Result<(), String> {
     validate_resource_name(name)?;
     codegen::verify_rapina_project()?;
 
@@ -134,9 +138,11 @@ pub fn resource(name: &str, field_args: &[String]) -> Result<(), String> {
 
     let pk_type = "i32"; // New resources default to i32 PK
 
+    let timestamps = if with_timestamps { None } else { Some("none") };
+
     codegen::create_feature_module(singular, plural, pascal, &fields, pk_type, false)?;
-    codegen::update_entity_file(pascal, &fields, None, None, false)?;
-    codegen::create_migration_file(plural, pascal_plural, &fields, pk_type)?;
+    codegen::update_entity_file(pascal, &fields, timestamps, None, false)?;
+    codegen::create_migration_file(plural, pascal_plural, &fields, pk_type, with_timestamps)?;
 
     if let Err(e) = codegen::wire_main_rs(&[plural.as_str()], Path::new(".")) {
         eprintln!("  {} Could not auto-wire main.rs: {}", "!".yellow(), e);
@@ -263,7 +269,7 @@ mod tests {
                 name: "active".to_string(),
                 rust_type: "bool".to_string(),
                 schema_type: "bool".to_string(),
-                column_method: ".boolean().not_null()".to_string(),
+                column_method: ".boolean().not_null().default(Expr::value(false))".to_string(),
                 nullable: false,
             },
         ];
@@ -515,11 +521,11 @@ mod tests {
                 name: "published".to_string(),
                 rust_type: "bool".to_string(),
                 schema_type: "bool".to_string(),
-                column_method: ".boolean().not_null()".to_string(),
+                column_method: ".boolean().not_null().default(Expr::value(false))".to_string(),
                 nullable: false,
             },
         ];
-        let content = codegen::generate_migration("posts", "Posts", &fields, "i32");
+        let content = codegen::generate_migration("posts", "Posts", &fields, "i32", false);
 
         assert!(content.contains("MigrationTrait for Migration"));
         assert!(content.contains("Posts::Table"));
@@ -527,8 +533,97 @@ mod tests {
         assert!(content.contains("Posts::Title"));
         assert!(content.contains("Posts::Published"));
         assert!(content.contains(".string().not_null()"));
-        assert!(content.contains(".boolean().not_null()"));
+        assert!(content.contains(".boolean().not_null().default(Expr::value(false))"));
         assert!(content.contains("enum Posts {"));
         assert!(content.contains("drop_table"));
+        // no timestamps when with_timestamps=false
+        assert!(!content.contains("CreatedAt"));
+        assert!(!content.contains("UpdatedAt"));
+    }
+
+    #[test]
+    fn test_boolean_field_has_default_false() {
+        let f = parse_field("active:bool").unwrap();
+        assert!(
+            f.column_method.contains(".default(Expr::value(false))"),
+            "boolean column_method must include default(false), got: {}",
+            f.column_method
+        );
+
+        let f2 = parse_field("enabled:boolean").unwrap();
+        assert!(
+            f2.column_method.contains(".default(Expr::value(false))"),
+            "boolean column_method must include default(false), got: {}",
+            f2.column_method
+        );
+    }
+
+    #[test]
+    fn test_generate_migration_with_timestamps() {
+        let fields = vec![FieldInfo {
+            name: "title".to_string(),
+            rust_type: "String".to_string(),
+            schema_type: "String".to_string(),
+            column_method: ".string().not_null()".to_string(),
+            nullable: false,
+        }];
+        let content = codegen::generate_migration("posts", "Posts", &fields, "i32", true);
+
+        assert!(content.contains("Posts::CreatedAt"));
+        assert!(content.contains("Posts::UpdatedAt"));
+        assert!(content.contains("CreatedAt,"));
+        assert!(content.contains("UpdatedAt,"));
+        assert!(
+            content.contains(
+                ".timestamp_with_time_zone().not_null().default(Expr::current_timestamp())"
+            )
+        );
+    }
+
+    #[test]
+    fn test_generate_migration_no_timestamps() {
+        let fields = vec![FieldInfo {
+            name: "name".to_string(),
+            rust_type: "String".to_string(),
+            schema_type: "String".to_string(),
+            column_method: ".string().not_null()".to_string(),
+            nullable: false,
+        }];
+        let content = codegen::generate_migration("things", "Things", &fields, "i32", false);
+
+        assert!(!content.contains("CreatedAt"));
+        assert!(!content.contains("UpdatedAt"));
+        assert!(!content.contains("current_timestamp"));
+    }
+
+    #[test]
+    fn test_schema_block_no_timestamps_attr_when_with_timestamps() {
+        // When with_timestamps=true, entity gets no #[timestamps] attr
+        // → schema! macro defaults to both created_at/updated_at (matches migration)
+        let fields = vec![FieldInfo {
+            name: "name".to_string(),
+            rust_type: "String".to_string(),
+            schema_type: "String".to_string(),
+            column_method: String::new(),
+            nullable: false,
+        }];
+        let block = codegen::generate_schema_block("User", &fields, None, None);
+        assert!(!block.contains("#[timestamps"));
+    }
+
+    #[test]
+    fn test_schema_block_timestamps_none_when_no_timestamps() {
+        // When with_timestamps=false, entity must get #[timestamps(none)]
+        // to prevent schema! macro from auto-generating timestamp columns
+        // that don't exist in the migration → would cause runtime mismatch
+        let fields = vec![FieldInfo {
+            name: "name".to_string(),
+            rust_type: "String".to_string(),
+            schema_type: "String".to_string(),
+            column_method: String::new(),
+            nullable: false,
+        }];
+        let block = codegen::generate_schema_block("User", &fields, Some("none"), None);
+        assert!(block.contains("#[timestamps(none)]"));
     }
 }

--- a/rapina-cli/src/commands/add.rs
+++ b/rapina-cli/src/commands/add.rs
@@ -138,10 +138,12 @@ pub fn resource(name: &str, field_args: &[String], with_timestamps: bool) -> Res
 
     let pk_type = "i32"; // New resources default to i32 PK
 
-    let timestamps = if with_timestamps { None } else { Some("none") };
+    // None = no #[timestamps] attr → schema! macro adds both (default).
+    // Some("none") = #[timestamps(none)] → macro skips them.
+    let timestamps_attr = if with_timestamps { None } else { Some("none") };
 
     codegen::create_feature_module(singular, plural, pascal, &fields, pk_type, false)?;
-    codegen::update_entity_file(pascal, &fields, timestamps, None, false)?;
+    codegen::update_entity_file(pascal, &fields, timestamps_attr, None, false)?;
     codegen::create_migration_file(plural, pascal_plural, &fields, pk_type, with_timestamps)?;
 
     if let Err(e) = codegen::wire_main_rs(&[plural.as_str()], Path::new(".")) {
@@ -578,52 +580,5 @@ mod tests {
                 ".timestamp_with_time_zone().not_null().default(Expr::current_timestamp())"
             )
         );
-    }
-
-    #[test]
-    fn test_generate_migration_no_timestamps() {
-        let fields = vec![FieldInfo {
-            name: "name".to_string(),
-            rust_type: "String".to_string(),
-            schema_type: "String".to_string(),
-            column_method: ".string().not_null()".to_string(),
-            nullable: false,
-        }];
-        let content = codegen::generate_migration("things", "Things", &fields, "i32", false);
-
-        assert!(!content.contains("CreatedAt"));
-        assert!(!content.contains("UpdatedAt"));
-        assert!(!content.contains("current_timestamp"));
-    }
-
-    #[test]
-    fn test_schema_block_no_timestamps_attr_when_with_timestamps() {
-        // When with_timestamps=true, entity gets no #[timestamps] attr
-        // → schema! macro defaults to both created_at/updated_at (matches migration)
-        let fields = vec![FieldInfo {
-            name: "name".to_string(),
-            rust_type: "String".to_string(),
-            schema_type: "String".to_string(),
-            column_method: String::new(),
-            nullable: false,
-        }];
-        let block = codegen::generate_schema_block("User", &fields, None, None);
-        assert!(!block.contains("#[timestamps"));
-    }
-
-    #[test]
-    fn test_schema_block_timestamps_none_when_no_timestamps() {
-        // When with_timestamps=false, entity must get #[timestamps(none)]
-        // to prevent schema! macro from auto-generating timestamp columns
-        // that don't exist in the migration → would cause runtime mismatch
-        let fields = vec![FieldInfo {
-            name: "name".to_string(),
-            rust_type: "String".to_string(),
-            schema_type: "String".to_string(),
-            column_method: String::new(),
-            nullable: false,
-        }];
-        let block = codegen::generate_schema_block("User", &fields, Some("none"), None);
-        assert!(block.contains("#[timestamps(none)]"));
     }
 }

--- a/rapina-cli/src/commands/codegen.rs
+++ b/rapina-cli/src/commands/codegen.rs
@@ -479,8 +479,9 @@ pub(crate) fn generate_migration(
     pascal_plural: &str,
     fields: &[FieldInfo],
     pk_type: &str,
+    with_timestamps: bool,
 ) -> String {
-    let column_defs: Vec<String> = fields
+    let mut column_defs: Vec<String> = fields
         .iter()
         .filter(|f| f.name != "id") // Skip id as it's added separately
         .map(|f| {
@@ -494,11 +495,22 @@ pub(crate) fn generate_migration(
         })
         .collect();
 
-    let iden_variants: Vec<String> = fields
+    let mut iden_variants: Vec<String> = fields
         .iter()
         .filter(|f| f.name != "id") // Skip prefix/reserved id
         .map(|f| format!("    {},", to_pascal_case(&f.name)))
         .collect();
+
+    if with_timestamps {
+        column_defs.push(format!(
+            "                    .col(ColumnDef::new({pascal_plural}::CreatedAt).timestamp_with_time_zone().not_null().default(Expr::current_timestamp()))"
+        ));
+        column_defs.push(format!(
+            "                    .col(ColumnDef::new({pascal_plural}::UpdatedAt).timestamp_with_time_zone().not_null().default(Expr::current_timestamp()))"
+        ));
+        iden_variants.push("    CreatedAt,".to_string());
+        iden_variants.push("    UpdatedAt,".to_string());
+    }
 
     let readable_name = format!("create {}", plural);
 
@@ -666,6 +678,7 @@ pub(crate) fn create_migration_file(
     pascal_plural: &str,
     fields: &[FieldInfo],
     pk_type: &str,
+    with_timestamps: bool,
 ) -> Result<(), String> {
     let migrations_dir = Path::new("src/migrations");
 
@@ -681,7 +694,7 @@ pub(crate) fn create_migration_file(
     let filename = format!("{}.rs", module_name);
     let filepath = migrations_dir.join(&filename);
 
-    let template = generate_migration(plural, pascal_plural, fields, pk_type);
+    let template = generate_migration(plural, pascal_plural, fields, pk_type, with_timestamps);
     fs::write(&filepath, template).map_err(|e| format!("Failed to write migration file: {}", e))?;
     println!(
         "  {} Created {}",

--- a/rapina-cli/src/commands/import.rs
+++ b/rapina-cli/src/commands/import.rs
@@ -577,6 +577,7 @@ fn generate_for_table(
     };
 
     codegen::update_entity_file(&pascal, &fields, timestamps, primary_key.as_deref(), force)?;
+    // Always false: DB already owns the schema, so no timestamp columns are injected.
     codegen::create_migration_file(plural, &pascal_plural, &fields, pk_type, false)?;
     codegen::create_feature_module(&singular, plural, &pascal, &fields, pk_type, force)?;
 

--- a/rapina-cli/src/commands/import.rs
+++ b/rapina-cli/src/commands/import.rs
@@ -577,7 +577,7 @@ fn generate_for_table(
     };
 
     codegen::update_entity_file(&pascal, &fields, timestamps, primary_key.as_deref(), force)?;
-    codegen::create_migration_file(plural, &pascal_plural, &fields, pk_type)?;
+    codegen::create_migration_file(plural, &pascal_plural, &fields, pk_type, false)?;
     codegen::create_feature_module(&singular, plural, &pascal, &fields, pk_type, force)?;
 
     println!(

--- a/rapina-cli/src/main.rs
+++ b/rapina-cli/src/main.rs
@@ -148,6 +148,9 @@ enum AddCommands {
         name: String,
         /// Fields in name:type format (e.g., title:string body:text published:bool)
         fields: Vec<String>,
+        /// Skip injecting created_at/updated_at timestamp columns
+        #[arg(long)]
+        no_timestamps: bool,
     },
 }
 
@@ -271,7 +274,11 @@ fn main() {
         }
         Some(Commands::Add { command }) => {
             let result = match command {
-                AddCommands::Resource { name, fields } => commands::add::resource(&name, &fields),
+                AddCommands::Resource {
+                    name,
+                    fields,
+                    no_timestamps,
+                } => commands::add::resource(&name, &fields, !no_timestamps),
             };
             if let Err(e) = result {
                 eprintln!("{} {}", "Error:".red().bold(), e);


### PR DESCRIPTION
## Summary

 - `bool`/`boolean` fields now emit `.default(Expr::value(false))` in                                                                                   
    the generated migration — avoids requiring every insert to set the
    field explicitly                                                                                                                                     
  - `created_at` and `updated_at` (`TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP`)                                                                                                are injected automatically into every migration                                                                                  
    and the entity `schema!` block, matching Rails/Django conventions                                                                                  
    and satisfying SeaORM `ActiveModelBehavior`                                                                                                          
  - `--no-timestamps` flag opts out; entity receives `#[timestamps(none)]`                                                                             
    to keep migration and entity in sync
## Related Issues

Closes #496 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
