### PR TITLE
Bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Cargo deny is failing on main due to GHSA-xgp8-3hg3-c2mh, a name constraint handling bug in rustls-webpki 0.103.10. Practical risk is low (only reachable after signature verification and requires misissuance), but cargo-deny blocks any advisory regardless of severity.

Lockfile-only bump to 0.103.12 which contains the patch. Cargo.toml already allows the new version so no manifest changes are needed.

Closes #500.