### PR TITLE
docs: mention llms endpoint in agent rules

### DIFF
--- a/rapina-cli/src/commands/agents/core.md
+++ b/rapina-cli/src/commands/agents/core.md
@@ -65,7 +65,7 @@ Rapina::new()
 ## CLI
 
 - `rapina dev` — run with auto-reload
-- When `rapina dev` is running, fetch `GET /__rapina/llms.txt` at session start to inspect generated route context; debug builds enable it by default.
+- When `rapina dev` is running, fetch `/__rapina/llms.txt` at session start to inspect generated route context.
 - `rapina doctor` — diagnose project issues
 - `rapina routes` — list all registered routes
 - `rapina add resource <name>` — scaffold a new CRUD resource

--- a/rapina-cli/src/commands/agents/core.md
+++ b/rapina-cli/src/commands/agents/core.md
@@ -65,6 +65,7 @@ Rapina::new()
 ## CLI
 
 - `rapina dev` — run with auto-reload
+- When `rapina dev` is running, fetch `GET /__rapina/llms.txt` at session start to inspect generated route context; debug builds enable it by default.
 - `rapina doctor` — diagnose project issues
 - `rapina routes` — list all registered routes
 - `rapina add resource <name>` — scaffold a new CRUD resource

--- a/rapina-cli/src/commands/new.rs
+++ b/rapina-cli/src/commands/new.rs
@@ -343,7 +343,6 @@ mod tests {
         assert!(content.contains("State<T>"));
         assert!(content.contains("rapina add resource"));
         assert!(content.contains("/__rapina/llms.txt"));
-        assert!(content.contains("debug builds enable it by default"));
         assert!(content.contains("Don't"));
         assert!(content.contains("BEGIN:rapina-agent-rules"));
         assert!(content.contains("END:rapina-agent-rules"));

--- a/rapina-cli/src/commands/new.rs
+++ b/rapina-cli/src/commands/new.rs
@@ -342,6 +342,8 @@ mod tests {
         assert!(content.contains("TestClient"));
         assert!(content.contains("State<T>"));
         assert!(content.contains("rapina add resource"));
+        assert!(content.contains("/__rapina/llms.txt"));
+        assert!(content.contains("debug builds enable it by default"));
         assert!(content.contains("Don't"));
         assert!(content.contains("BEGIN:rapina-agent-rules"));
         assert!(content.contains("END:rapina-agent-rules"));


### PR DESCRIPTION
## Summary
- add the `/__rapina/llms.txt` startup hint to the generated AGENTS.md core CLI rules
- cover the generated AGENTS.md content so the llms endpoint instruction stays present

Fixes #578.

## Validation
- `cargo test -p rapina-cli generate_agents` (2 passed)
- `cargo test -p rapina-cli generate_rapina_docs` (12 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p rapina-cli --all-targets -- -D warnings`
- `cargo test -p rapina-cli` (196 passed)
- `cargo test --locked --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Notes
- Docs/test-only change; I did not run a live `rapina dev` server smoke.