### PR TITLE
Generate relationship fields in schema! block from foreign keys

### DIFF
--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -137,6 +137,12 @@ cargo install rapina-cli --features import-sqlite
 
 For each valid table, the command generates the same files as `rapina add resource`: a feature module (`src/<plural>/`), a `schema!` block in `src/entity.rs`, and a timestamped migration.
 
+When both sides of a foreign key are being imported, the command generates relationship fields in the `schema!` block instead of plain integer columns:
+
+- Non-nullable FK (`author_id NOT NULL → users.id`) → `author: User` (BelongsTo)
+- Nullable FK (`author_id NULL → users.id`) → `author: Option<User>` (BelongsTo)
+- Referenced table receives → `comments: Vec<Comment>` (HasMany)
+
 Tables are skipped if they have no primary key, a composite primary key, or are internal migration tables (`seaql_migrations`, `sqlx_migrations`, `__diesel_schema_migrations`).
 
 ### Re-importing with `--force`

--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -159,6 +159,12 @@ cargo install rapina-cli --features import-sqlite
 
 For each valid table, the command generates the same files as `rapina add resource`: a feature module (`src/<plural>/`), a `schema!` block in `src/entity.rs`, and a timestamped migration.
 
+When both sides of a foreign key are being imported, the command generates relationship fields in the `schema!` block instead of plain integer columns:
+
+- Non-nullable FK (`author_id NOT NULL → users.id`) → `author: User` (BelongsTo)
+- Nullable FK (`author_id NULL → users.id`) → `author: Option<User>` (BelongsTo)
+- Referenced table receives → `comments: Vec<Comment>` (HasMany)
+
 Tables are skipped if they have no primary key, a composite primary key, or are internal migration tables (`seaql_migrations`, `sqlx_migrations`, `__diesel_schema_migrations`).
 
 ### Re-importing with `--force`

--- a/rapina-cli/src/commands/add.rs
+++ b/rapina-cli/src/commands/add.rs
@@ -48,7 +48,7 @@ pub fn resource(name: String, fields: Vec<FieldInfo>, with_timestamps: bool) -> 
     let timestamps_attr = if with_timestamps { None } else { Some("none") };
 
     codegen::create_feature_module(&name, plural, pascal, &fields, &pk_type, false)?;
