### PR TITLE
fix(jwt): return error when validate_aud=true but set_audience() never called

### DIFF
--- a/rapina/src/health/endpoint.rs
+++ b/rapina/src/health/endpoint.rs
@@ -19,7 +19,6 @@ use crate::{
     response::{APPLICATION_JSON, BoxBody, full},
     state::AppState,
 };
-
 /// Handler for `GET /__rapina/health/live`.
 ///
 /// Always returns `200 OK` with `{"status": "ok"}` as long as the process is running.
@@ -73,6 +72,22 @@ pub async fn readiness_check(
                 if db_ok { "ok".into() } else { "error".into() },
             );
             if !db_ok {
+                all_ok = false;
+            }
+        }
+    }
+
+    // JWT configuration check — surfaces validate_aud misconfiguration before real traffic hits.
+    #[cfg(feature = "jwks")]
+    {
+        use jsonwebtoken::Validation;
+        if let Some(validation) = state.get::<Validation>() {
+            let jwt_ok = !(validation.validate_aud && validation.aud.is_none());
+            checks.insert(
+                "jwt".to_string(),
+                if jwt_ok { "ok".into() } else { "error".into() },
+            );
+            if !jwt_ok {
                 all_ok = false;
             }
         }
@@ -231,6 +246,42 @@ mod tests {
         assert_eq!(json["status"], "error");
         assert_eq!(json["checks"]["redis"], "ok");
         assert_eq!(json["checks"]["stripe"], "error");
+    }
+
+    #[cfg(feature = "jwks")]
+    #[tokio::test]
+    async fn test_readiness_check_jwt_misconfiguration_returns_503() {
+        use crate::jwt::default_validation;
+
+        let misconfigured = default_validation(); // validate_aud=true, aud=None
+        let app = Rapina::new().with_health_check(true).state(misconfigured);
+        let client = TestClient::new(app).await;
+        let response = client.get("/__rapina/health/ready").send().await;
+        let status = response.status();
+        let json = response.json::<Value>();
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["status"], "error");
+        assert_eq!(json["checks"]["jwt"], "error");
+    }
+
+    #[cfg(feature = "jwks")]
+    #[tokio::test]
+    async fn test_readiness_check_jwt_correctly_configured_returns_ok() {
+        use crate::jwt::default_validation;
+
+        let mut validation = default_validation();
+        validation.set_audience(&["https://example.com/api"]);
+        let app = Rapina::new().with_health_check(true).state(validation);
+        let client = TestClient::new(app).await;
+        let json = client
+            .get("/__rapina/health/ready")
+            .send()
+            .await
+            .json::<Value>();
+
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["checks"]["jwt"], "ok");
     }
 
     #[cfg(feature = "sqlite")]

