### PR TITLE
Fix in-flight request metric leak

### DIFF
--- a/rapina/src/metrics/middleware.rs
+++ b/rapina/src/metrics/middleware.rs
@@ -1,11 +1,11 @@
 use std::time::Instant;
 
-use hyper::body::Incoming;
-use hyper::{Request, Response};
-
 use crate::context::RequestContext;
 use crate::middleware::{BoxFuture, Middleware, Next};
 use crate::response::BoxBody;
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+use prometheus::IntGauge;
 
 use super::prometheus::MetricsRegistry;
 
@@ -16,6 +16,35 @@ pub struct MetricsMiddleware {
 impl MetricsMiddleware {
     pub fn new(registry: MetricsRegistry) -> Self {
         Self { registry }
+    }
+}
+
+/// RAII guard that safely manages the `http_requests_in_flight` metric.
+///
+/// In Hyper/Tokio, if a client closes the TCP connection mid-request,
+/// the executing Future is abruptly dropped. If we manually called `.inc()`
+/// and `.dec()` in the middleware, the `.dec()` would never execute upon
+/// cancellation, causing a permanent metric leak.
+///
+/// This guard ensures that the gauge is strictly incremented on creation
+/// and guaranteed to be decremented when dropped, regardless of whether
+/// the request succeeds or is cancelled by the runtime.
+struct InFlightGuard {
+    gauge: IntGauge,
+}
+
+impl InFlightGuard {
+    /// Constructs a new Inflight Guard, which automatically increments the Prometheus gauge
+    fn new(gauge: IntGauge) -> Self {
+        gauge.inc();
+        Self { gauge }
+    }
+}
+
+impl Drop for InFlightGuard {
+    /// Drops the Inflight Guard, which automatically decrements the Prometheus gauge
+    fn drop(&mut self) {
+        self.gauge.dec();
     }
 }
 
@@ -46,11 +75,11 @@ impl Middleware for MetricsMiddleware {
         let registry = self.registry.clone();
 
         Box::pin(async move {
-            registry.http_requests_in_flight.inc();
+            let _in_flight_guard = InFlightGuard::new(registry.http_requests_in_flight.clone());
+
             let start = Instant::now();
             let response = next.run(req).await;
             let duration = start.elapsed().as_secs_f64();
-            registry.http_requests_in_flight.dec();
 
             let status = response.status().as_u16().to_string();
             registry
@@ -112,5 +141,28 @@ mod tests {
     fn test_metrics_middleware_new() {
         let registry = MetricsRegistry::new();
         let _middleware = MetricsMiddleware::new(registry);
+    }
+
+    #[test]
+    fn test_in_flight_guard_increments_and_decrements_cleanly() {
+        let registry = MetricsRegistry::new();
+        let gauge = registry.http_requests_in_flight.clone();
+
+        assert_eq!(gauge.get(), 0, "In-Flight Gauge should start at 0");
+
+        {
+            let _guard = InFlightGuard::new(gauge.clone());
+            assert_eq!(
+                gauge.get(),
+                1,
+                "In-Flight Gauge should be 1 while guard is in scope"
+            );
+        }
+
+        assert_eq!(
+            gauge.get(),
+            0,
+            "In-Flight Gauge should return to 0 after guard drops"
+        );
     }
 }

--- a/rapina/tests/metrics.rs
+++ b/rapina/tests/metrics.rs
@@ -6,6 +6,9 @@ use http::StatusCode;
 use rapina::metrics::MetricsRegistry;
 use rapina::prelude::*;
 use rapina::testing::TestClient;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -158,4 +161,64 @@ fn test_metrics_registry_encode_returns_text() {
     let out = r.encode();
     assert!(!out.is_empty());
     assert!(out.contains("# TYPE"));
+}
+
+// ── RAII guard for in-flight requests ────────────────────────
+
+#[tokio::test]
+async fn test_in_flight_metric_leak_on_client_disconnect() {
+    // Build Rapina app with a slow endpoint
+    let app = Rapina::new().with_metrics(true).router(Router::new().route(
+        http::Method::GET,
+        "/slow",
+        |_, _, _| async move {
+            // Sleep for 10 seconds, to simulate a slow DB query or long-running processing.
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            StatusCode::OK
+        },
+    ));
+
+    let client = TestClient::new(app).await;
+
+    // Verify http_requests_in_flight metric starts at 1
+    let metrics = client.get("/metrics").send().await.text();
+    assert!(
+        metrics.contains("http_requests_in_flight 1"),
+        "in-flight metric should start at 1 (value 1 because of the current /metrics request)"
+    );
+
+    // Connect to the test server using a raw TCP socket
+    let mut stream = TcpStream::connect(client.addr())
+        .await
+        .expect("Failed to connect via raw TCP");
+
+    // Send a valid HTTP GET request to the /slow endpoint
+    let request = "GET /slow HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n";
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("Failed to write to TCP stream");
+
+    // Wait a bit to ensure Hyper starts processing the request
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Verify the metric incremented to 2
+    let metrics = client.get("/metrics").send().await.text();
+    assert!(
+        metrics.contains("http_requests_in_flight 2"),
+        "in-flight metric should increment to 2 while request is processing"
+    );
+
+    // THE CANCELLATION POINT, drops the TCP connection mid-flight
+    drop(stream);
+
+    // Wait a bit for the OS and Hyper to process the TCP close and our RAII guard to drop
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Verify http_requests_in_flight metric is back to 1
+    let metrics = client.get("/metrics").send().await.text();
+    assert!(
+        metrics.contains("http_requests_in_flight 1"),
+        "in-flight metric MUST return to 1 after client disconnects mid-request"
+    );
 }


### PR DESCRIPTION
## Summary

Fixes the `http_requests_in_flight` metric leak in case the client closes the connection to the Rapina webserver before the endpoint handler finished processing.

## Related Issues

Closes #516

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
