### PR TITLE
feat(uuid): enable serde feature for Uuid serialization

### DIFF
--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -40,7 +40,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 httpdate = "1"
 # FIXME: move behind a `snapshot` feature flag
 regex = "1"

--- a/rapina/src/extract/mod.rs
+++ b/rapina/src/extract/mod.rs
@@ -1118,6 +1118,38 @@ mod tests {
         assert_eq!(err.status(), 400);
     }
 
+    #[tokio::test]
+    async fn test_query_extractor_uuid() {
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Params {
+            id: uuid::Uuid,
+        }
+
+        let id = uuid::Uuid::new_v4();
+        let (parts, _) = TestRequest::get(&format!("/users?id={id}")).into_parts();
+        let result =
+            Query::<Params>::from_request_parts(&parts, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0.id, id);
+    }
+
+    #[tokio::test]
+    async fn test_query_extractor_uuid_invalid() {
+        #[allow(dead_code)]
+        #[derive(serde::Deserialize, Debug)]
+        struct Params {
+            id: uuid::Uuid,
+        }
+
+        let (parts, _) = TestRequest::get("/users?id=not-a-uuid").into_parts();
+        let result =
+            Query::<Params>::from_request_parts(&parts, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status(), 400);
+    }
+
     // Headers extractor tests
     #[tokio::test]
     async fn test_headers_extractor() {
@@ -1185,6 +1217,27 @@ mod tests {
 
         let result = Path::<u64>::from_request_parts(&parts, &params, &empty_state()).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_path_extractor_uuid() {
+        let id = uuid::Uuid::new_v4();
+        let (parts, _) = TestRequest::get(&format!("/users/{id}")).into_parts();
+        let params = params(&[("id", &id.to_string())]);
+
+        let result = Path::<uuid::Uuid>::from_request_parts(&parts, &params, &empty_state()).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0, id);
+    }
+
+    #[tokio::test]
+    async fn test_path_extractor_uuid_invalid() {
+        let (parts, _) = TestRequest::get("/users/not-a-uuid").into_parts();
+        let params = params(&[("id", "not-a-uuid")]);
+
+        let result = Path::<uuid::Uuid>::from_request_parts(&parts, &params, &empty_state()).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status(), 400);
     }
 
     // Context extractor tests

--- a/rapina/tests/extractors.rs
+++ b/rapina/tests/extractors.rs
@@ -661,3 +661,70 @@ async fn test_cookie_extraction_missing() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+// UUID serde Tests
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Resource {
+    id: rapina::uuid::Uuid,
+    name: String,
+}
+
+#[tokio::test]
+async fn test_uuid_in_json_body() {
+    let app = Rapina::new()
+        .with_introspection(false)
+        .router(Router::new().route(
+            http::Method::POST,
+            "/resources",
+            |req, _, _| async move {
+                use http_body_util::BodyExt;
+                let body = req.into_body().collect().await.unwrap().to_bytes();
+                let resource: Resource = serde_json::from_slice(&body).unwrap();
+                Json(resource)
+            },
+        ));
+
+    let id = rapina::uuid::Uuid::new_v4();
+    let client = TestClient::new(app).await;
+    let response = client
+        .post("/resources")
+        .json(&Resource {
+            id,
+            name: "test".to_string(),
+        })
+        .send()
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let resource: Resource = response.json();
+    assert_eq!(resource.id, id);
+    assert_eq!(resource.name, "test");
+}
+
+#[tokio::test]
+async fn test_uuid_in_json_response() {
+    let id = rapina::uuid::Uuid::new_v4();
+    let app = Rapina::new()
+        .with_introspection(false)
+        .router(Router::new().route(
+            http::Method::GET,
+            "/resources/:id",
+            move |_, _, _| async move {
+                Json(Resource {
+                    id,
+                    name: "example".to_string(),
+                })
+            },
+        ));
+
+    let client = TestClient::new(app).await;
+    let response = client
+        .get(&format!("/resources/{id}"))
+        .send()
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let resource: Resource = response.json();
+    assert_eq!(resource.id, id);
+}

--- a/rapina/tests/extractors.rs
+++ b/rapina/tests/extractors.rs
@@ -674,16 +674,14 @@ struct Resource {
 async fn test_uuid_in_json_body() {
     let app = Rapina::new()
         .with_introspection(false)
-        .router(Router::new().route(
-            http::Method::POST,
-            "/resources",
-            |req, _, _| async move {
+        .router(
+            Router::new().route(http::Method::POST, "/resources", |req, _, _| async move {
                 use http_body_util::BodyExt;
                 let body = req.into_body().collect().await.unwrap().to_bytes();
                 let resource: Resource = serde_json::from_slice(&body).unwrap();
                 Json(resource)
-            },
-        ));
+            }),
+        );
 
     let id = rapina::uuid::Uuid::new_v4();
     let client = TestClient::new(app).await;
@@ -719,10 +717,7 @@ async fn test_uuid_in_json_response() {
         ));
 
     let client = TestClient::new(app).await;
-    let response = client
-        .get(&format!("/resources/{id}"))
-        .send()
-        .await;
+    let response = client.get(&format!("/resources/{id}")).send().await;
 
     assert_eq!(response.status(), StatusCode::OK);
     let resource: Resource = response.json();


### PR DESCRIPTION
## Summary                              
  Added `"serde"` to the `uuid` feature flags in
  `Cargo.toml` — enables `Serialize`/`Deserialize`         
  for `uuid::Uuid`, which is required for users to use
  `Uuid` in `Path<T>`, `Query<T>`,                         
  and JSON body/response extractors via the re-exported
  `rapina::uuid`.                                          
                                                          
  Added 4 unit tests (`Path<Uuid>` valid/invalid,          
  `Query<Uuid>` valid/invalid) and 2 integration          
  tests (`Uuid` in JSON body and JSON response) — covers   
  all 3 use cases from the issue.                          
                                                 
  ## Related Issues                                        
  Closes #493               
                                                           
  ## Checklist                                            
  - [x] `cargo fmt` passes                       
  - [x] `cargo clippy` has no warnings                    
  - [x] Tests pass
  - [ ] Documentation updated (if needed)
