### PR TITLE
Add cursor-based pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ version = "0.11.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "base64",
  "bytes",
  "criterion",
  "dashmap",

--- a/docs/content/docs/core-concepts/pagination.md
+++ b/docs/content/docs/core-concepts/pagination.md
@@ -237,3 +237,111 @@ Any request with `?per_page=51` now returns a 422.
 `exec` runs the data fetch and count queries **concurrently** using `tokio::join!`, not sequentially. Two queries hit the database in parallel, so latency is the cost of whichever query is slower, not both combined.
 
 The `Select<E>` is cloned before splitting into fetch and count paginators. SeaORM query builders are cheap to clone (they're just AST nodes, not connections).
+
+## Cursor Pagination
+
+For high-traffic feeds, infinite-scroll lists, and any endpoint where rows can shift while a user is paging through them, cursor pagination is the better fit. Rapina ships `CursorPaginate<V>` and `CursorPaginated<T>` alongside the offset variant.
+
+### When to choose which
+
+| | Offset pagination | Cursor pagination |
+|---|---|---|
+| URL shape | `?page=2&per_page=20` | `?after=<token>&limit=20` |
+| Total count | Yes (`total`, `total_pages`) | No (intentional) |
+| Stable across writes | No, rows can shift between pages | Yes |
+| Random page access | Yes, jump to page N | No, walk forward or backward |
+| Cost on large tables | Grows with offset | Constant per page |
+
+Reach for offset when the dataset is small, mostly static, and users want to land directly on page 47. Reach for cursor when the data is a feed, a timeline, an audit log, or anything where consistency between fetches matters more than knowing the total.
+
+### Quick start
+
+Declare the entity's default cursor column once with the `CursorKey` trait, then handlers stay terse:
+
+```rust
+use rapina::prelude::*;
+use rapina::database::Db;
+use rapina::pagination::{CursorKey, CursorPaginate, CursorPaginated};
+use entity::user::{self, Entity as User};
+
+impl CursorKey for user::Model {
+    type Column = user::Column;
+    type Value = i32;
+    const COLUMN: user::Column = user::Column::Id;
+    fn cursor_value(&self) -> i32 { self.id }
+}
+
+#[derive(Serialize, JsonSchema)]
+struct UserResponse {
+    id: i32,
+    name: String,
+}
+
+impl From<user::Model> for UserResponse {
+    fn from(m: user::Model) -> Self {
+        Self { id: m.id, name: m.name }
+    }
+}
+
+#[get("/users")]
+async fn list_users(
+    db: Db,
+    cursor: CursorPaginate<i32>,
+) -> Result<CursorPaginated<UserResponse>> {
+    Ok(cursor
+        .exec(User::find(), db.conn())
+        .await?
+        .map(UserResponse::from))
+}
+```
+
+### Query parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `after` | none | Opaque token; return rows after this position |
+| `before` | none | Opaque token; return rows before this position |
+| `limit` | 20 | Items per page (capped by `PaginationConfig::max_per_page`) |
+
+Returns **422 Validation Error** when:
+- `after` and `before` are both supplied
+- `limit` is `0` or above the cap
+- a token fails to base64-decode or fails to deserialize as `V`
+
+### Response shape
+
+```json
+{
+  "data": [{ "id": 11, "name": "Kim" }, { "id": 12, "name": "Lee" }],
+  "next_cursor": "MTI",
+  "prev_cursor": null
+}
+```
+
+Tokens are URL-safe unpadded base64. `next_cursor` is `null` on the last page; `prev_cursor` is `null` on the very first page (when neither `?after=` nor `?before=` was supplied). Clients should round-trip the strings verbatim.
+
+### `CursorKey` and one-off cursors
+
+`exec` reads the default cursor column from the entity's `CursorKey` impl. For a one-off cursor on a non-default column (for example `email` in a search-by-email endpoint), reach for `exec_by` and pass the column and accessor at the call site:
+
+```rust
+#[get("/users/by-email")]
+async fn list_users_by_email(
+    db: Db,
+    cursor: CursorPaginate<String>,
+) -> Result<CursorPaginated<user::Model>> {
+    cursor
+        .exec_by(User::find(), user::Column::Email, db.conn(), |u| u.email.clone())
+        .await
+}
+```
+
+The closure must return the value of `column` for the given row, otherwise pagination will not point where the client expects. SeaORM's `Model` has no generic "get value of column" accessor, so the column and the accessor must be supplied together.
+
+### Composite cursors
+
+Currently single-column only. Composite cursors (e.g. `(created_at, id)` for stable ordering across rows with the same timestamp) are a non-breaking addition planned for a later release.
+
+### Configuration
+
+`CursorPaginate` shares `PaginationConfig` with offset pagination: `default_per_page` becomes the default `limit`, `max_per_page` enforces the cap.

--- a/docs/content/docs/core-concepts/pagination.md
+++ b/docs/content/docs/core-concepts/pagination.md
@@ -5,7 +5,7 @@ weight = 6
 date = 2025-02-27
 +++
 
-Every list endpoint needs the same boilerplate: LIMIT/OFFSET, a count query, and response metadata. Rapina handles this with a `Paginate` extractor and a `Paginated<T>` response wrapper.
+List endpoints come in two shapes: page-numbered (`?page=2&per_page=20`) and cursor-based (`?after=<token>&limit=20`). Rapina ships both as first-class primitives. Use the offset-style `Paginate` / `Paginated<T>` for random page access, and `CursorPaginate` / `CursorPaginated<T>` for stable feeds and infinite scroll.
 
 ## Quick Start
 

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -84,6 +84,7 @@ sea-orm = { version = "1.1", optional = true, features = ["runtime-tokio-rustls"
 # Database migration (optional)
 sea-orm-migration = { version = "1.1", optional = true, features = ["runtime-tokio-rustls"] }
 async-trait = { version = "0.1", optional = true }
+base64 = { version = "0.22", optional = true }
 
 # Prometheus (optional)
 prometheus = { version = '0.13', optional = true }
@@ -134,7 +135,7 @@ required-features = ["multipart"]
 default = ["compression", "rate-limit"]
 rate-limit = []
 compression = ["flate2"]
-database = ["sea-orm", "sea-orm-migration", "async-trait"]
+database = ["sea-orm", "sea-orm-migration", "async-trait", "base64"]
 postgres = ["database", "sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
 mysql = ["database", "sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 sqlite = ["database", "sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]

--- a/rapina/examples/todo-app/src/entity.rs
+++ b/rapina/examples/todo-app/src/entity.rs
@@ -1,3 +1,4 @@
+use rapina::pagination::CursorKey;
 use rapina::prelude::*;
 
 schema! {
@@ -5,5 +6,14 @@ schema! {
     Todo {
         title: String,
         done: bool,
+    }
+}
+
+impl CursorKey for todo::Model {
+    type Column = todo::Column;
+    type Value = i32;
+    const COLUMN: todo::Column = todo::Column::Id;
+    fn cursor_value(&self) -> i32 {
+        self.id
     }
 }

--- a/rapina/examples/todo-app/src/todos/handlers.rs
+++ b/rapina/examples/todo-app/src/todos/handlers.rs
@@ -1,4 +1,5 @@
 use rapina::database::{Db, DbError};
+use rapina::pagination::{CursorPaginate, CursorPaginated};
 use rapina::prelude::*;
 use rapina::sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, PaginatorTrait, Set};
 
@@ -15,6 +16,15 @@ use crate::AppConfig;
 pub async fn list_todos(db: Db) -> Result<Json<Vec<Model>>> {
     let todos = Todo::find().all(db.conn()).await.map_err(DbError)?;
     Ok(Json(todos))
+}
+
+#[get("/todos/cursor")]
+#[errors(TodoError)]
+pub async fn list_todos_cursor(
+    db: Db,
+    cursor: CursorPaginate<i32>,
+) -> Result<CursorPaginated<Model>> {
+    cursor.exec(Todo::find(), db.conn()).await
 }
 
 #[get("/todos/:id")]

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -156,7 +156,9 @@ pub mod prelude {
     pub use crate::middleware::{RapinaService, TowerLayerMiddleware};
     pub use crate::observability::TracingConfig;
     #[cfg(feature = "database")]
-    pub use crate::pagination::{Paginate, Paginated, PaginationConfig};
+    pub use crate::pagination::{
+        CursorKey, CursorPaginate, CursorPaginated, Paginate, Paginated, PaginationConfig,
+    };
     #[cfg(feature = "websocket")]
     pub use crate::relay::{Relay, RelayConfig, RelayEvent};
     pub use crate::response::{IntoResponse, StaticStr};

--- a/rapina/src/pagination.rs
+++ b/rapina/src/pagination.rs
@@ -1,16 +1,19 @@
 //! Built-in pagination for database-backed list endpoints.
 //!
-//! Provides a [`Paginate`] extractor that reads `?page=1&per_page=20` from query
-//! params, and a [`Paginated<T>`] response wrapper that serializes data with
-//! pagination metadata. The [`Paginate::exec`] method glues them together by
-//! running fetch + count concurrently against a SeaORM `Select`.
+//! Two flavors are provided, both feature-gated behind `database`:
 //!
-//! # Quick Start
+//! - [`Paginate`] / [`Paginated`] for offset/limit (`?page=&per_page=`),
+//!   carrying total counts and page numbers.
+//! - [`CursorPaginate`] / [`CursorPaginated`] for cursor pagination
+//!   (`?after=&before=&limit=`), with opaque tokens and no count query.
+//!
+//! Both share [`PaginationConfig`] for `default_per_page` and `max_per_page`.
+//!
+//! # Offset
 //!
 //! ```rust,ignore
 //! use rapina::prelude::*;
 //! use rapina::database::Db;
-//! use rapina::pagination::{Paginate, Paginated};
 //! use entity::user::{self, Entity as User};
 //!
 //! #[get("/users")]
@@ -19,13 +22,38 @@
 //! }
 //! ```
 //!
+//! # Cursor
+//!
+//! Implement [`CursorKey`] once per entity to declare the default cursor
+//! column. Handlers then need only the query and the connection.
+//!
+//! ```rust,ignore
+//! use rapina::prelude::*;
+//! use rapina::database::Db;
+//! use rapina::pagination::CursorKey;
+//! use entity::user::{self, Entity as User};
+//!
+//! impl CursorKey for user::Model {
+//!     type Column = user::Column;
+//!     type Value = i32;
+//!     const COLUMN: user::Column = user::Column::Id;
+//!     fn cursor_value(&self) -> i32 { self.id }
+//! }
+//!
+//! #[get("/users")]
+//! async fn list_users(db: Db, cursor: CursorPaginate<i32>) -> Result<CursorPaginated<user::Model>> {
+//!     cursor.exec(User::find(), db.conn()).await
+//! }
+//! ```
+//!
+//! For a one-off cursor on a non-default column, use
+//! [`CursorPaginate::exec_by`].
+//!
 //! # Configuration
 //!
 //! Register [`PaginationConfig`] via `.state()` to override defaults:
 //!
 //! ```rust,ignore
-//! use rapina::pagination::PaginationConfig;
-//!
 //! Rapina::new()
 //!     .state(PaginationConfig {
 //!         default_per_page: 25,
@@ -36,8 +64,11 @@
 
 use std::sync::Arc;
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64;
 use schemars::JsonSchema;
-use sea_orm::{EntityTrait, PaginatorTrait, Select};
+use sea_orm::sea_query::IntoValueTuple;
+use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, Select};
 use serde::{Deserialize, Serialize};
 
 use crate::database::DbError;
@@ -198,6 +229,285 @@ impl<T: Serialize> IntoResponse for Paginated<T> {
             .header("content-type", "application/json")
             .body(crate::response::full(body))
             .unwrap()
+    }
+}
+
+// ── Cursor-based pagination ────────────────────────────────────────────────
+
+/// Raw query params for cursor pagination. All optional so the no-args
+/// case yields the first page at the default limit.
+#[derive(Deserialize)]
+struct CursorPaginateQuery {
+    after: Option<String>,
+    before: Option<String>,
+    limit: Option<u64>,
+}
+
+fn encode_cursor<V: Serialize>(value: &V) -> Result<String, Error> {
+    let json = serde_json::to_vec(value)
+        .map_err(|e| Error::validation(format!("failed to encode cursor: {e}")))?;
+    Ok(BASE64.encode(json))
+}
+
+fn decode_cursor<V: for<'de> Deserialize<'de>>(token: &str) -> Result<V, Error> {
+    let bytes = BASE64
+        .decode(token)
+        .map_err(|e| Error::validation(format!("invalid cursor: {e}")))?;
+    serde_json::from_slice(&bytes).map_err(|e| Error::validation(format!("invalid cursor: {e}")))
+}
+
+/// Direction of cursor traversal. Set by which token is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CursorDirection {
+    /// First page, or `?after=` continuation.
+    Forward,
+    /// `?before=` reverse continuation.
+    Backward,
+}
+
+/// Cursor-based pagination extractor. Reads `?after=<token>&before=<token>&limit=<n>`.
+///
+/// The type parameter `V` is the typed cursor value the after/before tokens
+/// decode into. It must match the column you call `cursor_by` on in
+/// [`CursorPaginate::exec`]. For example, `CursorPaginate<i32>` for an `id`
+/// column, or `CursorPaginate<chrono::DateTime<Utc>>` for `created_at`.
+///
+/// Returns 422 when:
+/// - both `after` and `before` are supplied
+/// - `limit` is zero or exceeds the configured max
+/// - a token fails to base64-decode or fails to deserialize as `V`
+#[derive(Debug, Clone)]
+pub struct CursorPaginate<V> {
+    /// Decoded `after` cursor, when present.
+    pub after: Option<V>,
+    /// Decoded `before` cursor, when present.
+    pub before: Option<V>,
+    /// Number of items requested. Falls back to config default.
+    pub limit: u64,
+    direction: CursorDirection,
+}
+
+impl<V> FromRequestParts for CursorPaginate<V>
+where
+    V: for<'de> Deserialize<'de> + Send + Sync + 'static,
+{
+    async fn from_request_parts(
+        parts: &http::request::Parts,
+        _params: &PathParams,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Error> {
+        let query_str = parts.uri.query().unwrap_or("");
+        let raw: CursorPaginateQuery = serde_urlencoded::from_str(query_str)
+            .map_err(|e| Error::validation(format!("invalid cursor params: {}", e)))?;
+
+        let config = state.get::<PaginationConfig>();
+        let default_limit = config.map_or(DEFAULT_PER_PAGE, |c| c.default_per_page);
+        let max_limit = config.map_or(DEFAULT_MAX_PER_PAGE, |c| c.max_per_page);
+
+        if raw.after.is_some() && raw.before.is_some() {
+            return Err(Error::validation(
+                "after and before cannot be combined; use one or the other",
+            ));
+        }
+
+        let limit = raw.limit.unwrap_or(default_limit);
+        if limit == 0 {
+            return Err(Error::validation("limit must be >= 1"));
+        }
+        if limit > max_limit {
+            return Err(Error::validation(format!("limit must be <= {max_limit}")));
+        }
+
+        let after = raw.after.as_deref().map(decode_cursor::<V>).transpose()?;
+        let before = raw.before.as_deref().map(decode_cursor::<V>).transpose()?;
+
+        let direction = if before.is_some() {
+            CursorDirection::Backward
+        } else {
+            CursorDirection::Forward
+        };
+
+        Ok(CursorPaginate {
+            after,
+            before,
+            limit,
+            direction,
+        })
+    }
+}
+
+/// Cursor-paginated response wrapper. Implements `IntoResponse` so it can be
+/// returned directly from handlers.
+///
+/// The token strings in `next_cursor` and `prev_cursor` are opaque base64
+/// payloads. Clients should not parse them; they should round-trip them
+/// verbatim into the next request's `?after=` or `?before=`.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CursorPaginated<T> {
+    pub data: Vec<T>,
+    pub next_cursor: Option<String>,
+    pub prev_cursor: Option<String>,
+}
+
+impl<T> CursorPaginated<T> {
+    /// Transforms data items while preserving cursor metadata.
+    pub fn map<U>(self, f: impl FnMut(T) -> U) -> CursorPaginated<U> {
+        CursorPaginated {
+            data: self.data.into_iter().map(f).collect(),
+            next_cursor: self.next_cursor,
+            prev_cursor: self.prev_cursor,
+        }
+    }
+}
+
+impl<T: Serialize> IntoResponse for CursorPaginated<T> {
+    fn into_response(self) -> http::Response<BoxBody> {
+        let body = serde_json::to_vec(&self).unwrap_or_default();
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header("content-type", "application/json")
+            .body(crate::response::full(body))
+            .unwrap()
+    }
+}
+
+/// Declares the default cursor column for a SeaORM model.
+///
+/// Implementing this trait once per entity lets handlers call
+/// [`CursorPaginate::exec`] with just the query and connection. Without it,
+/// reach for [`CursorPaginate::exec_by`] and pass the column and accessor
+/// at the call site.
+///
+/// ```rust,ignore
+/// impl CursorKey for user::Model {
+///     type Column = user::Column;
+///     type Value = i32;
+///     const COLUMN: Self::Column = user::Column::Id;
+///     fn cursor_value(&self) -> Self::Value { self.id }
+/// }
+/// ```
+pub trait CursorKey {
+    /// The SeaORM column enum for the entity.
+    type Column: ColumnTrait;
+    /// The cursor value type. Must match the column's runtime type.
+    type Value: Serialize + IntoValueTuple;
+
+    /// The column to sort and seek on.
+    const COLUMN: Self::Column;
+
+    /// Reads the cursor value off a row.
+    fn cursor_value(&self) -> Self::Value;
+}
+
+impl<V: Serialize> CursorPaginate<V> {
+    /// Runs a cursor-paginated query against an entity whose default cursor
+    /// is declared via [`CursorKey`]. For one-off cursors on a non-default
+    /// column, use [`CursorPaginate::exec_by`].
+    pub async fn exec<E>(
+        self,
+        select: Select<E>,
+        conn: &sea_orm::DatabaseConnection,
+    ) -> Result<CursorPaginated<E::Model>, Error>
+    where
+        E: EntityTrait,
+        E::Model: CursorKey<Value = V> + Send + Sync,
+        V: IntoValueTuple,
+    {
+        self.exec_by(
+            select,
+            <E::Model as CursorKey>::COLUMN,
+            conn,
+            <E::Model as CursorKey>::cursor_value,
+        )
+        .await
+    }
+
+    /// Runs a cursor-paginated query, specifying the column and value
+    /// accessor explicitly. Use this when the cursor is on a non-default
+    /// column or when no [`CursorKey`] impl exists for the entity.
+    ///
+    /// `extract` must return the same column value that `column` selects on;
+    /// otherwise the next and previous tokens will not point where the client
+    /// expects.
+    pub async fn exec_by<E, C, F>(
+        self,
+        select: Select<E>,
+        column: C,
+        conn: &sea_orm::DatabaseConnection,
+        extract: F,
+    ) -> Result<CursorPaginated<E::Model>, Error>
+    where
+        E: EntityTrait,
+        E::Model: Send + Sync,
+        C: ColumnTrait,
+        V: IntoValueTuple,
+        F: Fn(&E::Model) -> V,
+    {
+        let CursorPaginate {
+            after,
+            before,
+            limit,
+            direction,
+        } = self;
+
+        let mut cursor = select.cursor_by(column);
+        let had_after = after.is_some();
+        let had_before = before.is_some();
+        if let Some(v) = after {
+            cursor.after(v);
+        }
+        if let Some(v) = before {
+            cursor.before(v);
+        }
+
+        let take = limit + 1;
+        let rows: Vec<E::Model> = match direction {
+            CursorDirection::Forward => cursor.first(take).all(conn).await,
+            CursorDirection::Backward => cursor.last(take).all(conn).await,
+        }
+        .map_err(DbError)?;
+
+        let mut data = rows;
+        let has_more = data.len() as u64 > limit;
+        if has_more {
+            // Trim the overflow row from whichever end is further from the
+            // cursor; the kept page is the `limit` rows closest to it.
+            match direction {
+                CursorDirection::Forward => data.truncate(limit as usize),
+                CursorDirection::Backward => {
+                    data.drain(..(data.len() - limit as usize));
+                }
+            }
+        }
+
+        let token = |row: Option<&E::Model>| -> Result<Option<String>, Error> {
+            row.map(&extract).as_ref().map(encode_cursor).transpose()
+        };
+
+        let (next_cursor, prev_cursor) = match direction {
+            CursorDirection::Forward => (
+                if has_more { token(data.last())? } else { None },
+                if had_after {
+                    token(data.first())?
+                } else {
+                    None
+                },
+            ),
+            CursorDirection::Backward => (
+                if had_before {
+                    token(data.last())?
+                } else {
+                    None
+                },
+                if has_more { token(data.first())? } else { None },
+            ),
+        };
+
+        Ok(CursorPaginated {
+            data,
+            next_cursor,
+            prev_cursor,
+        })
     }
 }
 
@@ -412,5 +722,163 @@ mod tests {
 
         let err = result.unwrap_err();
         assert_eq!(err.status(), 422);
+    }
+
+    // ── Cursor codec ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_cursor_codec_roundtrip_i32() {
+        let token = encode_cursor(&42i32).unwrap();
+        let decoded: i32 = decode_cursor(&token).unwrap();
+        assert_eq!(decoded, 42);
+    }
+
+    #[test]
+    fn test_cursor_codec_roundtrip_string() {
+        let token = encode_cursor(&"hello world".to_string()).unwrap();
+        let decoded: String = decode_cursor(&token).unwrap();
+        assert_eq!(decoded, "hello world");
+    }
+
+    #[test]
+    fn test_cursor_codec_token_is_url_safe_base64_of_json() {
+        // Lock the wire format: URL-safe unpadded base64 of the JSON bytes.
+        // Documented in pagination.md; integration tests rely on this shape.
+        let token = encode_cursor(&7i32).unwrap();
+        assert!(!token.contains('+') && !token.contains('/') && !token.contains('='));
+        let bytes = BASE64.decode(&token).unwrap();
+        assert_eq!(bytes, b"7");
+    }
+
+    #[test]
+    fn test_cursor_decode_rejects_non_base64() {
+        let err = decode_cursor::<i32>("not!!!base64").unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    #[test]
+    fn test_cursor_decode_rejects_wrong_type() {
+        let token = encode_cursor(&42i32).unwrap();
+        let err = decode_cursor::<String>(&token).unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    // ── CursorPaginate extractor ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_cursor_paginate_defaults() {
+        let (parts, _) = TestRequest::get("/items").into_parts();
+        let p: CursorPaginate<i32> =
+            CursorPaginate::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap();
+        assert!(p.after.is_none());
+        assert!(p.before.is_none());
+        assert_eq!(p.limit, 20);
+        assert_eq!(p.direction, CursorDirection::Forward);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_after_token() {
+        let token = encode_cursor(&100i32).unwrap();
+        let (parts, _) = TestRequest::get(&format!("/items?after={}", token)).into_parts();
+        let p: CursorPaginate<i32> =
+            CursorPaginate::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap();
+        assert_eq!(p.after, Some(100));
+        assert_eq!(p.direction, CursorDirection::Forward);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_before_token() {
+        let token = encode_cursor(&50i32).unwrap();
+        let (parts, _) = TestRequest::get(&format!("/items?before={}", token)).into_parts();
+        let p: CursorPaginate<i32> =
+            CursorPaginate::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap();
+        assert_eq!(p.before, Some(50));
+        assert_eq!(p.direction, CursorDirection::Backward);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_after_and_before_rejected() {
+        let after = encode_cursor(&1i32).unwrap();
+        let before = encode_cursor(&10i32).unwrap();
+        let (parts, _) =
+            TestRequest::get(&format!("/items?after={}&before={}", after, before)).into_parts();
+        let err =
+            CursorPaginate::<i32>::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap_err();
+        assert_eq!(err.status(), 422);
+        assert!(err.message().contains("after and before"));
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_limit_zero_rejected() {
+        let (parts, _) = TestRequest::get("/items?limit=0").into_parts();
+        let err =
+            CursorPaginate::<i32>::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_limit_exceeds_max_rejected() {
+        let (parts, _) = TestRequest::get("/items?limit=101").into_parts();
+        let err =
+            CursorPaginate::<i32>::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap_err();
+        assert_eq!(err.status(), 422);
+        assert!(err.message().contains("<= 100"));
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginate_garbage_token_rejected() {
+        let (parts, _) = TestRequest::get("/items?after=!!!").into_parts();
+        let err =
+            CursorPaginate::<i32>::from_request_parts(&parts, &empty_params(), &empty_state())
+                .await
+                .unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_paginated_response_shape() {
+        let p = CursorPaginated {
+            data: vec!["a", "b", "c"],
+            next_cursor: Some("opaque-next".to_string()),
+            prev_cursor: None,
+        };
+
+        let response = p.into_response();
+        assert_eq!(response.status(), http::StatusCode::OK);
+        use http_body_util::BodyExt;
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["data"], serde_json::json!(["a", "b", "c"]));
+        assert_eq!(json["next_cursor"], "opaque-next");
+        assert!(json["prev_cursor"].is_null());
+        // Lock the schema: no total, no has_more.
+        assert!(json.get("total").is_none());
+        assert!(json.get("has_more").is_none());
+    }
+
+    #[test]
+    fn test_cursor_paginated_map() {
+        let p = CursorPaginated {
+            data: vec![1, 2, 3],
+            next_cursor: Some("n".into()),
+            prev_cursor: Some("p".into()),
+        };
+        let mapped = p.map(|n| n * 10);
+        assert_eq!(mapped.data, vec![10, 20, 30]);
+        assert_eq!(mapped.next_cursor.as_deref(), Some("n"));
+        assert_eq!(mapped.prev_cursor.as_deref(), Some("p"));
     }
 }

--- a/rapina/tests/pagination.rs
+++ b/rapina/tests/pagination.rs
@@ -195,3 +195,237 @@ async fn test_paginated_response_via_handler() {
 }
 
 use rapina::extract::FromRequestParts;
+
+// ── Cursor pagination end-to-end (sqlite-backed) ──────────────────────────
+
+#[cfg(feature = "sqlite")]
+mod cursor_e2e {
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use rapina::pagination::CursorPaginate;
+    use rapina::sea_orm::{
+        ActiveModelTrait, ConnectionTrait, Database, DatabaseConnection, DbBackend, EntityTrait,
+        Schema, Set,
+    };
+
+    mod entity {
+        use rapina::pagination::CursorKey;
+        use rapina::sea_orm::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel, serde::Serialize)]
+        #[sea_orm(table_name = "items")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+
+        impl CursorKey for Model {
+            type Column = Column;
+            type Value = i32;
+            const COLUMN: Column = Column::Id;
+            fn cursor_value(&self) -> i32 {
+                self.id
+            }
+        }
+    }
+
+    /// Mint a cursor token directly. The wire format is `URL_SAFE_NO_PAD(json(value))`,
+    /// documented in `pagination.md` and locked by the unit tests in `pagination.rs`.
+    fn mint_token<V: serde::Serialize>(value: &V) -> String {
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(value).unwrap())
+    }
+
+    async fn setup_db_with(rows: u32) -> DatabaseConnection {
+        let conn = Database::connect("sqlite::memory:").await.unwrap();
+        let backend = conn.get_database_backend();
+        let schema = Schema::new(DbBackend::Sqlite);
+        let stmt = schema.create_table_from_entity(entity::Entity);
+        conn.execute(backend.build(&stmt)).await.unwrap();
+
+        for i in 1..=rows {
+            entity::ActiveModel {
+                id: Set(i as i32),
+                name: Set(format!("item-{i}")),
+            }
+            .insert(&conn)
+            .await
+            .unwrap();
+        }
+        conn
+    }
+
+    async fn setup_db() -> DatabaseConnection {
+        setup_db_with(10).await
+    }
+
+    fn build_app(conn: DatabaseConnection) -> Rapina {
+        Rapina::new()
+            .with_introspection(false)
+            .state(conn)
+            .router(Router::new().route(
+                http::Method::GET,
+                "/items",
+                |req, params, state: Arc<rapina::state::AppState>| async move {
+                    let (parts, _) = req.into_parts();
+                    let cursor =
+                        match CursorPaginate::<i32>::from_request_parts(&parts, &params, &state)
+                            .await
+                        {
+                            Ok(c) => c,
+                            Err(e) => return e.into_response(),
+                        };
+                    let conn = state.get::<DatabaseConnection>().unwrap();
+                    match cursor.exec(entity::Entity::find(), conn).await {
+                        Ok(p) => p.into_response(),
+                        Err(e) => e.into_response(),
+                    }
+                },
+            ))
+    }
+
+    fn ids(j: &serde_json::Value) -> Vec<i32> {
+        j["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["id"].as_i64().unwrap() as i32)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn forward_pagination_walks_all_rows() {
+        let client = TestClient::new(build_app(setup_db().await)).await;
+
+        let r = client.get("/items?limit=3").send().await;
+        assert_eq!(r.status(), StatusCode::OK);
+        let j: serde_json::Value = r.json();
+        assert_eq!(ids(&j), vec![1, 2, 3]);
+        assert!(j["next_cursor"].is_string());
+        assert!(j["prev_cursor"].is_null(), "no prev on first page");
+
+        let mut next = j["next_cursor"].as_str().unwrap().to_string();
+        let mut all_ids = ids(&j);
+        loop {
+            let r = client
+                .get(&format!("/items?limit=3&after={next}"))
+                .send()
+                .await;
+            assert_eq!(r.status(), StatusCode::OK);
+            let j: serde_json::Value = r.json();
+            all_ids.extend(ids(&j));
+            assert!(j["prev_cursor"].is_string(), "prev set when after was used");
+            match j["next_cursor"].as_str() {
+                Some(t) => next = t.to_string(),
+                None => break,
+            }
+        }
+        assert_eq!(all_ids, (1..=10).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn last_page_has_no_next_cursor() {
+        let client = TestClient::new(build_app(setup_db().await)).await;
+        let j: serde_json::Value = client.get("/items?limit=10").send().await.json();
+        assert_eq!(ids(&j).len(), 10);
+        assert!(j["next_cursor"].is_null());
+        assert!(j["prev_cursor"].is_null());
+    }
+
+    #[tokio::test]
+    async fn empty_table_returns_empty_page() {
+        let client = TestClient::new(build_app(setup_db_with(0).await)).await;
+        let j: serde_json::Value = client.get("/items?limit=5").send().await.json();
+        assert!(ids(&j).is_empty());
+        assert!(j["next_cursor"].is_null());
+        assert!(j["prev_cursor"].is_null());
+    }
+
+    #[tokio::test]
+    async fn limit_one_walks_one_row_at_a_time() {
+        let client = TestClient::new(build_app(setup_db_with(3).await)).await;
+
+        let j: serde_json::Value = client.get("/items?limit=1").send().await.json();
+        assert_eq!(ids(&j), vec![1]);
+        let next = j["next_cursor"].as_str().unwrap().to_string();
+
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=1&after={next}"))
+            .send()
+            .await
+            .json();
+        assert_eq!(ids(&j), vec![2]);
+        let next = j["next_cursor"].as_str().unwrap().to_string();
+
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=1&after={next}"))
+            .send()
+            .await
+            .json();
+        assert_eq!(ids(&j), vec![3]);
+        assert!(j["next_cursor"].is_null(), "last row, no next");
+    }
+
+    #[tokio::test]
+    async fn stale_cursor_past_end_returns_empty_page() {
+        let client = TestClient::new(build_app(setup_db_with(5).await)).await;
+        let token = mint_token(&999i32);
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=3&after={token}"))
+            .send()
+            .await
+            .json();
+        assert!(ids(&j).is_empty());
+        assert!(j["next_cursor"].is_null());
+        // No prev_cursor either: there were zero rows to extract from.
+        assert!(j["prev_cursor"].is_null());
+    }
+
+    #[tokio::test]
+    async fn next_cursor_round_trips_to_prev_cursor() {
+        let client = TestClient::new(build_app(setup_db().await)).await;
+
+        // Walk forward two pages.
+        let j: serde_json::Value = client.get("/items?limit=3").send().await.json();
+        assert_eq!(ids(&j), vec![1, 2, 3]);
+        let after_p1 = j["next_cursor"].as_str().unwrap().to_string();
+
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=3&after={after_p1}"))
+            .send()
+            .await
+            .json();
+        assert_eq!(ids(&j), vec![4, 5, 6]);
+        let prev_p2 = j["prev_cursor"].as_str().unwrap().to_string();
+
+        // Use prev_cursor to step back: should land on a page strictly before id=4.
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=3&before={prev_p2}"))
+            .send()
+            .await
+            .json();
+        assert_eq!(ids(&j), vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn backward_pagination_returns_ascending_data() {
+        let client = TestClient::new(build_app(setup_db().await)).await;
+        let token = mint_token(&8i32);
+
+        let j: serde_json::Value = client
+            .get(&format!("/items?limit=3&before={token}"))
+            .send()
+            .await
+            .json();
+        // The three rows immediately behind id=8, ordered ascending.
+        assert_eq!(ids(&j), vec![5, 6, 7]);
+        assert!(j["next_cursor"].is_string());
+        assert!(j["prev_cursor"].is_string());
+    }
+}


### PR DESCRIPTION
Closes #456

Adds cursor-based pagination as a sibling to the existing offset/limit primitive. Built on SeaORM's `cursor_by` with opaque URL-safe base64(JSON) tokens, Stripe-style `?after=&before=&limit=` semantics, no count query, no shared response shape. Lands behind the `database` feature alongside `Paginate`.

Handlers stay terse via a `CursorKey` trait that declares the entity's default cursor column once:

```rust
impl CursorKey for user::Model {
    type Column = user::Column;
    type Value = i32;
    const COLUMN: user::Column = user::Column::Id;
    fn cursor_value(&self) -> i32 { self.id }
}

#[get(\"/users\")]
async fn list_users(db: Db, cursor: CursorPaginate<i32>) -> Result<CursorPaginated<user::Model>> {
    cursor.exec(User::find(), db.conn()).await
}
```

`exec_by(select, column, conn, |m| ...)` is available for one-off cursors on a non-default column.

Single-column cursors only in this PR. Composite cursors are a non-breaking follow-up, the wire format is opaque so it can carry tuples later without breaking existing clients.