### PR TITLE
Support streaming and SSE responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,12 +2677,14 @@ dependencies = [
 name = "rapina"
 version = "0.11.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "bytes",
  "criterion",
  "dashmap",
  "dotenvy",
  "flate2",
+ "futures-core",
  "futures-util",
  "http",
  "http-body-util",
@@ -2697,6 +2699,7 @@ dependencies = [
  "matchit",
  "multer",
  "nix 0.31.2",
+ "pin-project-lite",
  "prometheus",
  "rapina-macros",
  "redis",

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -80,7 +80,14 @@ CompressionConfig::default()
 CompressionConfig::new(512, 9)  // min 512 bytes, maximum compression
 ```
 
-Compression is skipped when the client does not send `Accept-Encoding: gzip` or `deflate`, the response already has a `Content-Encoding` header, the `Content-Type` is not compressible (e.g. `image/png`), or the body is smaller than `min_size`. `Vary: Accept-Encoding` is added automatically for correct proxy caching.
+Compression is skipped when the client does not send `Accept-Encoding: gzip` or `deflate`, the response already has a `Content-Encoding` header, the `Content-Type` is not compressible (e.g. `image/png`), or (for buffered bodies) the body is smaller than `min_size`. `Vary: Accept-Encoding` is added automatically for correct proxy caching.
+
+### Streaming bodies
+
+`StreamResponse` and `SseResponse` (see [Streaming & SSE](@/docs/core-concepts/streaming.md)) are handled differently:
+
+- **`text/event-stream`**: never compressed. Gzip across event boundaries breaks SSE framing at proxies.
+- **Other streaming bodies**: compressed per-chunk with a persistent gzip/deflate encoder. The `min_size` and "compression not worth it" guards don't apply, since the total size isn't known in advance. Streaming bodies always get compressed when the client accepts it. `Content-Length` is removed; the response uses chunked transfer encoding.
 
 ---
 

--- a/docs/content/docs/core-concepts/streaming.md
+++ b/docs/content/docs/core-concepts/streaming.md
@@ -1,0 +1,194 @@
++++
+title = "Streaming & SSE"
+description = "Streaming response bodies, Server-Sent Events, keep-alive, and compression interaction"
+weight = 12
+date = 2026-04-26
++++
+
+Rapina supports two response shapes for incremental delivery: `StreamResponse` for arbitrary chunked bytes (file downloads, LLM token streams, custom protocols) and `SseResponse` for [Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html). Both write to the wire as data arrives instead of buffering the entire response in memory.
+
+Both ship in the default feature set and live under `rapina::response`.
+
+## Producing the stream
+
+The examples below use [`async-stream`](https://docs.rs/async-stream) to build the `Stream<Item = ...>` argument that `StreamResponse::new` and `SseResponse::new` accept. It's the most ergonomic option, but it's not a Rapina dependency. Add it to your own `Cargo.toml`:
+
+```toml
+[dependencies]
+async-stream = "0.3"
+```
+
+Other ways to produce a stream:
+- [`tokio_stream::wrappers::ReceiverStream`](https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.ReceiverStream.html) when you have a `tokio::sync::mpsc::Receiver` already.
+- [`futures::stream::iter`](https://docs.rs/futures/latest/futures/stream/fn.iter.html) for a one-shot fixed-size sequence.
+- A manual `impl Stream for MyType` when you need precise control over polling.
+
+## Server-Sent Events
+
+`SseResponse` wraps a [`Stream`](https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html) of `SseEvent` values and serializes them to the SSE wire format. It sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `X-Accel-Buffering: no` so reverse proxies (nginx, Cloudflare) do not buffer the stream.
+
+```rust
+use std::time::Duration;
+use rapina::http::Method;
+use rapina::prelude::*;
+use rapina::response::{BodyError, SseEvent, SseResponse};
+use rapina::router::Router;
+
+let router = Router::new().route(Method::GET, "/events", |_, _, _| async {
+    let stream = async_stream::stream! {
+        for i in 0u64.. {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            yield Ok::<_, BodyError>(SseEvent::data(format!("tick {}", i)).id(i.to_string()));
+        }
+    };
+    SseResponse::new(stream)
+});
+```
+
+`SseEvent` is a small builder. Multi-line `data` produces multiple `data:` lines per the spec.
+
+```rust
+SseEvent::data("hello")
+    .event("update")
+    .id("42")
+    .retry(5000);
+
+// Comment-only event (browsers ignore comments). Useful for inline annotations
+// or operator-visible markers without affecting the EventSource client.
+SseEvent::comment("operator marker");
+
+// Comment alongside data.
+SseEvent::data("payload").with_comment("debug-info");
+```
+
+### Convenience constructors
+
+For the common cases of "I have a finite list" or "I want to send from a channel", you don't need `async-stream`:
+
+```rust
+// Finite list of events.
+SseResponse::from_events(vec![
+    SseEvent::data("a"),
+    SseEvent::data("b"),
+]);
+
+// Send from a tokio channel.
+let (tx, rx) = tokio::sync::mpsc::channel(32);
+tokio::spawn(async move {
+    tx.send(Ok(SseEvent::data("via channel"))).await.unwrap();
+});
+SseResponse::from_receiver(rx);
+```
+
+Same `from_receiver` constructor exists on `StreamResponse` for raw `Bytes`.
+
+### Custom headers and status
+
+```rust
+SseResponse::new(stream)
+    .status(StatusCode::OK)
+    .header("x-trace-id", trace_id)
+    .keep_alive_text("ping");          // emits `: ping\n\n` instead of the default `:\n\n`
+
+StreamResponse::new(stream)
+    .content_type("application/pdf")
+    .header("content-disposition", "attachment; filename=\"report.pdf\"");
+```
+
+### Keep-alive
+
+Default: a `:\n\n` comment frame every 15 seconds when the user stream is idle. This stops idle proxies from closing the connection. Disable or change the interval:
+
+```rust
+SseResponse::new(stream).keep_alive(None);                                  // off
+SseResponse::new(stream).keep_alive(Some(Duration::from_secs(30)));         // 30s
+```
+
+The keep-alive timer is implemented inside the body itself (no separate task). When the response is dropped, both the user stream and the timer are dropped together, so client disconnect cancels everything cleanly.
+
+### Browser client
+
+Standard EventSource:
+
+```javascript
+const es = new EventSource('/events');
+es.onmessage = (m) => console.log(m.data);
+es.addEventListener('update', (m) => console.log('update:', m.data));
+```
+
+## Raw chunked streaming
+
+`StreamResponse` is the lower-level primitive. Wraps any `Stream<Item = Result<Bytes, BodyError>>`. Use it for binary streams, file downloads, or any chunked protocol where you don't want SSE framing.
+
+```rust
+use bytes::Bytes;
+use rapina::response::{BodyError, StreamResponse};
+
+let router = Router::new().route(Method::GET, "/download", |_, _, _| async {
+    let s = async_stream::stream! {
+        let file = tokio::fs::File::open("/tmp/big.bin").await.unwrap();
+        let mut reader = tokio::io::BufReader::new(file);
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = tokio::io::AsyncReadExt::read(&mut reader, &mut buf).await.unwrap();
+            if n == 0 { break; }
+            yield Ok::<_, BodyError>(Bytes::copy_from_slice(&buf[..n]));
+        }
+    };
+    StreamResponse::new(s).content_type("application/octet-stream")
+});
+```
+
+`status()` and `content_type()` are chainable. Default status is `200 OK`, default content-type is `application/octet-stream`.
+
+## Compression interaction
+
+The compression middleware does the right thing automatically:
+
+- **`text/event-stream`**: never compressed. Gzip across SSE event boundaries breaks framing at proxies; Starlette ships the same exclusion.
+- **Other streaming bodies** (`size_hint().exact() == None`): compressed per-chunk with a persistent gzip/deflate encoder. The `min_size` and "compression not worth it" guards don't apply, since the total size isn't known in advance. Streaming bodies always get compressed when the client accepts it. `Content-Length` is dropped, `Content-Encoding` and `Vary: Accept-Encoding` are added.
+- **Buffered bodies**: the existing path runs unchanged (collect, check `min_size`, try compression, return whichever is smaller).
+
+## Body type
+
+Both `StreamResponse` and `SseResponse` produce a `Response<BoxBody>`, the same type every other handler returns. Middleware that doesn't touch the body (auth, CORS, trace IDs, request logging) passes them through untouched. Middleware that DOES need to read the body checks `body.size_hint().exact()` and skips streaming bodies if buffering would be wrong (cache does this; compression handles streaming explicitly).
+
+If you're implementing your own middleware and need to check whether a response is buffered or streaming:
+
+```rust
+use hyper::body::Body as _;
+
+if response.body().size_hint().exact().is_none() {
+    // streaming, pass through, don't try to buffer
+    return response;
+}
+```
+
+## Troubleshooting
+
+**Events arrive only after the handler finishes.** Check that you're returning `SseResponse::new(stream)` and not `Vec<SseEvent>::into_response()`. The latter buffers. If you're behind nginx, confirm `proxy_buffering off` for the route. The `X-Accel-Buffering: no` header takes care of this for nginx versions that respect it, but some proxy configs still buffer.
+
+**Browser EventSource keeps reconnecting.** Most likely the connection is being closed by an upstream proxy after an idle timeout. Set `SseResponse::new(...).keep_alive(Some(Duration::from_secs(N)))` to a value below the proxy timeout (15s default works for almost all proxies).
+
+**Compression broke my stream.** Two cases:
+- *SSE*: should never happen. `text/event-stream` is unconditionally skipped. If you see `Content-Encoding: gzip` on an SSE response, file a bug.
+- *Other streaming bodies*: the wire bytes are valid gzip, but some HTTP clients don't decompress chunked gzip incrementally. `curl` with `--compressed` or any standard browser handles it fine. `gunzip` on a saved chunked-decoded stream also works. If you're hitting "unexpected EOF" on a custom client, make sure it's reading until the connection closes (or the chunked terminator) before passing bytes to the gunzip layer.
+
+**Server panics with "encoder present until upstream end".** Indicates the compression body's invariant was violated. Should be unreachable; report a bug with the producer code.
+
+**Client disconnect leaks tasks.** It shouldn't. `SseBody` and `StreamingCompressedBody` only own the producer stream and a timer, both dropped when the body is dropped. If you see leaks, check that your producer stream itself doesn't hold a `tokio::spawn` handle that outlives the response. Use `async_stream::stream!` rather than spawning a separate task.
+
+**Mid-handler error.** Yield `Err(BodyError)` from the producer stream:
+
+```rust
+let s = async_stream::stream! {
+    yield Ok::<_, BodyError>(Bytes::from_static(b"start"));
+    yield Err(Box::new(std::io::Error::other("boom")) as BodyError);
+};
+```
+
+The connection will be closed without a clean termination chunk. The client sees a truncated response. There's no way to send a structured error mid-stream once the headers are committed. That's a property of HTTP/1.1, not Rapina.
+
+## Body error type
+
+`BodyError` is `Box<dyn std::error::Error + Send + Sync>`. Part of the public middleware contract: any code that calls `body.collect().await` or polls frames from a Rapina response body receives this type. Producers convert their own errors via `Box::new(err)` or `err.into()`.

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -27,6 +27,8 @@ hyper-util = { version = "0.1.19", features = [
 http = "1.4.0"
 http-body-util = "0.1.3"
 bytes = "1.11.1"
+futures-core = { version = "0.3", default-features = false, features = ["std"] }
+pin-project-lite = "0.2"
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
@@ -103,6 +105,7 @@ tokio-cron-scheduler = { version = "0.15.1", optional = true }
 tokio-util = { version = "0.7.18", optional = true }
 
 [dev-dependencies]
+async-stream = "0.3"
 criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1"
 matchit = "0.9"

--- a/rapina/examples/sse.rs
+++ b/rapina/examples/sse.rs
@@ -1,0 +1,30 @@
+//! SSE counter example.
+//!
+//! Run with `cargo run --example sse`, then `curl -N http://127.0.0.1:3000/events`
+//! to watch one event arrive per second.
+
+use std::time::Duration;
+
+use rapina::http::Method;
+use rapina::prelude::*;
+use rapina::response::{BodyError, SseEvent, SseResponse};
+use rapina::router::Router;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let router = Router::new().route(Method::GET, "/events", |_, _, _| async {
+        let stream = async_stream::stream! {
+            for i in 0u64.. {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                yield Ok::<_, BodyError>(SseEvent::data(format!("tick {}", i)).id(i.to_string()));
+            }
+        };
+        SseResponse::new(stream)
+    });
+
+    Rapina::new()
+        .with_health_check(true)
+        .router(router)
+        .listen("127.0.0.1:3000")
+        .await
+}

