### PR TITLE
Fix: log validation error serialization failures instead of silently dropping them

### DIFF
--- a/rapina/src/extract/mod.rs
+++ b/rapina/src/extract/mod.rs
@@ -525,8 +525,12 @@ impl<T: DeserializeOwned + Validate + Send> FromRequest for Validated<Json<T>> {
     ) -> Result<Self, Error> {
         let json = Json::<T>::from_request(req, params, state).await?;
         json.0.validate().map_err(|e| {
-            Error::validation("validation failed")
-                .with_details(serde_json::to_value(e).unwrap_or_default())
+            Error::validation("validation failed").with_details(
+                serde_json::to_value(&e).unwrap_or_else(|err| {
+                    tracing::warn!("Failed to serialize validation error details: {err}");
+                    serde_json::Value::default()
+                }),
+            )
         })?;
         Ok(Validated(json))
     }
@@ -540,8 +544,12 @@ impl<T: DeserializeOwned + Validate + Send> FromRequest for Validated<Form<T>> {
     ) -> Result<Self, Error> {
         let form = Form::<T>::from_request(req, params, state).await?;
         form.0.validate().map_err(|e| {
-            Error::validation("validation failed")
-                .with_details(serde_json::to_value(e).unwrap_or_default())
+            Error::validation("validation failed").with_details(
+                serde_json::to_value(&e).unwrap_or_else(|err| {
+                    tracing::warn!("Failed to serialize validation error details: {err}");
+                    serde_json::Value::default()
+                }),
+            )
         })?;
         Ok(Validated(form))
     }
@@ -1722,5 +1730,182 @@ mod tests {
             crate::jobs::Jobs::from_request_parts(&parts, &empty_params(), &empty_state()).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().status(), 500);
+    }
+
+    // Validated<Json<T>> extractor tests
+
+    #[tokio::test]
+    async fn test_validated_json_valid_input() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(length(min = 1))]
+            name: String,
+        }
+
+        let req = TestRequest::post("/")
+            .json(&serde_json::json!({ "name": "Alice" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Json<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().into_inner().0.name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_validated_json_invalid_input_returns_422() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(length(min = 3))]
+            name: String,
+        }
+
+        let req = TestRequest::post("/")
+            .json(&serde_json::json!({ "name": "Al" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Json<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    #[tokio::test]
+    async fn test_validated_json_invalid_input_details_not_empty() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(email)]
+            email: String,
+        }
+
+        let req = TestRequest::post("/")
+            .json(&serde_json::json!({ "email": "not-an-email" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Json<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        let err = result.unwrap_err();
+        // details should be a non-null object with field errors, not an empty {}
+        let details = err.details();
+        assert!(details.is_some());
+        let details = details.unwrap();
+        assert!(details.is_object());
+        assert!(!details.as_object().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_validated_json_bad_json_returns_400() {
+        let req = TestRequest::post("/")
+            .header("content-type", "application/json")
+            .body(b"{not valid json".as_ref())
+            .into_incoming_request()
+            .await;
+
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        #[allow(dead_code)]
+        struct Payload {
+            name: String,
+        }
+
+        let result =
+            Validated::<Json<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status(), 400);
+    }
+
+    // Validated<Form<T>> extractor tests
+
+    #[tokio::test]
+    async fn test_validated_form_valid_input() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(length(min = 1))]
+            name: String,
+        }
+
+        let req = TestRequest::post("/")
+            .form(&serde_json::json!({ "name": "Bob" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Form<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().into_inner().0.name, "Bob");
+    }
+
+    #[tokio::test]
+    async fn test_validated_form_invalid_input_returns_422() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(length(min = 5))]
+            name: String,
+        }
+
+        let req = TestRequest::post("/")
+            .form(&serde_json::json!({ "name": "Bo" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Form<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), 422);
+    }
+
+    #[tokio::test]
+    async fn test_validated_form_invalid_input_details_not_empty() {
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        struct Payload {
+            #[validate(email)]
+            email: String,
+        }
+
+        let req = TestRequest::post("/")
+            .form(&serde_json::json!({ "email": "bad" }))
+            .into_incoming_request()
+            .await;
+
+        let result =
+            Validated::<Form<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        let err = result.unwrap_err();
+        let details = err.details();
+        assert!(details.is_some());
+        let details = details.unwrap();
+        assert!(details.is_object());
+        assert!(!details.as_object().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_validated_form_bad_content_type_returns_400() {
+        let req = TestRequest::post("/")
+            .header("content-type", "text/plain")
+            .body(b"name=Bob".as_ref())
+            .into_incoming_request()
+            .await;
+
+        #[derive(serde::Deserialize, validator::Validate, Debug)]
+        #[allow(dead_code)]
+        struct Payload {
+            name: String,
+        }
+
+        let result =
+            Validated::<Form<Payload>>::from_request(req, &empty_params(), &empty_state()).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().status(), 400);
     }
 }

--- a/rapina/src/test.rs
+++ b/rapina/src/test.rs
@@ -4,8 +4,12 @@
 
 use bytes::Bytes;
 use http::Request;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper_util::rt::TokioIo;
 use serde::Serialize;
 use std::sync::Arc;
+use tokio::sync::oneshot;
 
 use crate::context::RequestContext;
 use crate::extract::PathParams;
@@ -133,6 +137,60 @@ impl TestRequest {
     /// Get the body bytes
     pub fn get_body(&self) -> &Bytes {
         &self.body
+    }
+
+    /// Build a `Request<Incoming>` suitable for `FromRequest` extractors.
+    ///
+    /// Uses an in-memory duplex I/O pair and a real hyper HTTP/1.1 handshake
+    /// so the resulting request carries a genuine `Incoming` body stream.
+    pub async fn into_incoming_request(self) -> Request<Incoming> {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        let uri = self.uri.clone();
+        let method = self.method.clone();
+        let headers = self.headers.clone();
+        let body_bytes = self.body.clone();
+
+        let (req_tx, req_rx) = oneshot::channel::<Request<Incoming>>();
+
+        // Server side: accept one request and send it through the channel
+        tokio::spawn(async move {
+            let tx = std::sync::Mutex::new(Some(req_tx));
+            let service = hyper::service::service_fn(move |req: Request<Incoming>| {
+                let captured = tx.lock().unwrap().take();
+                async move {
+                    if let Some(tx) = captured {
+                        let _ = tx.send(req);
+                    }
+                    Ok::<_, std::convert::Infallible>(http::Response::new(http_body_util::Empty::<
+                        Bytes,
+                    >::new(
+                    )))
+                }
+            });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(server_io), service)
+                .await;
+        });
+
+        // Client side: send one HTTP/1.1 request
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(client_io))
+            .await
+            .expect("http1 handshake failed");
+
+        tokio::spawn(conn);
+
+        let mut req_builder = Request::builder().method(method).uri(uri);
+        for (key, value) in headers.iter() {
+            req_builder = req_builder.header(key, value);
+        }
+        let request = req_builder
+            .body(Full::new(body_bytes))
+            .expect("request build failed");
+
+        let _ = sender.send_request(request).await;
+
+        req_rx.await.expect("server did not capture the request")
     }
 }
 


### PR DESCRIPTION
## Summary

Replace silent `.unwrap_or_default()` with `.unwrap_or_else()` + `tracing::warn!` in both `Validated<Json<T>>` and `Validated<Form<T>>` extractors, so serialization failures are logged rather than silently swallowed. Also adds an `into_incoming_request()` helper to `TestRequest` and 8 new tests covering valid/invalid input and parse errors for both extractors.

## Related Issues

Closes #577

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)