--- a/rapina/src/jwt/extract.rs
+++ b/rapina/src/jwt/extract.rs
@@ -78,9 +78,9 @@ where
 
         let validation = if let Some(validation) = validation {
             if validation.validate_aud && validation.aud.is_none() {
-                tracing::debug!(
-                    "aud claim validation is enabled but validation.set_audience was not called"
-                );
+                return Err(Error::internal(
+                    "JWT misconfiguration: validate_aud is enabled but set_audience() was never called",
+                ));
             }
 
             let mut v = validation.clone();
@@ -172,12 +172,14 @@ mod tests {
     use crate::jwt;
     use crate::jwt::JwksClient;
     use crate::jwt::extract::{DefaultClaims, JsonWebToken};
+    use crate::jwt::jwks_client::{direct_for_test, oidc_for_test};
     use crate::prelude::Router;
     use crate::state::AppState;
     use crate::test::{TestRequest, empty_params, empty_state};
     use crate::testing::TestClient;
     use http::header;
     use http::header::AUTHORIZATION;
+    use jsonwebtoken::jwk::JwkSet;
     use std::net::SocketAddr;
     use std::sync::Arc;
 
@@ -225,15 +227,15 @@ mod tests {
 
     fn setup_jwks_client(addr: SocketAddr) -> JwksClient {
         let jwks_url = format!("http://{}/realms/master/protocol/openid-connect/cert", addr);
-        JwksClient::direct(jwks_url.to_string(), "* * * * * */5".to_string())
+        direct_for_test(jwks_url, "* * * * * */5".to_string())
     }
 
     fn setup_jwks_client_oidc_discovery(addr: SocketAddr) -> JwksClient {
-        let oidc_discovery_url = format!(
+        let discovery_url = format!(
             "http://{}/realms/master/.well-known/openid-configuration",
             addr
         );
-        JwksClient::oidc(oidc_discovery_url.to_string(), "* * * * * */5".to_string())
+        oidc_for_test(discovery_url, "* * * * * */5".to_string())
     }
 
     #[tokio::test]
@@ -346,5 +348,29 @@ mod tests {
         let error = result.expect_err("Expected extraction to fail");
         assert_eq!(error.status(), 500);
         assert!(error.message().contains("internal authentication error"));
+    }
+
+    #[test]
+    fn test_jsonwebtoken_new_aud_misconfiguration() {
+        let jwks: JwkSet = serde_json::from_str(AUTH0_SAMPLE_JWKS).unwrap();
+
+        // validate_aud=true but no audience set via set_audience() — silent bypass without this fix
+        let misconfigured_validation = jwt::default_validation();
+        assert!(misconfigured_validation.validate_aud);
+        assert!(misconfigured_validation.aud.is_none());
+
+        let result: Result<JsonWebToken<DefaultClaims>, Error> = JsonWebToken::new(
+            jwks,
+            Some(&misconfigured_validation),
+            TEST_TOKEN.to_string(),
+        );
+
+        let error = result.expect_err("Expected misconfiguration to fail");
+        assert_eq!(error.status(), 500);
+        assert!(
+            error
+                .message()
+                .contains("validate_aud is enabled but set_audience() was never called")
+        );
     }
 }

--- a/rapina/src/jwt/extract.rs
+++ b/rapina/src/jwt/extract.rs
@@ -78,9 +78,12 @@ where
 
         let validation = if let Some(validation) = validation {
             if validation.validate_aud && validation.aud.is_none() {
-                return Err(Error::internal(
-                    "JWT misconfiguration: validate_aud is enabled but set_audience() was never called",
-                ));
+                tracing::error!(
+                    "JWT misconfiguration: validate_aud is enabled but set_audience() was never called. All requests will fail until this is fixed."
+                );
+                panic!(
+                    "JWT misconfiguration: validate_aud is enabled but set_audience() was never called"
+                );
             }
 
             let mut v = validation.clone();
@@ -351,26 +354,21 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(
+        expected = "JWT misconfiguration: validate_aud is enabled but set_audience() was never called"
+    )]
     fn test_jsonwebtoken_new_aud_misconfiguration() {
         let jwks: JwkSet = serde_json::from_str(AUTH0_SAMPLE_JWKS).unwrap();
 
-        // validate_aud=true but no audience set via set_audience() — silent bypass without this fix
+        // validate_aud=true but no audience set via set_audience() — panics to fail fast
         let misconfigured_validation = jwt::default_validation();
         assert!(misconfigured_validation.validate_aud);
         assert!(misconfigured_validation.aud.is_none());
 
-        let result: Result<JsonWebToken<DefaultClaims>, Error> = JsonWebToken::new(
+        let _: Result<JsonWebToken<DefaultClaims>, Error> = JsonWebToken::new(
             jwks,
             Some(&misconfigured_validation),
             TEST_TOKEN.to_string(),
-        );
-
-        let error = result.expect_err("Expected misconfiguration to fail");
-        assert_eq!(error.status(), 500);
-        assert!(
-            error
-                .message()
-                .contains("validate_aud is enabled but set_audience() was never called")
         );
     }
 }

--- a/rapina/src/jwt/jwks_client.rs
+++ b/rapina/src/jwt/jwks_client.rs
@@ -188,6 +188,42 @@ async fn fetch_json_content<T: DeserializeOwned>(
     Ok(json)
 }
 
+/// Builds a `JwksClient` that accepts plain HTTP — for use in tests only.
+#[cfg(test)]
+pub(crate) fn direct_for_test(jwks_url: String, refresh_schedule: String) -> JwksClient {
+    let connector = HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .expect("no native root CA certificates found")
+        .https_or_http()
+        .enable_all_versions()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build(connector);
+    JwksClient::Direct {
+        client,
+        jwks_url,
+        refresh_schedule,
+        cache: Arc::new(RwLock::new(None)),
+    }
+}
+
+/// Builds an OIDC `JwksClient` that accepts plain HTTP — for use in tests only.
+#[cfg(test)]
+pub(crate) fn oidc_for_test(discovery_url: String, refresh_schedule: String) -> JwksClient {
+    let connector = HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .expect("no native root CA certificates found")
+        .https_or_http()
+        .enable_all_versions()
+        .build();
+    let client = Client::builder(TokioExecutor::new()).build(connector);
+    JwksClient::Oidc {
+        client,
+        discovery_url,
+        refresh_schedule,
+        cache: Arc::new(RwLock::new(None)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,17 +235,6 @@ mod tests {
     use std::net::SocketAddr;
 
     const AUTH0_SAMPLE_JWKS: &str = r#"{"keys":[{"alg":"RS256","kty":"RSA","use":"sig","n":"2V31IZF-EY2GxXQPI5OaEE--sezizPamNZDW9AjBE2cCErfufM312nT2jUsCnfjsXnh6Z_b-ncOMr97zIZkq1ofU7avemv8nX7NpKmoPBpVrMPprOax2-e3wt-bSfFLIHyghjFLKpkT0LOL_Fimi7xY-J86R06WHojLo3yGzAgQCswZmD4CFf6NcBWDcb6l6kx5vk_AdzHIkVEZH4aikUL_fn3zq5qbE25oOg6pT7F7Pp4zdHOAEKnIRS8tvP8tvvVRkUCrjBxz_Kx6Ne1YOD-fkIMRk_MgIWeKZZzZOYx4VrC0vqYiM-PcKWbNdt1kNoTHOeL06XZeSE6WPZ3VB1Q","e":"AQAB","kid":"1Z57d_i7TE6KTY57pKzDy","x5t":"1gA-aTE9VglLXZnrqvzwWhHsFdk","x5c":["MIIDDTCCAfWgAwIBAgIJHwhLfcIbNvmkMA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNVBAMTGWRldi1kdXp5YXlrNC5ldS5hdXRoMC5jb20wHhcNMjEwNjEzMDcxMTQ1WhcNMzUwMjIwMDcxMTQ1WjAkMSIwIAYDVQQDExlkZXYtZHV6eWF5azQuZXUuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2V31IZF+EY2GxXQPI5OaEE++sezizPamNZDW9AjBE2cCErfufM312nT2jUsCnfjsXnh6Z/b+ncOMr97zIZkq1ofU7avemv8nX7NpKmoPBpVrMPprOax2+e3wt+bSfFLIHyghjFLKpkT0LOL/Fimi7xY+J86R06WHojLo3yGzAgQCswZmD4CFf6NcBWDcb6l6kx5vk/AdzHIkVEZH4aikUL/fn3zq5qbE25oOg6pT7F7Pp4zdHOAEKnIRS8tvP8tvvVRkUCrjBxz/Kx6Ne1YOD+fkIMRk/MgIWeKZZzZOYx4VrC0vqYiM+PcKWbNdt1kNoTHOeL06XZeSE6WPZ3VB1QIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRPX3shmtgajnR4ly5t9VYB66ufGDAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAHtKpX70WU4uXOMjbFKj0e9HMXyCrdcX6TuYiMFqqlOGWM4yghSM8Bd0HkKcirm4DUoC+1dDMzXMZ+tbntavPt1xG0eRFjeocP+kIYTMQEG2LDM5HQ+Z7bdcwlxnuYOZQfpgKAfYbQ8Cxu38sB6q82I+5NJ0w0VXuG7nUZ1RD+rkXaeMYHNoibAtKBoTWrCaFWGV0E55OM+H0ckcHKUUnNXJOyZ+zEOzPFY5iuYIUmn1LfR1P0SLgIMfiooNC5ZuR/wLdbtyKtor2vzz7niEiewz+aPvfuPnWe/vMtQrfS37/yEhCozFnbIps/+S2Ay78mNBDuOAA9fg5yrnOmjABCU="]},{"alg":"RS256","kty":"RSA","use":"sig","n":"0KDpAuJZyDwPg9CfKi0R3QwDROyH0rvd39lmAoqQNqtYPghDToxFMDLpul0QHttbofHPJMKrPfeEFEOvw7KJgelCHZmckVKaz0e4tfu_2Uvw2kFljCmJGfspUU3mXxLyEea9Ef9JqUru6L8f_0_JIDMT3dceqU5ZqbG8u6-HRgRQ5Jqc_fF29Xyw3gxNP_Q46nsp_0yE68UZE1iPy1om0mpu8mpsY1-Nbvm51C8i4_tFQHdUXbhF4cjAoR0gZFNkzr7FCrL4On0hKeLcvxIHD17SxaBsTuCBGd35g7TmXsA4hSimD9taRHA-SkXh558JG5dr-YV9x80qjeSAvTyjcQ","e":"AQAB","kid":"v2HFn4VqJB-U4vtQRJ3Ql","x5t":"AhUBZjtsFdx7C1PFtWAJ756bo5k","x5c":["MIIDDTCCAfWgAwIBAgIJSSFLkuG8uAM8MA0GCSqGSIb3DQEBCwUAMCQxIjAgBgNVBAMTGWRldi1kdXp5YXlrNC5ldS5hdXRoMC5jb20wHhcNMjEwNjEzMDcxMTQ2WhcNMzUwMjIwMDcxMTQ2WjAkMSIwIAYDVQQDExlkZXYtZHV6eWF5azQuZXUuYXV0aDAuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0KDpAuJZyDwPg9CfKi0R3QwDROyH0rvd39lmAoqQNqtYPghDToxFMDLpul0QHttbofHPJMKrPfeEFEOvw7KJgelCHZmckVKaz0e4tfu/2Uvw2kFljCmJGfspUU3mXxLyEea9Ef9JqUru6L8f/0/JIDMT3dceqU5ZqbG8u6+HRgRQ5Jqc/fF29Xyw3gxNP/Q46nsp/0yE68UZE1iPy1om0mpu8mpsY1+Nbvm51C8i4/tFQHdUXbhF4cjAoR0gZFNkzr7FCrL4On0hKeLcvxIHD17SxaBsTuCBGd35g7TmXsA4hSimD9taRHA+SkXh558JG5dr+YV9x80qjeSAvTyjcQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSEkRwvkyYzzzY/jPd1n7/1VRQNdzAOBgNVHQ8BAf8EBAMCAoQwDQYJKoZIhvcNAQELBQADggEBAGtdl7QwzpaWZjbmd6UINAIlpuWIo2v4EJD9kGan/tUZTiUdBaJVwFHOkLRsbZHc5PmBB5IryjOcrqsmKvFdo6wUZA92qTuQVZrOTea07msOKSWE6yRUh1/VCXH2+vAiB9A4DFZ23WpZikBR+DmiD8NGwVgAwWw9jM6pe7ODY+qxFXGjQdTCHcDdbqG2160nKEHCBvjR1Sc/F0pzHPv8CBJCyGAPTCXX42sKZI92pPzdKSmNNijCuIEYLsjzKVxaUuwEqIshk3mYeu6im4VmXXFj+MlyMsusVWi2py7fGFadamzyiV/bxZe+4xzzrRG1Kow/WnVEizfTdEzFXO6YikE="]}]}"#;
-
-    /// Builds a client that accepts plain HTTP (test servers only).
-    fn build_test_http_client() -> HttpsClient {
-        let connector = HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .expect("no native root CA certificates found")
-            .https_or_http()
-            .enable_all_versions()
-            .build();
-        Client::builder(TokioExecutor::new()).build(connector)
-    }
 
     fn generate_oidc_discovery_content(port: &str) -> Json<serde_json::Value> {
         let string = format!("http://{}/realms/master/protocol/openid-connect/cert", port);
@@ -251,25 +276,15 @@ mod tests {
 
     fn setup_jwks_client_direct(addr: SocketAddr) -> JwksClient {
         let jwks_url = format!("http://{}/realms/master/protocol/openid-connect/cert", addr);
-        JwksClient::Direct {
-            client: build_test_http_client(),
-            jwks_url,
-            refresh_schedule: "0 0 0 0 0 0".to_string(),
-            cache: Arc::new(RwLock::new(None)),
-        }
+        direct_for_test(jwks_url, "0 0 0 0 0 0".to_string())
     }
 
     fn setup_jwks_client_oidc_discovery(addr: SocketAddr) -> JwksClient {
-        let oidc_discovery_url = format!(
+        let discovery_url = format!(
             "http://{}/realms/master/.well-known/openid-configuration",
             addr
         );
-        JwksClient::Oidc {
-            client: build_test_http_client(),
-            discovery_url: oidc_discovery_url,
-            refresh_schedule: "0 0 0 0 0 0".to_string(),
-            cache: Arc::new(RwLock::new(None)),
-        }
+        oidc_for_test(discovery_url, "0 0 0 0 0 0".to_string())
     }
 
     #[test]

--- a/rapina/src/jwt/jwks_client.rs
+++ b/rapina/src/jwt/jwks_client.rs
@@ -131,6 +131,9 @@ pub fn default_validation() -> Validation {
     validation.validate_exp = true;
     validation.validate_nbf = true;
 
+    // require aud to be present in every token — aligns with jsonwebtoken crate recommendation
+    validation.required_spec_claims.insert("aud".to_string());
+
     validation
 }
 


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on the JWT `aud` misconfiguration fix:

- **`required_spec_claims`**: Added `"aud"` to `default_validation()` so tokens without an `aud` claim are rejected by default, as recommended by the `jsonwebtoken` crate docs
- **Health check**: Added JWT misconfiguration check to `readiness_check` in `health/endpoint.rs` — if `validate_aud=true` and `set_audience()` was never called, the readiness endpoint returns 503 before real traffic hits, surfacing the misconfiguration via Kubernetes readiness probes
- **Panic on misconfiguration**: Replaced the silent 500 path with `tracing::error!` + `panic!` so the developer misconfiguration is caught at startup rather than serving broken responses indefinitely

## Related Issues

Closes #566

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)