--- a/rapina/src/cache.rs
+++ b/rapina/src/cache.rs
@@ -26,13 +26,13 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use dashmap::DashMap;
 use http::{Response, header};
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
 use hyper::Request;
-use hyper::body::Incoming;
+use hyper::body::{Body, Incoming};
 
 use crate::context::RequestContext;
 use crate::middleware::{BoxFuture, Middleware, Next};
-use crate::response::BoxBody;
+use crate::response::{BoxBody, empty, full};
 
 /// Internal header injected by the `#[cache(ttl = N)]` macro.
 /// The middleware reads this to determine caching behavior, then strips it.
@@ -257,13 +257,26 @@ impl Middleware for CacheMiddleware {
 
                 // Check if handler wants caching
                 if let Some(ttl) = extract_ttl_header(&response) {
+                    // Streaming bodies cannot be captured as a single Bytes blob.
+                    // A handler asking to cache one is a programming error: log
+                    // a warning so the operator notices the #[cache] is silently
+                    // being ignored, then pass the response through unchanged.
+                    if response.body().size_hint().exact().is_none() {
+                        tracing::warn!(
+                            path = %path,
+                            ttl,
+                            "cache middleware: streaming response cannot be cached, \
+                             passthrough. Remove #[cache] from this handler."
+                        );
+                        return response;
+                    }
                     let (parts, body) = response.into_parts();
                     let body_bytes = match body.collect().await {
                         Ok(collected) => collected.to_bytes(),
                         Err(_) => {
                             return Response::builder()
                                 .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                                .body(Full::new(Bytes::new()))
+                                .body(empty())
                                 .unwrap();
                         }
                     };
@@ -288,7 +301,7 @@ impl Middleware for CacheMiddleware {
                         .await;
 
                     // Return response without the internal header, with MISS marker
-                    let mut response = Response::from_parts(parts, Full::new(body_bytes));
+                    let mut response = Response::from_parts(parts, full(body_bytes));
                     response.headers_mut().remove(CACHE_TTL_HEADER);
                     response
                         .headers_mut()
@@ -362,7 +375,7 @@ fn build_response_from_cache(cached: CachedResponse, status: &'static str) -> Re
         }
     }
 
-    let mut response = builder.body(Full::new(cached.body)).unwrap();
+    let mut response = builder.body(full(cached.body)).unwrap();
 
     response
         .headers_mut()

--- a/rapina/src/error.rs
+++ b/rapina/src/error.rs
@@ -29,9 +29,7 @@ use serde::Serialize;
 use std::fmt;
 
 use crate::response::{APPLICATION_JSON, APPLICATION_PROBLEM_JSON, BoxBody, IntoResponse};
-use bytes::Bytes;
 use http::header::CONTENT_TYPE;
-use http_body_util::Full;
 
 /// Configuration for error response format.
 ///
@@ -431,7 +429,7 @@ impl IntoResponse for Error {
             http::Response::builder()
                 .status(self.0.status)
                 .header(CONTENT_TYPE, APPLICATION_PROBLEM_JSON)
-                .body(Full::new(Bytes::from(body)))
+                .body(crate::response::full(body))
                 .unwrap()
         } else {
             let response = standard::ErrorResponse {
@@ -447,7 +445,7 @@ impl IntoResponse for Error {
             http::Response::builder()
                 .status(self.0.status)
                 .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(Full::new(Bytes::from(body)))
+                .body(crate::response::full(body))
                 .unwrap()
         }
     }

--- a/rapina/src/extract/mod.rs
+++ b/rapina/src/extract/mod.rs
@@ -3,7 +3,6 @@
 //! Extractors are types that implement [`FromRequest`] or [`FromRequestParts`]
 //! and can be used as handler parameters to automatically parse request data.
 
-use bytes::Bytes;
 use http::Request;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
@@ -456,7 +455,7 @@ impl<T: serde::Serialize> IntoResponse for (http::StatusCode, Json<T>) {
         http::Response::builder()
             .status(self.0)
             .header(CONTENT_TYPE, APPLICATION_JSON)
-            .body(http_body_util::Full::new(Bytes::from(body)))
+            .body(crate::response::full(body))
             .unwrap()
     }
 }

--- a/rapina/src/health/endpoint.rs
+++ b/rapina/src/health/endpoint.rs
@@ -16,7 +16,7 @@ use hyper::body::Incoming;
 use crate::{
     extract::PathParams,
     health::config::HealthRegistry,
-    response::{APPLICATION_JSON, BoxBody},
+    response::{APPLICATION_JSON, BoxBody, full},
     state::AppState,
 };
 
@@ -36,9 +36,7 @@ pub async fn liveness_check(
     Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, APPLICATION_JSON)
-        .body(http_body_util::Full::new(bytes::Bytes::from(
-            serde_json::to_vec(&body).unwrap_or_default(),
-        )))
+        .body(full(serde_json::to_vec(&body).unwrap_or_default()))
         .unwrap()
 }
 
@@ -109,9 +107,7 @@ pub async fn readiness_check(
     Response::builder()
         .status(status)
         .header(CONTENT_TYPE, APPLICATION_JSON)
-        .body(http_body_util::Full::new(bytes::Bytes::from(
-            serde_json::to_vec(&body).unwrap_or_default(),
-        )))
+        .body(full(serde_json::to_vec(&body).unwrap_or_default()))
         .unwrap()
 }
 

--- a/rapina/src/introspection/endpoint.rs
+++ b/rapina/src/introspection/endpoint.rs
@@ -7,7 +7,7 @@ use hyper::body::Incoming;
 
 use crate::extract::PathParams;
 use crate::introspection::RouteInfo;
-use crate::response::{APPLICATION_JSON, BoxBody, IntoResponse};
+use crate::response::{APPLICATION_JSON, BoxBody, IntoResponse, full};
 use crate::state::AppState;
 
 /// Registry of route information stored in application state.
@@ -52,7 +52,7 @@ pub async fn list_routes(
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(http_body_util::Full::new(bytes::Bytes::from(json)))
+                .body(full(json))
                 .unwrap()
         }
         None => StatusCode::NOT_FOUND.into_response(),

--- a/rapina/src/introspection/llms_endpoint.rs
+++ b/rapina/src/introspection/llms_endpoint.rs
@@ -6,7 +6,7 @@ use http::{Request, Response, StatusCode, header::CONTENT_TYPE};
 use hyper::body::Incoming;
 
 use crate::extract::PathParams;
-use crate::response::{BoxBody, IntoResponse};
+use crate::response::{BoxBody, IntoResponse, full};
 use crate::state::AppState;
 
 /// Stores the pre-generated llms.txt content.
@@ -48,7 +48,7 @@ pub async fn llms_txt_handler(
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, "text/plain; charset=utf-8")
-                .body(http_body_util::Full::new(body))
+                .body(full(body))
                 .unwrap()
         }
         None => StatusCode::NOT_FOUND.into_response(),

--- a/rapina/src/metrics/prometheus.rs
+++ b/rapina/src/metrics/prometheus.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use bytes::Bytes;
 use http::{Request, Response, StatusCode};