-    codegen::update_entity_file(pascal, &fields, timestamps_attr, None, false)?;
+    codegen::update_entity_file(pascal, &fields, timestamps_attr, None, false, &[])?;
     codegen::create_migration_file(plural, pascal_plural, &fields, with_timestamps, None)?;
 
     if let Err(e) = codegen::wire_main_rs(&[plural.as_str()], Path::new(".")) {
@@ -220,7 +220,7 @@ mod tests {
             "title:string".parse().unwrap(),
             "done:bool".parse().unwrap(),
         ];
-        let content = codegen::generate_schema_block("Todo", &fields, None, None);
+        let content = codegen::generate_schema_block("Todo", &fields, None, None, &[]);
 
         assert!(content.contains("schema! {"));
         assert!(content.contains("Todo {"));

--- a/rapina-cli/src/commands/add.rs
+++ b/rapina-cli/src/commands/add.rs
@@ -48,7 +48,7 @@ pub fn resource(name: String, fields: Vec<FieldInfo>, with_timestamps: bool) -> 
     let timestamps_attr = if with_timestamps { None } else { Some("none") };
 
     codegen::create_feature_module(&name, plural, pascal, &fields, &pk_type, false)?;
-    codegen::update_entity_file(pascal, &fields, timestamps_attr, None, false)?;
+    codegen::update_entity_file(pascal, &fields, timestamps_attr, None, false, &[])?;
     codegen::create_migration_file(plural, pascal_plural, &fields, with_timestamps)?;
 
     if let Err(e) = codegen::wire_main_rs(&[plural.as_str()], Path::new(".")) {
@@ -220,7 +220,7 @@ mod tests {
             "title:string".parse().unwrap(),
             "done:bool".parse().unwrap(),
         ];
-        let content = codegen::generate_schema_block("Todo", &fields, None, None);
+        let content = codegen::generate_schema_block("Todo", &fields, None, None, &[]);
 
         assert!(content.contains("schema! {"));
         assert!(content.contains("Todo {"));

--- a/rapina-cli/src/commands/codegen.rs
+++ b/rapina-cli/src/commands/codegen.rs
@@ -4,6 +4,8 @@ use super::{Colorize, FieldInfo, NormalizedType};
 use std::fs;
 use std::path::Path;
 
+pub(crate) use super::relationships::{RelationshipKind, RelationshipSpec};
+
 pub(crate) fn to_pascal_case(s: &str) -> String {
     s.split('_')
         .map(|part| {
@@ -450,8 +452,9 @@ pub(crate) fn generate_schema_block(
     fields: &[FieldInfo],
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
+    relationships: &[RelationshipSpec],
 ) -> String {
-    let schema_fields: Vec<String> = fields
+    let mut all_field_lines: Vec<String> = fields
         .iter()
         .map(|f| {
             format!(
@@ -461,6 +464,21 @@ pub(crate) fn generate_schema_block(
             )
         })
         .collect();
+
+    for r in relationships {
+        let line = match r.kind {
+            RelationshipKind::BelongsTo { nullable: true } => {
+                format!("        {}: Option<{}>,", r.field_name, r.related_pascal)
+            }
+            RelationshipKind::BelongsTo { nullable: false } => {
+                format!("        {}: {},", r.field_name, r.related_pascal)
+            }
+            RelationshipKind::HasMany => {
+                format!("        {}: Vec<{}>,", r.field_name, r.related_pascal)
+            }
+        };
+        all_field_lines.push(line);
+    }
 
     let mut attrs = String::new();
 
@@ -483,7 +501,7 @@ schema! {{
 "#,
         pascal = pascal,
         attrs = attrs,
-        fields = schema_fields.join("\n"),
+        fields = all_field_lines.join("\n"),
     )
 }
 
@@ -615,6 +633,7 @@ pub(crate) fn update_entity_file(
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
     force: bool,
+    relationships: &[RelationshipSpec],
 ) -> Result<(), String> {
     update_entity_file_in(
         pascal,
@@ -622,6 +641,7 @@ pub(crate) fn update_entity_file(
         timestamps,
         primary_key,
         force,
+        relationships,
         Path::new("src/entity.rs"),
     )
 }
@@ -632,9 +652,11 @@ fn update_entity_file_in(
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
     force: bool,
+    relationships: &[RelationshipSpec],
     entity_path: &Path,
 ) -> Result<(), String> {
-    let schema_block = generate_schema_block(pascal, fields, timestamps, primary_key);
+    let schema_block =
+        generate_schema_block(pascal, fields, timestamps, primary_key, relationships);
 
     if entity_path.exists() {
         let mut content = fs::read_to_string(entity_path)
@@ -1262,7 +1284,7 @@ mod tests {
             "title:string".parse().unwrap(),
             "done:bool".parse().unwrap(),
         ];
-        let content = generate_schema_block("Todo", &fields, None, None);
+        let content = generate_schema_block("Todo", &fields, None, None, &[]);
 
         assert!(content.contains("title: String,"));
         assert!(content.contains("done: bool,"));
@@ -1365,16 +1387,16 @@ mod tests {
     fn test_generate_schema_block_with_timestamps() {
         let fields = vec!["title:string".parse().unwrap()];
 
-        let block = generate_schema_block("Post", &fields, None, None);
+        let block = generate_schema_block("Post", &fields, None, None, &[]);
         assert!(block.contains("schema! {"));
         assert!(block.contains("Post {"));
         assert!(block.contains("title: String,"));
         assert!(!block.contains("#[timestamps"));
 
-        let block = generate_schema_block("Post", &fields, Some("none"), None);
+        let block = generate_schema_block("Post", &fields, Some("none"), None, &[]);
         assert!(block.contains("#[timestamps(none)]"));
 
-        let block = generate_schema_block("Post", &fields, Some("created_at"), None);
+        let block = generate_schema_block("Post", &fields, Some("created_at"), None, &[]);
         assert!(block.contains("#[timestamps(created_at)]"));
     }
 
@@ -1386,11 +1408,42 @@ mod tests {
         ];
 
         let pk = vec!["user_id".to_string(), "role_id".to_string()];
-        let block = generate_schema_block("UsersRole", &fields, Some("none"), Some(&pk));
+        let block = generate_schema_block("UsersRole", &fields, Some("none"), Some(&pk), &[]);
         assert!(block.contains("#[primary_key(user_id, role_id)]"));
         assert!(block.contains("#[timestamps(none)]"));
         assert!(block.contains("user_id: i32,"));
         assert!(block.contains("role_id: i32,"));
+    }
+
+    #[test]
+    fn test_generate_schema_block_with_relationships() {
+        let fields = vec!["title:string".parse().unwrap()];
+
+        let rels = vec![
+            RelationshipSpec {
+                field_name: "user".to_string(),
+                related_pascal: "User".to_string(),
+                kind: RelationshipKind::BelongsTo { nullable: false },
+            },
+            RelationshipSpec {
+                field_name: "comments".to_string(),
+                related_pascal: "Comment".to_string(),
+                kind: RelationshipKind::HasMany,
+            },
+        ];
+
+        let block = generate_schema_block("Post", &fields, None, None, &rels);
+        assert!(block.contains("title: String,"));
+        assert!(block.contains("user: User,"));
+        assert!(block.contains("comments: Vec<Comment>,"));
+
+        let nullable_rels = vec![RelationshipSpec {
+            field_name: "author".to_string(),
+            related_pascal: "User".to_string(),
+            kind: RelationshipKind::BelongsTo { nullable: true },
+        }];
+        let block = generate_schema_block("Comment", &fields, None, None, &nullable_rels);
+        assert!(block.contains("author: Option<User>,"));
     }
 
     #[test]
@@ -1493,7 +1546,7 @@ schema! {
 
         let fields = vec!["title:string".parse().unwrap()];
 
-        update_entity_file_in("Post", &fields, None, None, true, &entity_path).unwrap();
+        update_entity_file_in("Post", &fields, None, None, true, &[], &entity_path).unwrap();
         let content = fs::read_to_string(&entity_path).unwrap();
         // Should have exactly one schema! block for Post, not two
         assert_eq!(content.matches("Post {").count(), 1);
@@ -1519,7 +1572,7 @@ schema! {
 
         let fields = vec!["title:string".parse().unwrap()];
 
-        update_entity_file_in("Post", &fields, None, None, false, &entity_path).unwrap();
+        update_entity_file_in("Post", &fields, None, None, false, &[], &entity_path).unwrap();
         let content = fs::read_to_string(&entity_path).unwrap();
         // Without force, should have two schema! blocks (duplicate)
         assert_eq!(content.matches("Post {").count(), 2);

--- a/rapina-cli/src/commands/codegen.rs
+++ b/rapina-cli/src/commands/codegen.rs
@@ -4,6 +4,21 @@ use super::{Colorize, FieldInfo, NormalizedType};
 use std::fs;
 use std::path::Path;
 
+pub(crate) struct RelationshipSpec {
+    pub field_name: String,
+    pub related_pascal: String,
+    pub nullable: bool,
+    pub kind: RelationshipKind,
+}
+
+// Construction sites live in import.rs, which is #[cfg(feature = "import")].
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum RelationshipKind {
+    BelongsTo,
+    HasMany,
+}
+
 pub(crate) fn to_pascal_case(s: &str) -> String {
     s.split('_')
         .map(|part| {
@@ -450,8 +465,9 @@ pub(crate) fn generate_schema_block(
     fields: &[FieldInfo],
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
+    relationships: &[RelationshipSpec],
 ) -> String {
-    let schema_fields: Vec<String> = fields
+    let mut all_field_lines: Vec<String> = fields
         .iter()
         .map(|f| {
             format!(
@@ -461,6 +477,22 @@ pub(crate) fn generate_schema_block(
             )
         })
         .collect();
+
+    for r in relationships {
+        let line = match r.kind {
+            RelationshipKind::BelongsTo => {
+                if r.nullable {
+                    format!("        {}: Option<{}>,", r.field_name, r.related_pascal)
+                } else {
+                    format!("        {}: {},", r.field_name, r.related_pascal)
+                }
+            }
+            RelationshipKind::HasMany => {
+                format!("        {}: Vec<{}>,", r.field_name, r.related_pascal)
+            }
+        };
+        all_field_lines.push(line);
+    }
 
     let mut attrs = String::new();
 
@@ -483,7 +515,7 @@ schema! {{
 "#,
         pascal = pascal,
         attrs = attrs,
-        fields = schema_fields.join("\n"),
+        fields = all_field_lines.join("\n"),
     )
 }
 
@@ -606,6 +638,7 @@ pub(crate) fn update_entity_file(
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
     force: bool,
+    relationships: &[RelationshipSpec],
 ) -> Result<(), String> {
     update_entity_file_in(
         pascal,
@@ -613,6 +646,7 @@ pub(crate) fn update_entity_file(
         timestamps,
         primary_key,
         force,
+        relationships,
         Path::new("src/entity.rs"),
     )
 }
@@ -623,9 +657,11 @@ fn update_entity_file_in(
     timestamps: Option<&str>,
     primary_key: Option<&[String]>,
     force: bool,
+    relationships: &[RelationshipSpec],
     entity_path: &Path,
 ) -> Result<(), String> {
-    let schema_block = generate_schema_block(pascal, fields, timestamps, primary_key);
+    let schema_block =
+        generate_schema_block(pascal, fields, timestamps, primary_key, relationships);
 
     if entity_path.exists() {
         let mut content = fs::read_to_string(entity_path)
@@ -1252,7 +1288,7 @@ mod tests {
             "title:string".parse().unwrap(),
             "done:bool".parse().unwrap(),
         ];
-        let content = generate_schema_block("Todo", &fields, None, None);
+        let content = generate_schema_block("Todo", &fields, None, None, &[]);
 
         assert!(content.contains("title: String,"));
         assert!(content.contains("done: bool,"));
@@ -1274,16 +1310,16 @@ mod tests {
     fn test_generate_schema_block_with_timestamps() {
         let fields = vec!["title:string".parse().unwrap()];
 
-        let block = generate_schema_block("Post", &fields, None, None);
+        let block = generate_schema_block("Post", &fields, None, None, &[]);
         assert!(block.contains("schema! {"));
         assert!(block.contains("Post {"));
         assert!(block.contains("title: String,"));
         assert!(!block.contains("#[timestamps"));
 
-        let block = generate_schema_block("Post", &fields, Some("none"), None);
+        let block = generate_schema_block("Post", &fields, Some("none"), None, &[]);
         assert!(block.contains("#[timestamps(none)]"));
 
-        let block = generate_schema_block("Post", &fields, Some("created_at"), None);
+        let block = generate_schema_block("Post", &fields, Some("created_at"), None, &[]);
         assert!(block.contains("#[timestamps(created_at)]"));
     }
 
@@ -1295,11 +1331,45 @@ mod tests {
         ];
 
         let pk = vec!["user_id".to_string(), "role_id".to_string()];
-        let block = generate_schema_block("UsersRole", &fields, Some("none"), Some(&pk));
+        let block = generate_schema_block("UsersRole", &fields, Some("none"), Some(&pk), &[]);
         assert!(block.contains("#[primary_key(user_id, role_id)]"));
         assert!(block.contains("#[timestamps(none)]"));
         assert!(block.contains("user_id: i32,"));
         assert!(block.contains("role_id: i32,"));
+    }
+
+    #[test]
+    fn test_generate_schema_block_with_relationships() {
+        let fields = vec!["title:string".parse().unwrap()];
+
+        let rels = vec![
+            RelationshipSpec {
+                field_name: "user".to_string(),
+                related_pascal: "User".to_string(),
+                nullable: false,
+                kind: RelationshipKind::BelongsTo,
+            },
+            RelationshipSpec {
+                field_name: "comments".to_string(),
+                related_pascal: "Comment".to_string(),
+                nullable: false,
+                kind: RelationshipKind::HasMany,
+            },
+        ];
+
+        let block = generate_schema_block("Post", &fields, None, None, &rels);
+        assert!(block.contains("title: String,"));
+        assert!(block.contains("user: User,"));
+        assert!(block.contains("comments: Vec<Comment>,"));
+
+        let nullable_rels = vec![RelationshipSpec {
+            field_name: "author".to_string(),
+            related_pascal: "User".to_string(),
+            nullable: true,
+            kind: RelationshipKind::BelongsTo,
+        }];
+        let block = generate_schema_block("Comment", &fields, None, None, &nullable_rels);
+        assert!(block.contains("author: Option<User>,"));
     }
 
     #[test]
@@ -1402,7 +1472,7 @@ schema! {
 
         let fields = vec!["title:string".parse().unwrap()];
 
-        update_entity_file_in("Post", &fields, None, None, true, &entity_path).unwrap();
+        update_entity_file_in("Post", &fields, None, None, true, &[], &entity_path).unwrap();
         let content = fs::read_to_string(&entity_path).unwrap();
         // Should have exactly one schema! block for Post, not two
         assert_eq!(content.matches("Post {").count(), 1);
@@ -1428,7 +1498,7 @@ schema! {
 
         let fields = vec!["title:string".parse().unwrap()];
 
-        update_entity_file_in("Post", &fields, None, None, false, &entity_path).unwrap();
+        update_entity_file_in("Post", &fields, None, None, false, &[], &entity_path).unwrap();
         let content = fs::read_to_string(&entity_path).unwrap();
         // Without force, should have two schema! blocks (duplicate)
         assert_eq!(content.matches("Post {").count(), 2);

--- a/rapina-cli/src/commands/import.rs
+++ b/rapina-cli/src/commands/import.rs
@@ -425,17 +425,21 @@ fn filter_and_validate_tables(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct RelationshipInfo {
     field_name: String,
     related_pascal: String,
-    kind: RelationKind,
+    kind: codegen::RelationshipKind,
+    fk_col: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-enum RelationKind {
-    BelongsTo,
-    HasMany,
+impl From<&RelationshipInfo> for codegen::RelationshipSpec {
+    fn from(r: &RelationshipInfo) -> Self {
+        codegen::RelationshipSpec {
+            field_name: r.field_name.clone(),
+            related_pascal: r.related_pascal.clone(),
+            kind: r.kind,
+        }
+    }
 }
 
 fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<RelationshipInfo>> {
@@ -460,6 +464,15 @@ fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<Re
             let ref_singular = codegen::singularize(&fk.referenced_table);
             let ref_pascal = codegen::to_pascal_case(&ref_singular);
 
+            let Some(col) = table.columns.iter().find(|c| &c.name == fk_column) else {
+                eprintln!(
+                    "  {} table {:?}: FK column {:?} not found in column list — skipping relationship",
+                    "warn:".yellow(),
+                    table.name,
+                    fk_column
+                );
+                continue;
+            };
             // BelongsTo on the FK side
             relationships
                 .entry(table.name.clone())
@@ -467,20 +480,29 @@ fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<Re
                 .push(RelationshipInfo {
                     field_name: field_name.to_string(),
                     related_pascal: ref_pascal.clone(),
-                    kind: RelationKind::BelongsTo,
+                    kind: codegen::RelationshipKind::BelongsTo {
+                        nullable: col.is_nullable,
+                    },
+                    fk_col: Some(fk_column.to_string()),
                 });
 
-            // HasMany on the referenced side
-            let owner_singular = codegen::singularize(&table.name);
-            let owner_pascal = codegen::to_pascal_case(&owner_singular);
-            relationships
+            // HasMany on the referenced side — deduplicated so that multiple FKs
+            // from the same table to the same target don't produce repeated entries.
+            // O(n²) over FKs per table, but this is a one-shot CLI path, not a hot loop.
+            let owner_pascal = codegen::to_pascal_case(&codegen::singularize(&table.name));
+            let ref_rels = relationships
                 .entry(fk.referenced_table.clone())
-                .or_default()
-                .push(RelationshipInfo {
+                .or_default();
+            if !ref_rels.iter().any(|r| {
+                matches!(r.kind, codegen::RelationshipKind::HasMany) && r.field_name == table.name
+            }) {
+                ref_rels.push(RelationshipInfo {
                     field_name: table.name.clone(),
                     related_pascal: owner_pascal,
-                    kind: RelationKind::HasMany,
+                    kind: codegen::RelationshipKind::HasMany,
+                    fk_col: None,
                 });
+            }
         }
     }
 
@@ -509,7 +531,7 @@ fn detect_timestamps(table: &IntrospectedTable) -> Option<&'static str> {
 
 fn generate_for_table(
     table: &IntrospectedTable,
-    _relationships: &HashMap<String, Vec<RelationshipInfo>>,
+    relationships: &HashMap<String, Vec<RelationshipInfo>>,
     force: bool,
 ) -> Result<(), String> {
     let singular = codegen::singularize(&table.name);
@@ -579,7 +601,38 @@ fn generate_for_table(
         .cloned()
         .unwrap_or(NormalizedType::I32);
 
-    codegen::update_entity_file(&pascal, &fields, timestamps, primary_key.as_deref(), force)?;
+    // Resolve relationships for this table and build codegen specs.
+    let table_rels = relationships
+        .get(&table.name)
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+
+    // FK columns covered by a BelongsTo are emitted as relationship fields in
+    // schema!, so exclude them from the plain field list to avoid duplicates.
+    let fk_cols_to_skip: std::collections::HashSet<&str> = table_rels
+        .iter()
+        .filter_map(|r| match r.kind {
+            codegen::RelationshipKind::BelongsTo { .. } => r.fk_col.as_deref(),
+            codegen::RelationshipKind::HasMany => None,
+        })
+        .collect();
+
+    let entity_fields: Vec<FieldInfo> = fields
+        .iter()
+        .filter(|f| !fk_cols_to_skip.contains(f.name.as_str()))
+        .cloned()
+        .collect();
+
+    let rel_specs: Vec<codegen::RelationshipSpec> = table_rels.iter().map(Into::into).collect();
+
+    codegen::update_entity_file(
+        &pascal,
+        &entity_fields,
+        timestamps,
+        primary_key.as_deref(),
+        force,
+        &rel_specs,
+    )?;
     codegen::create_migration_file(
         plural,
         &pascal_plural,
@@ -587,7 +640,7 @@ fn generate_for_table(
         false,
         primary_key.as_deref(),
     )?;
-    codegen::create_feature_module(&singular, plural, &pascal, &fields, &pk_type, force)?;
+    codegen::create_feature_module(&singular, plural, &pascal, &entity_fields, &pk_type, force)?;
 
     println!(
         "  {} Imported table {:?} as {} ({} columns, {} skipped)",
@@ -1073,14 +1126,131 @@ mod tests {
         assert_eq!(post_rels.len(), 1);
         assert_eq!(post_rels[0].field_name, "user");
         assert_eq!(post_rels[0].related_pascal, "User");
-        assert!(matches!(post_rels[0].kind, RelationKind::BelongsTo));
+        assert!(matches!(
+            post_rels[0].kind,
+            codegen::RelationshipKind::BelongsTo { nullable: false }
+        ));
+        assert_eq!(post_rels[0].fk_col, Some("user_id".to_string()));
 
         // users should have a HasMany Post
         let user_rels = rels.get("users").unwrap();
         assert_eq!(user_rels.len(), 1);
         assert_eq!(user_rels[0].field_name, "posts");
         assert_eq!(user_rels[0].related_pascal, "Post");
-        assert!(matches!(user_rels[0].kind, RelationKind::HasMany));
+        assert!(matches!(
+            user_rels[0].kind,
+            codegen::RelationshipKind::HasMany
+        ));
+        assert_eq!(user_rels[0].fk_col, None);
+    }
+
+    #[test]
+    fn test_resolve_relationships_nullable_fk() {
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: ImportType::Standard(NormalizedType::I32),
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "comments".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "author_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: true,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![IntrospectedForeignKey {
+                    columns: vec!["author_id".into()],
+                    referenced_table: "users".into(),
+                    referenced_columns: vec!["id".into()],
+                }],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+
+        let comment_rels = rels.get("comments").unwrap();
+        assert_eq!(comment_rels[0].field_name, "author");
+        assert!(matches!(
+            comment_rels[0].kind,
+            codegen::RelationshipKind::BelongsTo { nullable: true }
+        ));
+        assert_eq!(comment_rels[0].fk_col, Some("author_id".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_relationships_deduplicates_has_many() {
+        // comments has two FKs to users (author_id and reviewer_id);
+        // users should still get only one HasMany entry for comments.
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: ImportType::Standard(NormalizedType::I32),
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "comments".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "author_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "reviewer_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: true,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![
+                    IntrospectedForeignKey {
+                        columns: vec!["author_id".into()],
+                        referenced_table: "users".into(),
+                        referenced_columns: vec!["id".into()],
+                    },
+                    IntrospectedForeignKey {
+                        columns: vec!["reviewer_id".into()],
+                        referenced_table: "users".into(),
+                        referenced_columns: vec!["id".into()],
+                    },
+                ],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+
+        // comments gets two BelongsTo entries (one per FK)
+        let comment_rels = rels.get("comments").unwrap();
+        assert_eq!(comment_rels.len(), 2);
+
+        // users gets exactly one HasMany entry for comments, not two
+        let user_rels = rels.get("users").unwrap();
+        assert_eq!(user_rels.len(), 1);
+        assert_eq!(user_rels[0].field_name, "comments");
     }
 
     #[cfg(feature = "import-postgres")]

--- a/rapina-cli/src/commands/import.rs
+++ b/rapina-cli/src/commands/import.rs
@@ -425,17 +425,12 @@ fn filter_and_validate_tables(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 struct RelationshipInfo {
     field_name: String,
     related_pascal: String,
-    kind: RelationKind,
-}
-
-#[derive(Debug, Clone)]
-enum RelationKind {
-    BelongsTo,
-    HasMany,
+    kind: codegen::RelationshipKind,
+    nullable: bool,
+    fk_col: Option<String>,
 }
 
 fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<RelationshipInfo>> {
@@ -460,6 +455,13 @@ fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<Re
             let ref_singular = codegen::singularize(&fk.referenced_table);
             let ref_pascal = codegen::to_pascal_case(&ref_singular);
 
+            let nullable = table
+                .columns
+                .iter()
+                .find(|c| &c.name == fk_column)
+                .map(|c| c.is_nullable)
+                .unwrap_or(false);
+
             // BelongsTo on the FK side
             relationships
                 .entry(table.name.clone())
@@ -467,20 +469,28 @@ fn resolve_relationships(tables: &[IntrospectedTable]) -> HashMap<String, Vec<Re
                 .push(RelationshipInfo {
                     field_name: field_name.to_string(),
                     related_pascal: ref_pascal.clone(),
-                    kind: RelationKind::BelongsTo,
+                    kind: codegen::RelationshipKind::BelongsTo,
+                    nullable,
+                    fk_col: Some(fk_column.to_string()),
                 });
 
-            // HasMany on the referenced side
-            let owner_singular = codegen::singularize(&table.name);
-            let owner_pascal = codegen::to_pascal_case(&owner_singular);
-            relationships
+            // HasMany on the referenced side — deduplicated so that multiple FKs
+            // from the same table to the same target don't produce repeated entries.
+            let owner_pascal = codegen::to_pascal_case(&codegen::singularize(&table.name));
+            let ref_rels = relationships
                 .entry(fk.referenced_table.clone())
-                .or_default()
-                .push(RelationshipInfo {
+                .or_default();
+            if !ref_rels.iter().any(|r| {
+                matches!(r.kind, codegen::RelationshipKind::HasMany) && r.field_name == table.name
+            }) {
+                ref_rels.push(RelationshipInfo {
                     field_name: table.name.clone(),
                     related_pascal: owner_pascal,
-                    kind: RelationKind::HasMany,
+                    kind: codegen::RelationshipKind::HasMany,
+                    nullable: false,
+                    fk_col: None,
                 });
+            }
         }
     }
 
@@ -509,7 +519,7 @@ fn detect_timestamps(table: &IntrospectedTable) -> Option<&'static str> {
 
 fn generate_for_table(
     table: &IntrospectedTable,
-    _relationships: &HashMap<String, Vec<RelationshipInfo>>,
+    relationships: &HashMap<String, Vec<RelationshipInfo>>,
     force: bool,
 ) -> Result<(), String> {
     let singular = codegen::singularize(&table.name);
@@ -579,7 +589,46 @@ fn generate_for_table(
         .cloned()
         .unwrap_or(NormalizedType::I32);
 
-    codegen::update_entity_file(&pascal, &fields, timestamps, primary_key.as_deref(), force)?;
+    // Resolve relationships for this table and build codegen specs.
+    let table_rels = relationships
+        .get(&table.name)
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+
+    // FK columns covered by a BelongsTo are emitted as relationship fields in
+    // schema!, so exclude them from the plain field list to avoid duplicates.
+    let fk_cols_to_skip: std::collections::HashSet<&str> = table_rels
+        .iter()
+        .filter_map(|r| match r.kind {
+            codegen::RelationshipKind::BelongsTo => r.fk_col.as_deref(),
+            codegen::RelationshipKind::HasMany => None,
+        })
+        .collect();
+
+    let entity_fields: Vec<FieldInfo> = fields
+        .iter()
+        .filter(|f| !fk_cols_to_skip.contains(f.name.as_str()))
+        .cloned()
+        .collect();
+
+    let rel_specs: Vec<codegen::RelationshipSpec> = table_rels
+        .iter()
+        .map(|r| codegen::RelationshipSpec {
+            field_name: r.field_name.clone(),
+            related_pascal: r.related_pascal.clone(),
+            nullable: r.nullable,
+            kind: r.kind,
+        })
+        .collect();
+
+    codegen::update_entity_file(
+        &pascal,
+        &entity_fields,
+        timestamps,
+        primary_key.as_deref(),
+        force,
+        &rel_specs,
+    )?;
     codegen::create_migration_file(plural, &pascal_plural, &fields, false)?;
     codegen::create_feature_module(&singular, plural, &pascal, &fields, &pk_type, force)?;
 
@@ -1067,14 +1116,130 @@ mod tests {
         assert_eq!(post_rels.len(), 1);
         assert_eq!(post_rels[0].field_name, "user");
         assert_eq!(post_rels[0].related_pascal, "User");
-        assert!(matches!(post_rels[0].kind, RelationKind::BelongsTo));
+        assert!(matches!(
+            post_rels[0].kind,
+            codegen::RelationshipKind::BelongsTo
+        ));
+        assert!(!post_rels[0].nullable);
+        assert_eq!(post_rels[0].fk_col, Some("user_id".to_string()));
 
         // users should have a HasMany Post
         let user_rels = rels.get("users").unwrap();
         assert_eq!(user_rels.len(), 1);
         assert_eq!(user_rels[0].field_name, "posts");
         assert_eq!(user_rels[0].related_pascal, "Post");
-        assert!(matches!(user_rels[0].kind, RelationKind::HasMany));
+        assert!(matches!(
+            user_rels[0].kind,
+            codegen::RelationshipKind::HasMany
+        ));
+        assert!(!user_rels[0].nullable);
+        assert_eq!(user_rels[0].fk_col, None);
+    }
+
+    #[test]
+    fn test_resolve_relationships_nullable_fk() {
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: ImportType::Standard(NormalizedType::I32),
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "comments".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "author_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: true,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![IntrospectedForeignKey {
+                    columns: vec!["author_id".into()],
+                    referenced_table: "users".into(),
+                    referenced_columns: vec!["id".into()],
+                }],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+
+        let comment_rels = rels.get("comments").unwrap();
+        assert_eq!(comment_rels[0].field_name, "author");
+        assert!(comment_rels[0].nullable);
+        assert_eq!(comment_rels[0].fk_col, Some("author_id".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_relationships_deduplicates_has_many() {
+        // comments has two FKs to users (author_id and reviewer_id);
+        // users should still get only one HasMany entry for comments.
+        let tables = vec![
+            IntrospectedTable {
+                name: "users".into(),
+                columns: vec![IntrospectedColumn {
+                    name: "id".into(),
+                    col_type: ImportType::Standard(NormalizedType::I32),
+                    is_nullable: false,
+                }],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![],
+            },
+            IntrospectedTable {
+                name: "comments".into(),
+                columns: vec![
+                    IntrospectedColumn {
+                        name: "id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "author_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: false,
+                    },
+                    IntrospectedColumn {
+                        name: "reviewer_id".into(),
+                        col_type: ImportType::Standard(NormalizedType::I32),
+                        is_nullable: true,
+                    },
+                ],
+                primary_key_columns: vec!["id".into()],
+                foreign_keys: vec![
+                    IntrospectedForeignKey {
+                        columns: vec!["author_id".into()],
+                        referenced_table: "users".into(),
+                        referenced_columns: vec!["id".into()],
+                    },
+                    IntrospectedForeignKey {
+                        columns: vec!["reviewer_id".into()],
+                        referenced_table: "users".into(),
+                        referenced_columns: vec!["id".into()],
+                    },
+                ],
+            },
+        ];
+
+        let rels = resolve_relationships(&tables);
+
+        // comments gets two BelongsTo entries (one per FK)
+        let comment_rels = rels.get("comments").unwrap();
+        assert_eq!(comment_rels.len(), 2);
+
+        // users gets exactly one HasMany entry for comments, not two
+        let user_rels = rels.get("users").unwrap();
+        assert_eq!(user_rels.len(), 1);
+        assert_eq!(user_rels[0].field_name, "comments");
     }
 
     #[cfg(feature = "import-postgres")]

--- a/rapina-cli/src/commands/mod.rs
+++ b/rapina-cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod llms;
 pub mod migrate;
 pub mod new;
 pub mod openapi;
+pub(crate) mod relationships;
 pub mod routes;
 #[cfg(feature = "seed")]
 pub mod seed;

--- a/rapina-cli/src/commands/relationships.rs
+++ b/rapina-cli/src/commands/relationships.rs
@@ -1,0 +1,14 @@
+pub(crate) struct RelationshipSpec {
+    pub field_name: String,
+    pub related_pascal: String,
+    pub kind: RelationshipKind,
+}
+
+// Variants are only constructed in import.rs, which is #[cfg(feature = "import")].
+// The allow is scoped to non-import builds where the construction sites are compiled out.
+#[cfg_attr(not(feature = "import"), allow(dead_code))]
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum RelationshipKind {
+    BelongsTo { nullable: bool },
+    HasMany,
+}


### PR DESCRIPTION
## Summary

- `rapina import database` now translates FK columns into `BelongsTo`/`HasMany` relationship fields in the generated `schema!` block instead of emitting them as plain integer columns
- Raw FK columns (e.g. `user_id`) are excluded from the scalar fields list; the owning side gets a `belongs_to: RelatedModel` (or `Option<RelatedModel>` if nullable) field instead
- The referenced side gets a `items: Vec<OwningModel>` has-many field; duplicate has-many entries from multiple FKs to the same target are deduplicated
- Introduces `RelationshipSpec` / `RelationshipKind` in `codegen.rs` and threads them through `generate_schema_block` and `update_entity_file`

## Related Issues

Closes #244

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
