### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-15
+
 ### Added
-- **Tower compatibility layer**: `tower` feature flag with `TowerLayerMiddleware` (tower Layer → rapina Middleware adapter), `RapinaService` (rapina stack → tower Service adapter), and `.layer()` builder method
-- **NextService Clone support**: Tower layers requiring `Clone` on the inner service (e.g. tower-resilience, retry, circuit breaker) now work out of the box
-- `DatabaseConfig::auto_migrate` and `DATABASE_AUTO_MIGRATE` (default `false`). When `run_migrations` runs with auto-migrate off, pending migrations are not applied; Rapina logs a warning listing pending migration names and points to `rapina migrate up` / `rapina migrate init`.
+- **Cursor-based pagination**: `CursorPaginate<V>` extractor and `CursorPaginated<T>` response for stable feeds and infinite scroll, alongside existing offset pagination (#540).
+- **Streaming and SSE responses**: First-class streaming response types and Server-Sent Events support (#536).
+- **`llms.txt` endpoint and CLI export**: `/llms.txt` route plus `rapina llms` command for AI-tool discovery (#528).
+- **`Header<T>` typed extractor**: Strongly-typed header extraction with structured 400 errors (#542).
+- **Custom Prometheus collectors**: `MetricsBuilder::add_metric()` for registering app-defined collectors (#538).
+- **Opt-in auto-migrations**: `DatabaseConfig::auto_migrate(true)` and `DATABASE_AUTO_MIGRATE=true` apply pending migrations at startup (#547). Off by default; when off, `run_migrations` logs pending migration names and points to `rapina migrate up`.
+- **Bundled docs and `AGENTS.md`**: `rapina new` drops `AGENTS.md`, `CLAUDE.md`, and `.rapina-docs/` into new projects so AI coding tools have framework-specific context. `rapina doctor --fix-agents` refreshes after upgrades (#535).
 
 ### Changed
 - **Breaking:** `DatabaseConfig::new` and `from_env` default `auto_migrate` to `false`. Opt in with `.auto_migrate(true)` or `DATABASE_AUTO_MIGRATE=true` to apply migrations at startup.
+- **Unified type system**: Consolidated type representation across codegen, schema, and OpenAPI layers (#519).
+- **Cache invalidation: ancestor collection prefixes**: Mutations now invalidate every ancestor collection prefix, not just the exact route (#537).
+- **Codegen: consolidated PK source of truth**: Single primary-key inference path across `import` and `add` (#546).
+- **Skip rewrite of unchanged `generate_rapina_docs` output**: Avoids touch-time churn in source control (#564).
+- **`tokio-tungstenite` 0.28 → 0.29, `hyper-tungstenite` 0.19 → 0.20** (#560).
+
+### Fixed
+- **`schema!` rejected unsigned integer types**: Now emits a clear compile-time error pointing at the offending column (#557).
+
+## [0.11.0] - 2026-04-01
+
+### Added
+- **Tower compatibility layer**: `tower` feature flag with `TowerLayerMiddleware` (tower Layer → rapina Middleware adapter), `RapinaService` (rapina stack → tower Service adapter), and `.layer()` builder method.
+- **NextService Clone support**: Tower layers requiring `Clone` on the inner service (e.g. tower-resilience, retry, circuit breaker) now work out of the box.
 
 ## [0.10.0] - 2026-03-16
 
@@ -100,7 +120,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized error handling with `trace_id`
 - CLI (`rapina new`, `rapina dev`)
 
-[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/rapina-rs/rapina/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/rapina-rs/rapina/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/rapina-rs/rapina/compare/v0.9.0...v0.10.0
 [0.6.0]: https://github.com/rapina-rs/rapina/compare/v0.5.0...v0.6.0
 [0.2.0]: https://github.com/rapina-rs/rapina/compare/v0.1.0-alpha.3...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "rapina"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/docs/content/docs/core-concepts/background-jobs.md
+++ b/docs/content/docs/core-concepts/background-jobs.md
@@ -30,7 +30,7 @@ You need the `database` feature with PostgreSQL. The jobs migration uses Postgre
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["postgres"] }
+rapina = { version = "0.12.0", features = ["postgres"] }
 ```
 
 You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page.

--- a/docs/content/docs/core-concepts/caching.md
+++ b/docs/content/docs/core-concepts/caching.md
@@ -111,7 +111,7 @@ For multi-instance deployments where all instances need to share the same cache 
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["cache-redis"] }
+rapina = { version = "0.12.0", features = ["cache-redis"] }
 ```
 
 ```rust

--- a/docs/content/docs/core-concepts/cron-scheduler.md
+++ b/docs/content/docs/core-concepts/cron-scheduler.md
@@ -28,7 +28,7 @@ Enable the `cron-scheduler` feature flag:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11", features = ["cron-scheduler"] }
+rapina = { version = "0.12.0", features = ["cron-scheduler"] }
 ```
 
 No database or external service is required. The scheduler runs entirely in-process.

--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -13,7 +13,7 @@ Add the database feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["postgres"] }
+rapina = { version = "0.12.0", features = ["postgres"] }
 # or "mysql", "sqlite"
 ```
 

--- a/docs/content/docs/core-concepts/jwks.md
+++ b/docs/content/docs/core-concepts/jwks.md
@@ -52,7 +52,7 @@ Add the `jwks` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11", features = ["jwks"] }
+rapina = { version = "0.12.0", features = ["jwks"] }
 ```
 
 This pulls in Rapina's `cron-scheduler` for automatic periodic cache refresh and `hyper-rustls` for HTTPS fetching of the JWKS endpoint using your system's native root CA certificates.

--- a/docs/content/docs/core-concepts/metrics.md
+++ b/docs/content/docs/core-concepts/metrics.md
@@ -13,7 +13,7 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["metrics"] }
+rapina = { version = "0.12.0", features = ["metrics"] }
 ```
 
 Enable the endpoint in your application:

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -401,7 +401,7 @@ impl Middleware for SecurityHeadersMiddleware {
 Rapina can interop with the [Tower](https://docs.rs/tower) ecosystem via the `tower` feature flag. This lets you use battle-tested Tower layers (retry, circuit breakers, concurrency limits, etc.) as Rapina middleware.
 
 ```toml
-rapina = { version = "0.11.0", features = ["tower"] }
+rapina = { version = "0.12.0", features = ["tower"] }
 ```
 
 ### Using Tower layers as middleware

--- a/docs/content/docs/core-concepts/migrations.md
+++ b/docs/content/docs/core-concepts/migrations.md
@@ -15,7 +15,7 @@ Your `Cargo.toml` needs the `database` feature and a database driver:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["sqlite"] }
+rapina = { version = "0.12.0", features = ["sqlite"] }
 ```
 
 Replace `sqlite` with `postgres` or `mysql` depending on your database. You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page if you haven't set that up yet.

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -115,7 +115,7 @@ If you prefer not to use the CLI, add Rapina to an existing project:
 
 ```toml
 [dependencies]
-rapina = "0.10.0"
+rapina = "0.12.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```

--- a/docs/content/docs/guides/deployment.md
+++ b/docs/content/docs/guides/deployment.md
@@ -21,7 +21,7 @@ If your app uses a database, make sure the correct feature flag is enabled in yo
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["postgres"] }
+rapina = { version = "0.12.0", features = ["postgres"] }
 ```
 
 Available database features: `postgres`, `mysql`, `sqlite`.
@@ -343,7 +343,7 @@ Enable Prometheus metrics for monitoring:
 
 ```toml
 [dependencies]
-rapina = { version = "0.11.0", features = ["metrics"] }
+rapina = { version = "0.12.0", features = ["metrics"] }
 ```
 
 ```rust

--- a/justfile
+++ b/justfile
@@ -39,16 +39,18 @@ release VERSION:
     # Bump rapina-macros cross-reference in rapina/Cargo.toml
     sed -i '' 's/rapina-macros = { version = "[^"]*"/rapina-macros = { version = "{{VERSION}}"/' rapina/Cargo.toml
 
-    # Bump version references in docs and examples
-    find docs/ rapina/examples/ \( -name "*.md" -o -name "*.toml" \) \
-        | xargs sed -i '' "s/rapina = { version = \"[0-9][^\"]*\"/rapina = { version = \"{{VERSION}}\"/g"
+    # Bump version references in docs and examples (excluding blog history)
+    find docs/content/docs/ rapina/examples/ \( -name "*.md" -o -name "*.toml" \) \
+        | xargs sed -i '' \
+            -e "s/rapina = { version = \"[0-9][^\"]*\"/rapina = { version = \"{{VERSION}}\"/g" \
+            -e "s/^rapina = \"[0-9][^\"]*\"/rapina = \"{{VERSION}}\"/g"
 
     # Regenerate Cargo.lock
     cargo check --workspace
 
     # Create branch, commit, push, open PR
     git checkout -b release_{{VERSION}}
-    git add rapina/Cargo.toml rapina-macros/Cargo.toml rapina-cli/Cargo.toml Cargo.lock
+    git add rapina/Cargo.toml rapina-macros/Cargo.toml rapina-cli/Cargo.toml Cargo.lock CHANGELOG.md
     git add docs/ rapina/examples/
     git commit -m "Bump version to {{VERSION}}"
     git push origin release_{{VERSION}}

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI tool for Rapina web framework - create and run Rapina projects"

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-macros"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Procedural macros for the Rapina web framework"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A fast, type-safe web framework for Rust inspired by FastAPI"
@@ -73,7 +73,7 @@ flate2 = { version = "1.1", optional = true }
 multer = { version = "3.0", optional = true }
 
 # Our macros
-rapina-macros = { version = "0.11.0", path = "../rapina-macros/" }
+rapina-macros = { version = "0.12.0", path = "../rapina-macros/" }
 
 # Auto-discovery
 inventory = "0.3"

--- a/rapina/examples/url-shortener/url-shortner/Cargo.toml
+++ b/rapina/examples/url-shortener/url-shortner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rapina = { version = "0.11.0", features = ["sqlite", "postgres", "cache-redis"] }
+rapina = { version = "0.12.0", features = ["sqlite", "postgres", "cache-redis"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
@@ -4,6 +4,6 @@ expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.11.0.
+Built with [Rapina](https://rapina.rs) v0.12.0.
 
 ## Routes

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.11.0.
+Built with [Rapina](https://rapina.rs) v0.12.0.
 
 ## Routes
 


### PR DESCRIPTION
Bumps all version references to 0.12.0. Merge this PR then push the `v0.12.0` tag to trigger the release.