-use http_body_util::Full;
 use hyper::body::Incoming;
 use prometheus::{
     CounterVec, Encoder, HistogramOpts, HistogramVec, IntGauge, Opts, Registry, TextEncoder,
@@ -98,12 +96,12 @@ pub async fn metrics_handler(
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, PROMETHEUS_TEXT_FORMAT)
-                .body(Full::new(Bytes::from(body)))
+                .body(crate::response::full(body))
                 .unwrap()
         }
         None => Response::builder()
             .status(StatusCode::SERVICE_UNAVAILABLE)
-            .body(Full::new(Bytes::new()))
+            .body(crate::response::empty())
             .unwrap(),
     }
 }

--- a/rapina/src/middleware/compression.rs
+++ b/rapina/src/middleware/compression.rs
@@ -1,15 +1,18 @@
 use std::io::Write;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use bytes::Bytes;
 use flate2::Compression;
 use flate2::write::{DeflateEncoder, GzEncoder};
 use http::{HeaderValue, Response, header};
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
 use hyper::Request;
-use hyper::body::Incoming;
+use hyper::body::{Body, Frame, Incoming, SizeHint};
+use pin_project_lite::pin_project;
 
 use crate::context::RequestContext;
-use crate::response::{APPLICATION_JSON, BoxBody};
+use crate::response::{APPLICATION_JSON, BodyError, BoxBody, empty, full};
 
 use super::{BoxFuture, Middleware, Next};
 
@@ -153,6 +156,19 @@ impl Middleware for CompressionMiddleware {
 
             let response = next.run(req).await;
 
+            // SSE bodies must never be compressed: gzip across event boundaries
+            // breaks framing at proxies. See Starlette's GZipMiddleware (commit
+            // a9a8dab, Feb 2025) for the same exclusion.
+            let is_event_stream = response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.starts_with("text/event-stream"))
+                .unwrap_or(false);
+            if is_event_stream {
+                return response;
+            }
+
             let algorithm = match algorithm {
                 Some(alg)
                     if !Self::is_already_encoded(&response)
@@ -165,28 +181,46 @@ impl Middleware for CompressionMiddleware {
                 _ => return response,
             };
 
+            // Streaming path: per-chunk compression with persistent encoder
+            // state. We commit to compressing because the `min_size` guard
+            // and "not worth it" check from the buffered path don't apply,
+            // the total size isn't knowable in advance.
+            let level = Compression::new(self.config.level);
+            if response.body().size_hint().exact().is_none() {
+                let (mut parts, body) = response.into_parts();
+                let wrapped = StreamingCompressedBody::new(body, algorithm, level).boxed_unsync();
+                parts.headers.insert(
+                    header::CONTENT_ENCODING,
+                    HeaderValue::from_static(algorithm.content_encoding()),
+                );
+                parts.headers.remove(header::CONTENT_LENGTH);
+                parts
+                    .headers
+                    .insert(header::VARY, HeaderValue::from_static("Accept-Encoding"));
+                return Response::from_parts(parts, wrapped);
+            }
+
             let (parts, body) = response.into_parts();
             let body_bytes = match body.collect().await {
                 Ok(collected) => collected.to_bytes(),
-                Err(_) => return Response::from_parts(parts, Full::new(Bytes::new())),
+                Err(_) => return Response::from_parts(parts, empty()),
             };
 
             if body_bytes.len() < self.config.min_size {
-                return Response::from_parts(parts, Full::new(body_bytes));
+                return Response::from_parts(parts, full(body_bytes));
             }
 
-            let level = Compression::new(self.config.level);
             let compressed = match algorithm.compress(&body_bytes, level) {
                 Ok(data) => data,
-                Err(_) => return Response::from_parts(parts, Full::new(body_bytes)),
+                Err(_) => return Response::from_parts(parts, full(body_bytes)),
             };
 
             // not worth it
             if compressed.len() >= body_bytes.len() {
-                return Response::from_parts(parts, Full::new(body_bytes));
+                return Response::from_parts(parts, full(body_bytes));
             }
 
-            let mut response = Response::from_parts(parts, Full::new(Bytes::from(compressed)));
+            let mut response = Response::from_parts(parts, full(Bytes::from(compressed)));
             response.headers_mut().insert(
                 header::CONTENT_ENCODING,
                 HeaderValue::from_static(algorithm.content_encoding()),
@@ -198,6 +232,146 @@ impl Middleware for CompressionMiddleware {
 
             response
         })
+    }
+}
+
+pin_project! {
+    /// Streaming compressor wrapper. Owns the upstream body and a persistent
+    /// encoder; emits compressed chunks as upstream chunks arrive. Per Phase 3
+    /// of the streaming plan: large file streams should not be buffered.
+    struct StreamingCompressedBody {
+        #[pin]
+        inner: BoxBody,
+        encoder: Option<StreamingEncoder>,
+        tail: Option<Bytes>,
+        done: bool,
+    }
+}
+
+impl StreamingCompressedBody {
+    fn new(inner: BoxBody, algorithm: Algorithm, level: Compression) -> Self {
+        Self {
+            inner,
+            encoder: Some(StreamingEncoder::new(algorithm, level)),
+            tail: None,
+            done: false,
+        }
+    }
+}
+
+impl Body for StreamingCompressedBody {
+    type Data = Bytes;
+    type Error = BodyError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, BodyError>>> {
+        let mut this = self.project();
+
+        // Emit any leftover tail from a previous finish() before signalling end.
+        if let Some(tail) = this.tail.take() {
+            return Poll::Ready(Some(Ok(Frame::data(tail))));
+        }
+        if *this.done {
+            return Poll::Ready(None);
+        }
+
+        loop {
+            match this.inner.as_mut().poll_frame(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Err(e))) => {
+                    tracing::error!("compression upstream body yielded error: {}", e);
+                    return Poll::Ready(Some(Err(e)));
+                }
+                Poll::Ready(Some(Ok(frame))) => {
+                    if let Ok(data) = frame.into_data() {
+                        let encoder = this
+                            .encoder
+                            .as_mut()
+                            .expect("encoder present until upstream end");
+                        if let Err(e) = encoder.write(&data) {
+                            tracing::error!("compression encoder write failed: {}", e);
+                            return Poll::Ready(Some(Err(Box::new(e))));
+                        }
+                        let chunk = encoder.drain();
+                        if !chunk.is_empty() {
+                            return Poll::Ready(Some(Ok(Frame::data(chunk))));
+                        }
+                        // Encoder buffered internally; pull more from upstream.
+                        continue;
+                    }
+                    // Trailers/non-data frames: pass through.
+                    // (BoxBody from rapina never carries trailers today.)
+                    continue;
+                }
+                Poll::Ready(None) => {
+                    let encoder = match this.encoder.take() {
+                        Some(e) => e,
+                        None => {
+                            *this.done = true;
+                            return Poll::Ready(None);
+                        }
+                    };
+                    let tail = match encoder.finish() {
+                        Ok(bytes) => Bytes::from(bytes),
+                        Err(e) => {
+                            tracing::error!("compression encoder finish failed: {}", e);
+                            return Poll::Ready(Some(Err(Box::new(e))));
+                        }
+                    };
+                    *this.done = true;
+                    if tail.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Ready(Some(Ok(Frame::data(tail))));
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+enum StreamingEncoder {
+    Gzip(GzEncoder<Vec<u8>>),
+    Deflate(DeflateEncoder<Vec<u8>>),
+}
+
+impl StreamingEncoder {
+    fn new(alg: Algorithm, level: Compression) -> Self {
+        match alg {
+            Algorithm::Gzip => Self::Gzip(GzEncoder::new(Vec::new(), level)),
+            Algorithm::Deflate => Self::Deflate(DeflateEncoder::new(Vec::new(), level)),
+        }
+    }
+
+    fn write(&mut self, data: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Gzip(e) => e.write_all(data),
+            Self::Deflate(e) => e.write_all(data),
+        }
+    }
+
+    /// Take whatever output bytes the encoder has buffered so far. Empty if
+    /// the encoder is still accumulating internally. Reuses the buffer's
+    /// capacity across drains so long streams don't reallocate per chunk.
+    fn drain(&mut self) -> Bytes {
+        let buf = match self {
+            Self::Gzip(e) => e.get_mut(),
+            Self::Deflate(e) => e.get_mut(),
+        };
+        let cap = buf.capacity();
+        Bytes::from(std::mem::replace(buf, Vec::with_capacity(cap)))
+    }
+
+    fn finish(self) -> std::io::Result<Vec<u8>> {
+        match self {
+            Self::Gzip(e) => e.finish(),
+            Self::Deflate(e) => e.finish(),
+        }
     }
 }
 

--- a/rapina/src/middleware/cors.rs
+++ b/rapina/src/middleware/cors.rs
@@ -138,7 +138,7 @@ impl CorsMiddleware {
 
         builder = builder.header(header::VARY, "Origin");
 
-        builder.body(BoxBody::default()).unwrap()
+        builder.body(crate::response::empty()).unwrap()
     }
 
     fn add_cors_headers(&self, response: &mut Response<BoxBody>, origin: &Option<HeaderValue>) {
@@ -367,7 +367,7 @@ mod tests {
     fn empty_response() -> Response<BoxBody> {
         Response::builder()
             .status(StatusCode::OK)
-            .body(BoxBody::default())
+            .body(crate::response::empty())
             .unwrap()
     }
 

--- a/rapina/src/openapi/endpoint.rs
+++ b/rapina/src/openapi/endpoint.rs
@@ -8,7 +8,7 @@ use hyper::body::Incoming;
 use crate::{
     extract::PathParams,
     openapi::OpenApiSpec,
-    response::{APPLICATION_JSON, BoxBody},
+    response::{APPLICATION_JSON, BoxBody, full},
     state::AppState,
 };
 
@@ -44,14 +44,14 @@ pub async fn openapi_spec(
             Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, APPLICATION_JSON)
-                .body(http_body_util::Full::new(bytes::Bytes::from(json)))
+                .body(full(json))
                 .unwrap()
         }
         None => Response::builder()
             .status(StatusCode::NOT_FOUND)
             .header(CONTENT_TYPE, APPLICATION_JSON)
-            .body(http_body_util::Full::new(bytes::Bytes::from(
-                r#"{"error": "OpenAPI spec not configured"}"#,
+            .body(full(bytes::Bytes::from_static(
+                br#"{"error": "OpenAPI spec not configured"}"#,
             )))
             .unwrap(),
     }

--- a/rapina/src/pagination.rs
+++ b/rapina/src/pagination.rs
@@ -36,8 +36,6 @@
 
 use std::sync::Arc;
 
-use bytes::Bytes;
-use http_body_util::Full;
 use schemars::JsonSchema;
 use sea_orm::{EntityTrait, PaginatorTrait, Select};
 use serde::{Deserialize, Serialize};
@@ -198,7 +196,7 @@ impl<T: Serialize> IntoResponse for Paginated<T> {
         http::Response::builder()
             .status(http::StatusCode::OK)
             .header("content-type", "application/json")
-            .body(Full::new(Bytes::from(body)))
+            .body(crate::response::full(body))
             .unwrap()
     }
 }

--- a/rapina/src/response/mod.rs
+++ b/rapina/src/response/mod.rs
@@ -3,9 +3,13 @@
 //! This module defines the [`IntoResponse`] trait which allows various types
 //! to be converted into HTTP responses.
 
+mod stream;
+
+pub use stream::{SseEvent, SseResponse, StreamResponse};
+
 use bytes::Bytes;
 use http::{Response, StatusCode, header::CONTENT_TYPE};
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full, combinators::UnsyncBoxBody};
 
 pub(crate) const APPLICATION_JSON: &str = "application/json";
 pub(crate) const APPLICATION_PROBLEM_JSON: &str = "application/problem+json";
@@ -14,8 +18,39 @@ pub(crate) const FORM_CONTENT_TYPE: &str = "application/x-www-form-urlencoded";
 pub(crate) const PROMETHEUS_TEXT_FORMAT: &str = "text/plain; version=0.0.4; charset=utf-8";
 const TEXT_PLAIN_UTF8: &str = "text/plain; charset=utf-8";
 
+/// Error type for response body frames.
+///
+/// Part of the public middleware contract: any code that calls
+/// `body.collect().await` or polls frames from a Rapina response body
+/// receives this error type. Streaming response producers convert their
+/// own errors via `Box::new(err) as BodyError` or `err.into()`.
+pub type BodyError = Box<dyn std::error::Error + Send + Sync>;
+
 /// The body type used for HTTP responses.
-pub type BoxBody = Full<Bytes>;
+///
+/// A boxed [`http_body::Body`] trait object (`Send` but not `Sync`, matching
+/// axum's [`Body`](https://docs.rs/axum/latest/axum/body/struct.Body.html))
+/// so buffered bodies (via [`full`]) and streaming bodies (via
+/// `StreamResponse`/`SseResponse`) can share one response type. Most user
+/// streams are `Send` but not `Sync`, which rules out the `Sync`-required
+/// `BoxBody` variant.
+pub type BoxBody = UnsyncBoxBody<Bytes, BodyError>;
+
+/// Wrap a fully-buffered byte payload into a [`BoxBody`].
+///
+/// Use this in [`IntoResponse`] impls and middleware that produce a complete
+/// response body in one shot. `Bytes::from_static` flows through without
+/// allocation, preserving zero-copy for static payloads.
+pub fn full(bytes: impl Into<Bytes>) -> BoxBody {
+    Full::new(bytes.into())
+        .map_err(|never| match never {})
+        .boxed_unsync()
+}
+
+/// An empty [`BoxBody`].
+pub fn empty() -> BoxBody {
+    full(Bytes::new())
+}
 
 /// Trait for types that can be converted into an HTTP response.
 ///
@@ -55,7 +90,7 @@ impl IntoResponse for &str {
         Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, TEXT_PLAIN_UTF8)
-            .body(Full::new(Bytes::from(self.to_owned())))
+            .body(full(self.to_owned()))
             .unwrap()
     }
 }
@@ -65,7 +100,7 @@ impl IntoResponse for String {
         Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, TEXT_PLAIN_UTF8)
-            .body(Full::new(Bytes::from(self)))
+            .body(full(self))
             .unwrap()
     }
 }
@@ -91,17 +126,14 @@ impl IntoResponse for StaticStr {
         Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, TEXT_PLAIN_UTF8)
-            .body(Full::new(Bytes::from_static(self.0.as_bytes())))
+            .body(full(Bytes::from_static(self.0.as_bytes())))
             .unwrap()
     }
 }
 
 impl IntoResponse for StatusCode {
     fn into_response(self) -> Response<BoxBody> {
-        Response::builder()
-            .status(self)
-            .body(Full::new(Bytes::new()))
-            .unwrap()
+        Response::builder().status(self).body(empty()).unwrap()
     }
 }
 
@@ -110,7 +142,7 @@ impl IntoResponse for (StatusCode, String) {
         Response::builder()
             .status(self.0)
             .header(CONTENT_TYPE, TEXT_PLAIN_UTF8)
-            .body(Full::new(Bytes::from(self.1)))
+            .body(full(self.1))
             .unwrap()
     }
 }
@@ -128,6 +160,7 @@ impl<T: IntoResponse, E: IntoResponse> IntoResponse for std::result::Result<T, E
 mod tests {
     use super::*;
     use http_body_util::BodyExt;
+    use hyper::body::Body;
 
     #[tokio::test]
     async fn test_str_into_response() {
@@ -205,7 +238,7 @@ mod tests {
     fn test_response_into_response_identity() {
         let original = Response::builder()
             .status(StatusCode::ACCEPTED)
-            .body(Full::new(Bytes::from("test")))
+            .body(full("test"))
             .unwrap();
 
         let response = original.into_response();
@@ -257,5 +290,20 @@ mod tests {
         // Bytes::from_static produces a Bytes that references the original
         // static data without allocating. Verify the content is correct.
         assert_eq!(&body[..], b"static content");
+    }
+
+    #[test]
+    fn test_buffered_body_reports_exact_size_hint() {
+        // Streaming detection contract: full() produces a body whose
+        // size_hint().exact() is Some, while StreamBody-backed bodies
+        // (added in Phase 2) report None.
+        let body = full("hello");
+        assert_eq!(body.size_hint().exact(), Some(5));
+    }
+
+    #[test]
+    fn test_empty_body_reports_zero_size_hint() {
+        let body = empty();
+        assert_eq!(body.size_hint().exact(), Some(0));
     }
 }

--- a/rapina/src/response/stream.rs
+++ b/rapina/src/response/stream.rs
@@ -1,0 +1,849 @@
+//! Streaming response bodies: raw byte streams and Server-Sent Events.
+//!
+//! Both types implement [`IntoResponse`] and produce a [`BoxBody`] that
+//! `compression` and `cache` middleware will skip via either the SSE
+//! content-type rule or the `size_hint().exact() == None` rule.
+
+use std::fmt::Write as _;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_core::Stream;
+use http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode, header};
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::{Body, Frame, SizeHint};
+use pin_project_lite::pin_project;
+
+use super::{BodyError, BoxBody, IntoResponse};
+
+type BoxStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
+type SseStream = BoxStream<Result<SseEvent, BodyError>>;
+type ByteStream = BoxStream<Result<Bytes, BodyError>>;
+
+/// Streaming response of arbitrary chunked bytes.
+///
+/// Wraps any [`Stream`] of `Result<Bytes, BodyError>` so frames are written
+/// to the wire as they arrive. Content-Type defaults to
+/// `application/octet-stream`; override with [`StreamResponse::content_type`].
+///
+/// ```ignore
+/// use rapina::response::{BodyError, StreamResponse};
+/// use bytes::Bytes;
+///
+/// async fn handler() -> StreamResponse {
+///     let stream = async_stream::stream! {
+///         yield Ok::<_, BodyError>(Bytes::from_static(b"hello "));
+///         yield Ok(Bytes::from_static(b"world"));
+///     };
+///     StreamResponse::new(stream)
+/// }
+/// ```
+pub struct StreamResponse {
+    stream: ByteStream,
+    status: StatusCode,
+    content_type: HeaderValue,
+    extra_headers: HeaderMap,
+}
+
+impl StreamResponse {
+    /// Wrap a stream of `Result<Bytes, BodyError>` into a streaming response.
+    pub fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<Bytes, BodyError>> + Send + 'static,
+    {
+        Self {
+            stream: Box::pin(stream),
+            status: StatusCode::OK,
+            content_type: HeaderValue::from_static("application/octet-stream"),
+            extra_headers: HeaderMap::new(),
+        }
+    }
+
+    /// Build a streaming response from a `tokio::sync::mpsc::Receiver`. The
+    /// receiver carries `Result<Bytes, BodyError>` so producers can signal
+    /// errors mid-stream. When the sender side drops, the stream ends.
+    ///
+    /// ```ignore
+    /// let (tx, rx) = tokio::sync::mpsc::channel(32);
+    /// tokio::spawn(async move {
+    ///     tx.send(Ok(Bytes::from_static(b"chunk"))).await.unwrap();
+    /// });
+    /// StreamResponse::from_receiver(rx)
+    /// ```
+    pub fn from_receiver(rx: tokio::sync::mpsc::Receiver<Result<Bytes, BodyError>>) -> Self {
+        Self::new(ReceiverStream::new(rx))
+    }
+
+    pub fn status(mut self, status: StatusCode) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Set the response `Content-Type`.
+    ///
+    /// Accepts anything convertible to a [`HeaderValue`], so callers can pass
+    /// a `&str`, a `String`, or a pre-built `HeaderValue`. Conversion failure
+    /// at construction time panics; if you need fallible construction, build
+    /// the `HeaderValue` yourself and pass it in.
+    pub fn content_type<V>(mut self, content_type: V) -> Self
+    where
+        V: TryInto<HeaderValue>,
+        V::Error: std::fmt::Debug,
+    {
+        self.content_type = content_type
+            .try_into()
+            .expect("StreamResponse::content_type: invalid header value");
+        self
+    }
+
+    /// Add an arbitrary response header. Useful for `Content-Disposition`,
+    /// `ETag`, custom headers, etc. Mirrors the API of `Response::builder()`.
+    pub fn header<K, V>(mut self, name: K, value: V) -> Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: std::fmt::Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: std::fmt::Debug,
+    {
+        let name = name
+            .try_into()
+            .expect("StreamResponse::header: invalid header name");
+        let value = value
+            .try_into()
+            .expect("StreamResponse::header: invalid header value");
+        self.extra_headers.append(name, value);
+        self
+    }
+}
+
+impl IntoResponse for StreamResponse {
+    fn into_response(self) -> Response<BoxBody> {
+        let frames = FrameStream { inner: self.stream };
+        let body = StreamBody::new(frames).boxed_unsync();
+        let mut response = Response::builder()
+            .status(self.status)
+            .header(header::CONTENT_TYPE, self.content_type)
+            .body(body)
+            .expect("status and content-type are pre-validated");
+        response.headers_mut().extend(self.extra_headers);
+        response
+    }
+}
+
+pin_project! {
+    /// Adapter: lifts `Stream<Item = Result<Bytes, E>>` to
+    /// `Stream<Item = Result<Frame<Bytes>, E>>` without pulling `futures-util`.
+    struct FrameStream<S> {
+        #[pin]
+        inner: S,
+    }
+}
+
+impl<S> Stream for FrameStream<S>
+where
+    S: Stream<Item = Result<Bytes, BodyError>>,
+{
+    type Item = Result<Frame<Bytes>, BodyError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.inner.poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Ok(b))) => Poll::Ready(Some(Ok(Frame::data(b)))),
+            Poll::Ready(Some(Err(e))) => {
+                tracing::error!("stream response producer yielded error: {}", e);
+                Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
+}
+
+/// One Server-Sent Event.
+///
+/// Build with [`SseEvent::data`] for a normal event, [`SseEvent::comment`]
+/// for a comment-only event (browsers ignore comments, useful for keep-alive
+/// or operator annotations), or chain [`SseEvent::with_comment`] on top of a
+/// data event.
+///
+/// Multi-line `data` produces multiple `data:` lines per the EventSource spec.
+#[derive(Clone, Debug, Default)]
+pub struct SseEvent {
+    data: Option<String>,
+    comment: Option<String>,
+    event: Option<String>,
+    id: Option<String>,
+    retry: Option<u32>,
+}
+
+impl SseEvent {
+    /// Event with a data payload. The most common form.
+    pub fn data(data: impl Into<String>) -> Self {
+        Self {
+            data: Some(data.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Comment-only event (`: <text>\n\n`). Browsers ignore comments per the
+    /// EventSource spec; useful for human-readable annotations in the stream
+    /// and for proxies that need traffic to keep the connection warm.
+    pub fn comment(text: impl Into<String>) -> Self {
+        Self {
+            comment: Some(text.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Attach a comment to a data event. Renders as a `:` line before the
+    /// `data:` lines in the encoded output.
+    pub fn with_comment(mut self, text: impl Into<String>) -> Self {
+        self.comment = Some(text.into());
+        self
+    }
+
+    pub fn event(mut self, name: impl Into<String>) -> Self {
+        self.event = Some(name.into());
+        self
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn retry(mut self, ms: u32) -> Self {
+        self.retry = Some(ms);
+        self
+    }
+
+    /// Encode this event in the `text/event-stream` wire format.
+    ///
+    /// Field order: `comment`, `event`, `id`, `retry`, `data` (one line per
+    /// line of input), terminated by a blank line. LF only, no CR.
+    pub fn encode(&self) -> Bytes {
+        let mut out = String::with_capacity(self.data.as_deref().map_or(0, str::len) + 32);
+        if let Some(c) = &self.comment {
+            for line in c.split('\n') {
+                out.push_str(": ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        if let Some(name) = &self.event {
+            out.push_str("event: ");
+            out.push_str(name);
+            out.push('\n');
+        }
+        if let Some(id) = &self.id {
+            out.push_str("id: ");
+            out.push_str(id);
+            out.push('\n');
+        }
+        if let Some(retry) = self.retry {
+            let _ = writeln!(out, "retry: {retry}");
+        }
+        if let Some(data) = &self.data {
+            for line in data.split('\n') {
+                out.push_str("data: ");
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        out.push('\n');
+        Bytes::from(out)
+    }
+}
+
+const SSE_KEEP_ALIVE_DEFAULT: Duration = Duration::from_secs(15);
+const SSE_KEEP_ALIVE_FRAME_DEFAULT: &[u8] = b":\n\n";
+
+/// Server-Sent Events response.
+///
+/// Wraps a stream of `Result<SseEvent, BodyError>` and interleaves
+/// keep-alive comment frames when the user stream is idle for longer than
+/// the configured interval. Defaults: 15 second interval, `:\n\n` frame.
+/// Pass `None` to [`SseResponse::keep_alive`] to disable, or
+/// [`SseResponse::keep_alive_text`] to customize the frame text.
+///
+/// Sets `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and
+/// `X-Accel-Buffering: no` so reverse proxies do not buffer the stream.
+pub struct SseResponse {
+    stream: SseStream,
+    status: StatusCode,
+    keep_alive: Option<Duration>,
+    keep_alive_frame: Bytes,
+    extra_headers: HeaderMap,
+}
+
+impl SseResponse {
+    /// Wrap a stream of `Result<SseEvent, BodyError>`.
+    pub fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<SseEvent, BodyError>> + Send + 'static,
+    {
+        Self {
+            stream: Box::pin(stream),
+            status: StatusCode::OK,
+            keep_alive: Some(SSE_KEEP_ALIVE_DEFAULT),
+            keep_alive_frame: Bytes::from_static(SSE_KEEP_ALIVE_FRAME_DEFAULT),
+            extra_headers: HeaderMap::new(),
+        }
+    }
+
+    /// Build an SSE response from any iterator of events. Convenient when
+    /// you already have a finite list of events to send and don't want to
+    /// reach for `async_stream::stream!`.
+    ///
+    /// ```ignore
+    /// let events = vec![SseEvent::data("a"), SseEvent::data("b")];
+    /// SseResponse::from_events(events)
+    /// ```
+    pub fn from_events<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = SseEvent>,
+        I::IntoIter: Send + 'static,
+    {
+        Self::new(IterStream::new(iter.into_iter()))
+    }
+
+    /// Build an SSE response from a `tokio::sync::mpsc::Receiver`. The
+    /// receiver carries `Result<SseEvent, BodyError>` so producers can
+    /// signal errors mid-stream. When the sender drops, the stream ends.
+    ///
+    /// ```ignore
+    /// let (tx, rx) = tokio::sync::mpsc::channel(32);
+    /// tokio::spawn(async move {
+    ///     tx.send(Ok(SseEvent::data("hi"))).await.unwrap();
+    /// });
+    /// SseResponse::from_receiver(rx)
+    /// ```
+    pub fn from_receiver(rx: tokio::sync::mpsc::Receiver<Result<SseEvent, BodyError>>) -> Self {
+        Self::new(ReceiverStream::new(rx))
+    }
+
+    pub fn status(mut self, status: StatusCode) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Set or disable the keep-alive interval. Default is 15 seconds.
+    pub fn keep_alive(mut self, interval: Option<Duration>) -> Self {
+        self.keep_alive = interval;
+        self
+    }
+
+    /// Customize the keep-alive payload. Default is `:\n\n` (an empty
+    /// EventSource-spec comment, which browsers ignore). The payload is
+    /// always wrapped in the comment prefix and trailing blank line, so
+    /// pass just the comment text. For example, `keep_alive_text("ping")`
+    /// emits `: ping\n\n`.
+    pub fn keep_alive_text(mut self, text: impl AsRef<str>) -> Self {
+        let s = text.as_ref();
+        let mut out = String::with_capacity(s.len() + 4);
+        out.push_str(": ");
+        out.push_str(s);
+        out.push_str("\n\n");
+        self.keep_alive_frame = Bytes::from(out);
+        self
+    }
+
+    /// Add an arbitrary response header.
+    pub fn header<K, V>(mut self, name: K, value: V) -> Self
+    where
+        K: TryInto<HeaderName>,
+        K::Error: std::fmt::Debug,
+        V: TryInto<HeaderValue>,
+        V::Error: std::fmt::Debug,
+    {
+        let name = name
+            .try_into()
+            .expect("SseResponse::header: invalid header name");
+        let value = value
+            .try_into()
+            .expect("SseResponse::header: invalid header value");
+        self.extra_headers.append(name, value);
+        self
+    }
+}
+
+impl IntoResponse for SseResponse {
+    fn into_response(self) -> Response<BoxBody> {
+        let body = SseBody {
+            stream: self.stream,
+            keep_alive: self.keep_alive.map(KeepAliveState::new),
+            keep_alive_frame: self.keep_alive_frame,
+        }
+        .boxed_unsync();
+        let mut response = Response::builder()
+            .status(self.status)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CACHE_CONTROL, "no-cache")
+            .header("X-Accel-Buffering", "no")
+            .body(body)
+            .expect("status and content-type are pre-validated");
+        response.headers_mut().extend(self.extra_headers);
+        response
+    }
+}
+
+struct KeepAliveState {
+    interval: Duration,
+    sleep: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl KeepAliveState {
+    fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            sleep: Box::pin(tokio::time::sleep(interval)),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.sleep
+            .as_mut()
+            .reset(tokio::time::Instant::now() + self.interval);
+    }
+}
+
+pin_project! {
+    /// Custom [`Body`] impl that owns the user stream and the keep-alive timer.
+    ///
+    /// Polling order on each frame: try the user stream first; on `Pending`,
+    /// poll the keep-alive timer; if the timer fires, emit the keep-alive
+    /// payload and reset. Logs a debug line when dropped so operators can
+    /// spot client disconnects.
+    struct SseBody<S> {
+        #[pin]
+        stream: S,
+        keep_alive: Option<KeepAliveState>,
+        keep_alive_frame: Bytes,
+    }
+
+    impl<S> PinnedDrop for SseBody<S> {
+        fn drop(this: Pin<&mut Self>) {
+            tracing::debug!("SSE body dropped (client disconnect or stream completion)");
+            let _ = this;
+        }
+    }
+}
+
+impl<S> Body for SseBody<S>
+where
+    S: Stream<Item = Result<SseEvent, BodyError>> + Send + 'static,
+{
+    type Data = Bytes;
+    type Error = BodyError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, BodyError>>> {
+        let this = self.project();
+
+        match this.stream.poll_next(cx) {
+            Poll::Ready(Some(Ok(event))) => {
+                if let Some(ka) = this.keep_alive.as_mut() {
+                    ka.reset();
+                }
+                Poll::Ready(Some(Ok(Frame::data(event.encode()))))
+            }
+            Poll::Ready(Some(Err(e))) => {
+                tracing::error!("SSE producer yielded error: {}", e);
+                Poll::Ready(Some(Err(e)))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => match this.keep_alive.as_mut() {
+                Some(ka) => match ka.sleep.as_mut().poll(cx) {
+                    Poll::Ready(()) => {
+                        ka.reset();
+                        Poll::Ready(Some(Ok(Frame::data(this.keep_alive_frame.clone()))))
+                    }
+                    Poll::Pending => Poll::Pending,
+                },
+                None => Poll::Pending,
+            },
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+// Internal stream adapters. Hand-rolled so we don't need tokio-stream as a
+// runtime dep just for these two cases.
+
+pin_project! {
+    /// Wraps a `tokio::sync::mpsc::Receiver<T>` as a `Stream<Item = T>`.
+    struct ReceiverStream<T> {
+        rx: tokio::sync::mpsc::Receiver<T>,
+    }
+}
+
+impl<T> ReceiverStream<T> {
+    fn new(rx: tokio::sync::mpsc::Receiver<T>) -> Self {
+        Self { rx }
+    }
+}
+
+impl<T> Stream for ReceiverStream<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.project().rx.poll_recv(cx)
+    }
+}
+
+pin_project! {
+    /// Wraps an iterator as a `Stream<Item = Result<Item, BodyError>>`. Used
+    /// for `SseResponse::from_events`.
+    struct IterStream<I, T>
+    where
+        I: Iterator<Item = T>,
+    {
+        iter: I,
+    }
+}
+
+impl<I> IterStream<I, I::Item>
+where
+    I: Iterator,
+{
+    fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<I, T> Stream for IterStream<I, T>
+where
+    I: Iterator<Item = T>,
+{
+    type Item = Result<T, BodyError>;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        Poll::Ready(this.iter.next().map(Ok))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::poll_fn;
+    use std::marker::PhantomData;
+
+    /// Stream that yields nothing and completes immediately.
+    struct EmptyStream<T>(PhantomData<T>);
+    impl<T> Stream for EmptyStream<T> {
+        type Item = T;
+        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
+            Poll::Ready(None)
+        }
+    }
+    fn empty<T>() -> EmptyStream<T> {
+        EmptyStream(PhantomData)
+    }
+
+    /// Stream that is permanently pending.
+    struct PendingStream<T>(PhantomData<T>);
+    impl<T> Stream for PendingStream<T> {
+        type Item = T;
+        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
+            Poll::Pending
+        }
+    }
+    fn pending<T>() -> PendingStream<T> {
+        PendingStream(PhantomData)
+    }
+
+    #[test]
+    fn test_sse_event_data_only() {
+        let bytes = SseEvent::data("hello").encode();
+        assert_eq!(&bytes[..], b"data: hello\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_multiline_data() {
+        let bytes = SseEvent::data("line1\nline2").encode();
+        assert_eq!(&bytes[..], b"data: line1\ndata: line2\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_with_event_name() {
+        let bytes = SseEvent::data("payload").event("update").encode();
+        assert_eq!(&bytes[..], b"event: update\ndata: payload\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_with_id() {
+        let bytes = SseEvent::data("payload").id("42").encode();
+        assert_eq!(&bytes[..], b"id: 42\ndata: payload\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_with_retry() {
+        let bytes = SseEvent::data("payload").retry(5000).encode();
+        assert_eq!(&bytes[..], b"retry: 5000\ndata: payload\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_full() {
+        let bytes = SseEvent::data("payload")
+            .event("update")
+            .id("7")
+            .retry(1000)
+            .encode();
+        assert_eq!(
+            &bytes[..],
+            b"event: update\nid: 7\nretry: 1000\ndata: payload\n\n"
+        );
+    }
+
+    #[test]
+    fn test_sse_event_comment_only() {
+        let bytes = SseEvent::comment("debug-marker").encode();
+        assert_eq!(&bytes[..], b": debug-marker\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_data_with_comment() {
+        let bytes = SseEvent::data("payload").with_comment("annotated").encode();
+        assert_eq!(&bytes[..], b": annotated\ndata: payload\n\n");
+    }
+
+    #[test]
+    fn test_sse_event_multiline_comment() {
+        let bytes = SseEvent::comment("line1\nline2").encode();
+        assert_eq!(&bytes[..], b": line1\n: line2\n\n");
+    }
+
+    #[tokio::test]
+    async fn test_stream_response_size_hint_is_none() {
+        let s = empty::<Result<Bytes, BodyError>>();
+        let resp = StreamResponse::new(s).into_response();
+        assert_eq!(resp.body().size_hint().exact(), None);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/octet-stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_response_content_type_setters() {
+        let resp = StreamResponse::new(empty::<Result<Bytes, BodyError>>())
+            .content_type("application/pdf")
+            .into_response();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/pdf"
+        );
+
+        let dynamic = HeaderValue::from_str("application/x-custom").unwrap();
+        let resp = StreamResponse::new(empty::<Result<Bytes, BodyError>>())
+            .content_type(dynamic)
+            .into_response();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/x-custom"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_response_extra_headers() {
+        let resp = StreamResponse::new(empty::<Result<Bytes, BodyError>>())
+            .header("content-disposition", "attachment; filename=\"x.pdf\"")
+            .header("etag", "\"abc\"")
+            .into_response();
+        assert_eq!(
+            resp.headers().get("content-disposition").unwrap(),
+            "attachment; filename=\"x.pdf\""
+        );
+        assert_eq!(resp.headers().get("etag").unwrap(), "\"abc\"");
+    }
+
+    #[tokio::test]
+    async fn test_sse_response_headers_and_size_hint() {
+        let resp = SseResponse::new(empty::<Result<SseEvent, BodyError>>()).into_response();
+        assert_eq!(resp.body().size_hint().exact(), None);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-cache"
+        );
+        assert_eq!(resp.headers().get("X-Accel-Buffering").unwrap(), "no");
+    }
+
+    #[tokio::test]
+    async fn test_sse_response_extra_headers() {
+        let resp = SseResponse::new(empty::<Result<SseEvent, BodyError>>())
+            .header("x-trace-id", "abc123")
+            .into_response();
+        assert_eq!(resp.headers().get("x-trace-id").unwrap(), "abc123");
+    }
+
+    /// Regression: HeaderMap iteration yields `(None, value)` for repeated header
+    /// names, so naive `filter_map` on `Option<HeaderName>` drops every value
+    /// after the first. Both response types must round-trip multi-value headers.
+    #[tokio::test]
+    async fn test_stream_response_preserves_multi_value_headers() {
+        let resp = StreamResponse::new(empty::<Result<Bytes, BodyError>>())
+            .header(header::SET_COOKIE, "session=abc; Path=/")
+            .header(header::SET_COOKIE, "csrf=xyz; Path=/")
+            .into_response();
+        let cookies: Vec<_> = resp.headers().get_all(header::SET_COOKIE).iter().collect();
+        assert_eq!(cookies.len(), 2, "both Set-Cookie values must survive");
+        assert!(
+            cookies
+                .iter()
+                .any(|v| v.to_str().unwrap().contains("session=abc"))
+        );
+        assert!(
+            cookies
+                .iter()
+                .any(|v| v.to_str().unwrap().contains("csrf=xyz"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sse_response_preserves_multi_value_headers() {
+        let resp = SseResponse::new(empty::<Result<SseEvent, BodyError>>())
+            .header(header::SET_COOKIE, "session=abc; Path=/")
+            .header(header::SET_COOKIE, "csrf=xyz; Path=/")
+            .into_response();
+        let cookies: Vec<_> = resp.headers().get_all(header::SET_COOKIE).iter().collect();
+        assert_eq!(cookies.len(), 2, "both Set-Cookie values must survive");
+    }
+
+    #[tokio::test]
+    async fn test_sse_response_status_setter() {
+        let resp = SseResponse::new(empty::<Result<SseEvent, BodyError>>())
+            .status(StatusCode::ACCEPTED)
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    }
+
+    /// Drives `SseBody` directly: idle producer + short keep_alive must yield
+    /// a `:\n\n` frame within roughly the keep-alive interval.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sse_keep_alive_emits_default_comment_frame_when_idle() {
+        let body = SseBody {
+            stream: pending::<Result<SseEvent, BodyError>>(),
+            keep_alive: Some(KeepAliveState::new(Duration::from_millis(50))),
+            keep_alive_frame: Bytes::from_static(SSE_KEEP_ALIVE_FRAME_DEFAULT),
+        };
+        let mut body = std::pin::pin!(body);
+        let frame: Option<Result<Frame<Bytes>, BodyError>> =
+            poll_fn(|cx| body.as_mut().poll_frame(cx)).await;
+        let frame = frame
+            .expect("expected a frame")
+            .expect("frame yielded error");
+        let data = frame.into_data().expect("expected data frame");
+        assert_eq!(&data[..], b":\n\n");
+    }
+
+    /// Custom keep-alive payload renders as `: <text>\n\n`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sse_keep_alive_text_emits_custom_comment_frame() {
+        let body = SseBody {
+            stream: pending::<Result<SseEvent, BodyError>>(),
+            keep_alive: Some(KeepAliveState::new(Duration::from_millis(50))),
+            keep_alive_frame: {
+                // Construct the same way the public setter does.
+                let s = "ping";
+                let mut out = String::with_capacity(s.len() + 4);
+                out.push_str(": ");
+                out.push_str(s);
+                out.push_str("\n\n");
+                Bytes::from(out)
+            },
+        };
+        let mut body = std::pin::pin!(body);
+        let frame: Option<Result<Frame<Bytes>, BodyError>> =
+            poll_fn(|cx| body.as_mut().poll_frame(cx)).await;
+        let frame = frame
+            .expect("expected a frame")
+            .expect("frame yielded error");
+        let data = frame.into_data().expect("expected data frame");
+        assert_eq!(&data[..], b": ping\n\n");
+    }
+
+    /// Verify the public setter produces the right keep-alive frame.
+    #[test]
+    fn test_keep_alive_text_setter_builds_correct_frame() {
+        let resp = SseResponse::new(empty::<Result<SseEvent, BodyError>>()).keep_alive_text("ping");
+        assert_eq!(&resp.keep_alive_frame[..], b": ping\n\n");
+    }
+
+    /// Producer error path: yield Err and observe the body returning Some(Err).
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sse_propagates_producer_error() {
+        let s = async_stream::stream! {
+            yield Err(Box::new(std::io::Error::other("boom")) as BodyError);
+        };
+        let body = SseBody {
+            stream: s,
+            keep_alive: None,
+            keep_alive_frame: Bytes::from_static(SSE_KEEP_ALIVE_FRAME_DEFAULT),
+        };
+        let mut body = std::pin::pin!(body);
+        let frame: Option<Result<Frame<Bytes>, BodyError>> =
+            poll_fn(|cx| body.as_mut().poll_frame(cx)).await;
+        match frame {
+            Some(Err(e)) => assert!(e.to_string().contains("boom")),
+            Some(Ok(_)) => panic!("expected error, got data frame"),
+            None => panic!("expected error, got end of stream"),
+        }
+    }
+
+    /// Round-trip a finite list of events through `SseResponse::from_events`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sse_from_events_emits_events_in_order() {
+        let resp =
+            SseResponse::from_events(vec![SseEvent::data("first"), SseEvent::data("second")])
+                .keep_alive(None)
+                .into_response();
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let s = std::str::from_utf8(&body_bytes).unwrap();
+        assert!(s.contains("data: first"));
+        assert!(s.contains("data: second"));
+        assert!(s.find("first").unwrap() < s.find("second").unwrap());
+    }
+
+    /// Round-trip a tokio mpsc channel through `SseResponse::from_receiver`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_sse_from_receiver() {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tokio::spawn(async move {
+            tx.send(Ok(SseEvent::data("via channel"))).await.unwrap();
+            // dropping tx ends the stream
+        });
+        let resp = SseResponse::from_receiver(rx)
+            .keep_alive(None)
+            .into_response();
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(body_bytes.windows(11).any(|w| w == b"via channel"));
+    }
+
+    /// Round-trip a tokio mpsc channel through `StreamResponse::from_receiver`.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_stream_from_receiver() {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        tokio::spawn(async move {
+            tx.send(Ok(Bytes::from_static(b"via channel")))
+                .await
+                .unwrap();
+        });
+        let resp = StreamResponse::from_receiver(rx)
+            .content_type("text/plain")
+            .into_response();
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body_bytes[..], b"via channel");
+    }
+}

--- a/rapina/src/testing/client.rs
+++ b/rapina/src/testing/client.rs
@@ -391,8 +391,8 @@ mod tests {
                     http::Response::builder()
                         .status(StatusCode::OK)
                         .header(http::header::CONTENT_TYPE, APPLICATION_JSON)
-                        .body(http_body_util::Full::new(bytes::Bytes::from(
-                            r#"{"id":1,"name":"test"}"#,
+                        .body(crate::response::full(bytes::Bytes::from_static(
+                            br#"{"id":1,"name":"test"}"#,
                         )))
                         .unwrap()
                 }),

--- a/rapina/src/websocket.rs
+++ b/rapina/src/websocket.rs
@@ -64,6 +64,8 @@ impl FromRequest for WebSocketUpgrade {
         }
         let (response, websocket) = hyper_tungstenite::upgrade(&mut req, None)
             .map_err(|e| Error::internal(format!("WebSocket upgrade failed: {e}")))?;
+        let (parts, _) = response.into_parts();
+        let response = Response::from_parts(parts, crate::response::empty());
         Ok(Self {
             response,
             websocket,

--- a/rapina/tests/cache.rs
+++ b/rapina/tests/cache.rs
@@ -17,7 +17,7 @@ async fn test_cache_miss_then_hit() {
                 let mut response = http::Response::builder()
                     .status(StatusCode::OK)
                     .header("content-type", "application/json")
-                    .body(http_body_util::Full::new(bytes::Bytes::from(
+                    .body(rapina::response::full(bytes::Bytes::from(
                         r#"{"value":42}"#,
                     )))
                     .unwrap();
@@ -54,7 +54,7 @@ async fn test_cache_strips_internal_ttl_header() {
             Router::new().route(http::Method::GET, "/data", |_, _, _| async {
                 let mut response = http::Response::builder()
                     .status(StatusCode::OK)
-                    .body(http_body_util::Full::new(bytes::Bytes::from("ok")))
+                    .body(rapina::response::full(bytes::Bytes::from("ok")))
                     .unwrap();
                 response
                     .headers_mut()
@@ -116,7 +116,7 @@ async fn test_mutation_invalidates_cache() {
                 .route(http::Method::GET, "/items", |_, _, _| async {
                     let mut response = http::Response::builder()
                         .status(StatusCode::OK)
-                        .body(http_body_util::Full::new(bytes::Bytes::from("items")))
+                        .body(rapina::response::full(bytes::Bytes::from("items")))
                         .unwrap();
                     response
                         .headers_mut()
@@ -160,7 +160,7 @@ async fn test_cache_preserves_response_headers() {
                     .status(StatusCode::OK)
                     .header("content-type", "application/json")
                     .header("x-custom", "preserved")
-                    .body(http_body_util::Full::new(bytes::Bytes::from("{}")))
+                    .body(rapina::response::full(bytes::Bytes::from("{}")))
                     .unwrap();
                 response
                     .headers_mut()
@@ -195,7 +195,7 @@ async fn test_cache_only_caches_get() {
             Router::new().route(http::Method::POST, "/data", |_, _, _| async {
                 let mut response = http::Response::builder()
                     .status(StatusCode::CREATED)
-                    .body(http_body_util::Full::new(bytes::Bytes::from("created")))
+                    .body(rapina::response::full(bytes::Bytes::from("created")))
                     .unwrap();
                 response
                     .headers_mut()
@@ -224,7 +224,7 @@ async fn test_cache_query_params_affect_key() {
                 let query = req.uri().query().unwrap_or("none").to_string();
                 let mut response = http::Response::builder()
                     .status(StatusCode::OK)
-                    .body(http_body_util::Full::new(bytes::Bytes::from(query)))
+                    .body(rapina::response::full(bytes::Bytes::from(query)))
                     .unwrap();
                 response
                     .headers_mut()

--- a/rapina/tests/streaming.rs
+++ b/rapina/tests/streaming.rs
@@ -1,0 +1,359 @@
+//! Real-socket integration tests for streaming responses.
+//!
+//! Tower's `oneshot` doesn't exercise chunked transfer or socket-level
+//! buffering, so SSE and `StreamResponse` get a real `TcpListener`.
+//! Assertions favor behavior (incremental delivery via timing) over
+//! protocol implementation details (chunked transfer headers).
+
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use rapina::http::Method;
+use rapina::middleware::CompressionConfig;
+use rapina::prelude::*;
+use rapina::response::{BodyError, SseEvent, SseResponse, StreamResponse};
+use rapina::router::Router;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+async fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Spawns the app on a free port on a separate OS thread with its own
+/// runtime. Required because `Rapina: !Sync` means its `listen` future
+/// is `!Send` and cannot be `tokio::spawn`-ed.
+async fn spawn<F>(build_app: F) -> u16
+where
+    F: FnOnce() -> Rapina + Send + 'static,
+{
+    let port = free_port().await;
+    let addr = format!("127.0.0.1:{}", port);
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            let app = build_app();
+            let _ = app.listen(&addr).await;
+        });
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .is_ok()
+        {
+            return port;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("server did not start on port {}", port);
+}
+
+/// Send a raw HTTP/1.1 GET. Returns (stream, headers, body_prefix, sent_at).
+/// `body_prefix` contains any body bytes that arrived in the same read as the
+/// header terminator and would otherwise be lost.
+async fn send_request(
+    port: u16,
+    path: &str,
+    extra_headers: &str,
+) -> (TcpStream, Vec<u8>, Vec<u8>, Instant) {
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+        .await
+        .unwrap();
+    let req = format!(
+        "GET {} HTTP/1.1\r\nHost: 127.0.0.1\r\n{}\r\n",
+        path, extra_headers
+    );
+    let sent_at = Instant::now();
+    stream.write_all(req.as_bytes()).await.unwrap();
+    let raw = read_until_double_crlf(&mut stream).await;
+    let split = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("header terminator")
+        + 4;
+    let headers = raw[..split].to_vec();
+    let body_prefix = raw[split..].to_vec();
+    (stream, headers, body_prefix, sent_at)
+}
+
+/// Reads from the socket until it sees the `\r\n\r\n` header terminator.
+async fn read_until_double_crlf(stream: &mut TcpStream) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let mut tmp = [0u8; 256];
+    loop {
+        let n = stream.read(&mut tmp).await.unwrap();
+        assert!(n > 0, "connection closed before headers");
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            return buf;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_sse_emits_events_incrementally() {
+    let router = Router::new().route(Method::GET, "/events", |_, _, _| async {
+        let s = async_stream::stream! {
+            for i in 0..3u32 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                yield Ok::<_, BodyError>(SseEvent::data(format!("event-{}", i)));
+            }
+        };
+        SseResponse::new(s).keep_alive(None)
+    });
+
+    let port = spawn(|| Rapina::new().with_introspection(false).router(router)).await;
+
+    let (mut stream, headers, _body_prefix, sent_at) =
+        send_request(port, "/events", "Connection: close\r\n").await;
+
+    let header_str = String::from_utf8_lossy(&headers);
+    assert!(
+        header_str.contains("text/event-stream"),
+        "missing SSE content-type: {}",
+        header_str
+    );
+
+    // Read the first event payload from the body. With chunked transfer
+    // there's a hex length line first; we only care that some bytes containing
+    // "event-0" arrive before the handler finishes (~300 ms).
+    let mut body = Vec::with_capacity(256);
+    let mut buf = [0u8; 256];
+    let first_event_seen_at = loop {
+        let n = stream.read(&mut buf).await.unwrap();
+        if n == 0 {
+            panic!("connection closed before first event");
+        }
+        body.extend_from_slice(&buf[..n]);
+        if body.windows(7).any(|w| w == b"event-0") {
+            break Instant::now();
+        }
+    };
+
+    let elapsed = first_event_seen_at.duration_since(sent_at);
+    assert!(
+        elapsed < Duration::from_millis(250),
+        "first event took {:?}, handler should not buffer the stream",
+        elapsed
+    );
+}
+
+#[tokio::test]
+async fn test_stream_response_chunks_bytes() {
+    let router = Router::new().route(Method::GET, "/chunks", |_, _, _| async {
+        let s = async_stream::stream! {
+            for i in 0..3u32 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                yield Ok::<_, BodyError>(Bytes::from(format!("chunk-{} ", i)));
+            }
+        };
+        StreamResponse::new(s).content_type("text/plain")
+    });
+
+    let port = spawn(|| Rapina::new().with_introspection(false).router(router)).await;
+
+    let (mut stream, _headers, _body_prefix, sent_at) =
+        send_request(port, "/chunks", "Connection: close\r\n").await;
+
+    let mut body = Vec::with_capacity(256);
+    let mut buf = [0u8; 256];
+    let first_chunk_seen_at = loop {
+        let n = stream.read(&mut buf).await.unwrap();
+        if n == 0 {
+            panic!("connection closed before first chunk");
+        }
+        body.extend_from_slice(&buf[..n]);
+        if body.windows(7).any(|w| w == b"chunk-0") {
+            break Instant::now();
+        }
+    };
+
+    assert!(
+        first_chunk_seen_at.duration_since(sent_at) < Duration::from_millis(250),
+        "first chunk should arrive before handler finishes"
+    );
+
+    // Drain the rest, then verify all three chunks arrived.
+    let _ = tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut body)).await;
+    let body_str = String::from_utf8_lossy(&body);
+    for i in 0..3 {
+        assert!(
+            body_str.contains(&format!("chunk-{}", i)),
+            "missing chunk-{} in body: {:?}",
+            i,
+            body_str
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_compression_skips_sse_response() {
+    let router = Router::new().route(Method::GET, "/events", |_, _, _| async {
+        let s = async_stream::stream! {
+            for i in 0..3u32 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                yield Ok::<_, BodyError>(SseEvent::data(format!("event-{}", i)));
+            }
+        };
+        SseResponse::new(s).keep_alive(None)
+    });
+
+    let port = spawn(|| {
+        Rapina::new()
+            .with_introspection(false)
+            .with_compression(CompressionConfig::default())
+            .router(router)
+    })
+    .await;
+
+    let (mut stream, headers, _body_prefix, sent_at) = send_request(
+        port,
+        "/events",
+        "Accept-Encoding: gzip\r\nConnection: close\r\n",
+    )
+    .await;
+
+    let header_str = String::from_utf8_lossy(&headers);
+    assert!(
+        !header_str.to_lowercase().contains("content-encoding"),
+        "compression must skip SSE responses: {}",
+        header_str
+    );
+    assert!(header_str.contains("text/event-stream"));
+
+    // And events still arrive incrementally, proves compression didn't wedge
+    // the stream by trying to buffer it.
+    let mut body = Vec::with_capacity(256);
+    let mut buf = [0u8; 256];
+    let first_event_seen_at = loop {
+        let n = stream.read(&mut buf).await.unwrap();
+        if n == 0 {
+            panic!("connection closed before first event");
+        }
+        body.extend_from_slice(&buf[..n]);
+        if body.windows(7).any(|w| w == b"event-0") {
+            break Instant::now();
+        }
+    };
+
+    assert!(
+        first_event_seen_at.duration_since(sent_at) < Duration::from_millis(250),
+        "compression in front of SSE wedged the stream"
+    );
+}
+
+#[tokio::test]
+async fn test_compression_streams_large_body_per_chunk() {
+    // Producer emits 10 chunks of 4 KiB each, 50 ms apart. With compression,
+    // we should see compressed bytes arriving incrementally (not buffered),
+    // and the gunzipped result must equal the original.
+    let router = Router::new().route(Method::GET, "/big", |_, _, _| async {
+        let s = async_stream::stream! {
+            for i in 0..10u32 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                let mut chunk = vec![b'x'; 4096];
+                chunk[0] = b'0' + (i % 10) as u8;
+                yield Ok::<_, BodyError>(Bytes::from(chunk));
+            }
+        };
+        StreamResponse::new(s).content_type("text/plain")
+    });
+
+    let port = spawn(|| {
+        Rapina::new()
+            .with_introspection(false)
+            .with_compression(CompressionConfig::default())
+            .router(router)
+    })
+    .await;
+
+    let (mut stream, headers, body_prefix, sent_at) = send_request(
+        port,
+        "/big",
+        "Accept-Encoding: gzip\r\nConnection: close\r\n",
+    )
+    .await;
+
+    let header_str = String::from_utf8_lossy(&headers);
+    assert!(
+        header_str.to_lowercase().contains("content-encoding: gzip"),
+        "expected gzip content-encoding for streaming body: {}",
+        header_str
+    );
+    assert!(
+        !header_str.to_lowercase().contains("content-length"),
+        "streaming compression must not emit content-length: {}",
+        header_str
+    );
+
+    // The body_prefix may already contain the first compressed bytes that
+    // arrived alongside the headers. If not, read more and time-check.
+    let mut all = body_prefix;
+    let first_byte_at = if all.is_empty() {
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).await.unwrap();
+        assert!(n > 0, "no bytes received");
+        all.extend_from_slice(&buf[..n]);
+        Instant::now()
+    } else {
+        sent_at
+    };
+    assert!(
+        first_byte_at.duration_since(sent_at) < Duration::from_millis(250),
+        "first compressed byte took {:?}, compression should not buffer the stream",
+        first_byte_at.duration_since(sent_at)
+    );
+
+    // Drain the rest, dechunk, and gunzip. Verify roundtrip.
+    let _ = tokio::time::timeout(Duration::from_secs(3), stream.read_to_end(&mut all)).await;
+    let decoded = decode_chunked(&all);
+    eprintln!(
+        "raw={} dechunked_len={}\nfirst 200 raw bytes (hex): {}\nlast 100 raw bytes (hex): {}",
+        all.len(),
+        decoded.len(),
+        all.iter()
+            .take(200)
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>(),
+        all.iter()
+            .rev()
+            .take(100)
+            .rev()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>(),
+    );
+    let mut gz = flate2::read::GzDecoder::new(&decoded[..]);
+    let mut original = Vec::new();
+    std::io::Read::read_to_end(&mut gz, &mut original).expect("gunzip roundtrip");
+    assert_eq!(original.len(), 4096 * 10);
+    assert_eq!(&original[..1], b"0");
+    assert_eq!(&original[4096..4097], b"1");
+}
+
+/// Minimal HTTP/1.1 chunked-transfer decoder for the test.
+fn decode_chunked(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let line_end = match input[i..].windows(2).position(|w| w == b"\r\n") {
+            Some(p) => i + p,
+            None => break,
+        };
+        let size_str = std::str::from_utf8(&input[i..line_end]).unwrap_or("0");
+        let size = usize::from_str_radix(size_str.trim(), 16).unwrap_or(0);
+        i = line_end + 2;
+        if size == 0 {
+            break;
+        }
+        if i + size > input.len() {
+            break;
+        }
+        out.extend_from_slice(&input[i..i + size]);
+        i += size + 2; // chunk + trailing CRLF
+    }
+    out
+}


### PR DESCRIPTION
Closes #326

Replaces the `BoxBody = Full<Bytes>` alias with a real boxed `http_body::Body` trait object so streaming and buffered responses share one response type. Adds `StreamResponse` for raw chunked bytes and `SseResponse` plus `SseEvent` for Server-Sent Events. Keep-alive is implemented as a custom `Body` that owns a `tokio::time::Sleep`, no `tokio-stream` dep, no separate task. Same shape axum's `KeepAlive` uses. Compression middleware now per-chunk-encodes streaming bodies with a persistent `flate2` encoder and unconditionally skips `text/event-stream`, matching Starlette's commit a9a8dab from Feb 2025 (gzip across SSE event boundaries breaks framing at proxies). Cache middleware checks `body.size_hint().exact().is_none()` and skips streaming responses since they can't be captured as a single `Bytes` blob. Breaking change for users constructing `Response<BoxBody>` manually with `Full::new(...)`. Replace with `rapina::response::full(...)`. `BoxBody::default()` becomes `rapina::response::empty()`.