### PR TITLE
refactor: replace curl subprocess with ureq HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "ureq",
  "uuid",
 ]
 
@@ -4425,6 +4426,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4465,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -37,6 +37,7 @@ sqlx = { version = "0.8", optional = true }
 openapiv3 = { version = "2", optional = true }
 serde_yaml_ng = { version = "0.10", optional = true }
 sha2 = "0.11"
+ureq = "3.3.0"
 
 [features]
 default = []

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -37,7 +37,7 @@ sqlx = { version = "0.8", optional = true }
 openapiv3 = { version = "2", optional = true }
 serde_yaml_ng = { version = "0.10", optional = true }
 sha2 = "0.11"
-ureq = "3.3.0"
+ureq = "3.3"
 
 [features]
 default = []

--- a/rapina-cli/src/commands/doctor.rs
+++ b/rapina-cli/src/commands/doctor.rs
@@ -34,9 +34,8 @@ pub fn execute(config: DoctorConfig) -> Result<(), String> {
     );
     println!();
 
-    let agent = ureq::Agent::new_with_defaults();
-    let routes = fetch_json(&agent, &urls::build_routes_url(&config.host, config.port))?;
-    let openapi = fetch_json(&agent, &urls::build_openapi_url(&config.host, config.port));
+    let routes = fetch_json(&urls::build_routes_url(&config.host, config.port))?;
+    let openapi = fetch_json(&urls::build_openapi_url(&config.host, config.port));
 
     let mut result = DiagnosticResult {
         warnings: Vec::new(),
@@ -356,8 +355,8 @@ fn print_results(result: &DiagnosticResult) {
 }
 
 /// Fetch JSON from URL.
-fn fetch_json(agent: &ureq::Agent, url: &str) -> Result<Value, String> {
-    let mut response = agent.get(url).call().map_err(|e| {
+fn fetch_json(url: &str) -> Result<Value, String> {
+    let mut response = crate::common::AGENT.get(url).call().map_err(|e| {
         format!(
             "Failed to fetch data. Is the server running? ({}) ({})",
             url, e
@@ -613,23 +612,21 @@ mod tests {
             use std::io::Read;
             let _ = stream.read(&mut buf);
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
                 json.len(),
                 json
             );
             use std::io::Write;
             stream.write_all(response.as_bytes()).unwrap();
         });
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_json(&agent, &format!("http://127.0.0.1:{}", port));
+        let result = fetch_json(&format!("http://127.0.0.1:{}", port));
         handle.join().unwrap();
         assert_eq!(result.unwrap(), serde_json::json!({"status": "ok"}));
     }
 
     #[test]
     fn test_fetch_json_connection_refused() {
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_json(&agent, "http://127.0.0.1:1");
+        let result = fetch_json("http://127.0.0.1:1");
         assert!(result.is_err());
     }
 }

--- a/rapina-cli/src/commands/doctor.rs
+++ b/rapina-cli/src/commands/doctor.rs
@@ -4,7 +4,6 @@ use crate::commands::agents::{DriftStatus, check_drift, fix_agents, simple_diff}
 use crate::common::urls;
 use colored::Colorize;
 use serde_json::Value;
-use std::process::Command;
 
 struct DiagnosticResult {
     warnings: Vec<String>,
@@ -35,8 +34,9 @@ pub fn execute(config: DoctorConfig) -> Result<(), String> {
     );
     println!();
 
-    let routes = fetch_json(&urls::build_routes_url(&config.host, config.port))?;
-    let openapi = fetch_json(&urls::build_openapi_url(&config.host, config.port));
+    let agent = ureq::Agent::new_with_defaults();
+    let routes = fetch_json(&agent, &urls::build_routes_url(&config.host, config.port))?;
+    let openapi = fetch_json(&agent, &urls::build_openapi_url(&config.host, config.port));
 
     let mut result = DiagnosticResult {
         warnings: Vec::new(),
@@ -356,21 +356,17 @@ fn print_results(result: &DiagnosticResult) {
 }
 
 /// Fetch JSON from URL.
-fn fetch_json(url: &str) -> Result<Value, String> {
-    let output = Command::new("curl")
-        .args(["-s", "-f", url])
-        .output()
-        .map_err(|e| format!("Failed to run curl: {}", e))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to fetch data. Is the server running? ({})",
-            url
-        ));
-    }
-
-    let body =
-        String::from_utf8(output.stdout).map_err(|e| format!("Invalid UTF-8 response: {}", e))?;
+fn fetch_json(agent: &ureq::Agent, url: &str) -> Result<Value, String> {
+    let mut response = agent.get(url).call().map_err(|e| {
+        format!(
+            "Failed to fetch data. Is the server running? ({}) ({})",
+            url, e
+        )
+    })?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response body: {}", e))?;
 
     serde_json::from_str(&body).map_err(|e| format!("Invalid JSON response: {}", e))
 }
@@ -604,5 +600,36 @@ mod tests {
         check_openapi_metadata(&openapi, &mut result);
         assert!(result.warnings.is_empty());
         assert_eq!(result.passed.len(), 1);
+    }
+
+    #[test]
+    fn test_fetch_json_success() {
+        let json = r#"{"status":"ok"}"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            use std::io::Read;
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                json.len(),
+                json
+            );
+            use std::io::Write;
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_json(&agent, &format!("http://127.0.0.1:{}", port));
+        handle.join().unwrap();
+        assert_eq!(result.unwrap(), serde_json::json!({"status": "ok"}));
+    }
+
+    #[test]
+    fn test_fetch_json_connection_refused() {
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_json(&agent, "http://127.0.0.1:1");
+        assert!(result.is_err());
     }
 }

--- a/rapina-cli/src/commands/llms.rs
+++ b/rapina-cli/src/commands/llms.rs
@@ -5,8 +5,7 @@ use std::fs;
 
 /// Export llms.txt to stdout or file.
 pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), String> {
-    let agent = ureq::Agent::new_with_defaults();
-    let content = fetch_llms_txt(&agent, host, port)?;
+    let content = fetch_llms_txt(host, port)?;
 
     match output {
         Some(path) => {
@@ -22,9 +21,9 @@ pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), Strin
 }
 
 /// Fetch llms.txt from the running application.
-fn fetch_llms_txt(agent: &ureq::Agent, host: &str, port: u16) -> Result<String, String> {
+fn fetch_llms_txt(host: &str, port: u16) -> Result<String, String> {
     let url = crate::common::urls::build_llms_url(host, port);
-    let mut response = agent.get(&url).call().map_err(|e| {
+    let mut response = crate::common::AGENT.get(&url).call().map_err(|e| {
         format!(
             "Failed to fetch llms.txt. Is the server running on {}? ({})",
             url, e
@@ -44,7 +43,7 @@ mod tests {
 
     #[test]
     fn test_fetch_llms_txt_success() {
-        let body = "User-agent: *\nDisallow: /admin";
+        let body = "User-agent: *\r\nDisallow: /admin";
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let handle = std::thread::spawn(move || {
@@ -53,23 +52,21 @@ mod tests {
             use std::io::Read;
             let _ = stream.read(&mut buf);
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
                 body.len(),
                 body
             );
             use std::io::Write;
             stream.write_all(response.as_bytes()).unwrap();
         });
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_llms_txt(&agent, "127.0.0.1", port);
+        let result = fetch_llms_txt("127.0.0.1", port);
         handle.join().unwrap();
         assert_eq!(result.unwrap(), body);
     }
 
     #[test]
     fn test_fetch_llms_txt_connection_refused() {
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_llms_txt(&agent, "127.0.0.1", 1);
+        let result = fetch_llms_txt("127.0.0.1", 1);
         assert!(result.is_err());
     }
 }

--- a/rapina-cli/src/commands/llms.rs
+++ b/rapina-cli/src/commands/llms.rs
@@ -2,11 +2,11 @@
 
 use colored::Colorize;
 use std::fs;
-use std::process::Command;
 
 /// Export llms.txt to stdout or file.
 pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), String> {
-    let content = fetch_llms_txt(host, port)?;
+    let agent = ureq::Agent::new_with_defaults();
+    let content = fetch_llms_txt(&agent, host, port)?;
 
     match output {
         Some(path) => {
@@ -22,19 +22,54 @@ pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), Strin
 }
 
 /// Fetch llms.txt from the running application.
-fn fetch_llms_txt(host: &str, port: u16) -> Result<String, String> {
+fn fetch_llms_txt(agent: &ureq::Agent, host: &str, port: u16) -> Result<String, String> {
     let url = crate::common::urls::build_llms_url(host, port);
-    let output = Command::new("curl")
-        .args(["-s", "-f", &url])
-        .output()
-        .map_err(|e| format!("Failed to run curl: {}", e))?;
+    let mut response = agent.get(&url).call().map_err(|e| {
+        format!(
+            "Failed to fetch llms.txt. Is the server running on {}? ({})",
+            url, e
+        )
+    })?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response body: {}", e))?;
 
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to fetch llms.txt. Is the server running on {}?",
-            url
-        ));
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_llms_txt_success() {
+        let body = "User-agent: *\nDisallow: /admin";
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            use std::io::Read;
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            use std::io::Write;
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_llms_txt(&agent, "127.0.0.1", port);
+        handle.join().unwrap();
+        assert_eq!(result.unwrap(), body);
     }
 
-    String::from_utf8(output.stdout).map_err(|e| format!("Invalid UTF-8 response: {}", e))
+    #[test]
+    fn test_fetch_llms_txt_connection_refused() {
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_llms_txt(&agent, "127.0.0.1", 1);
+        assert!(result.is_err());
+    }
 }

--- a/rapina-cli/src/commands/openapi.rs
+++ b/rapina-cli/src/commands/openapi.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 
 /// Export OpenAPI spec to stdout or file.
 pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), String> {
-    let spec = fetch_openapi_spec(host, port)?;
+    let agent = ureq::Agent::new_with_defaults();
+    let spec = fetch_openapi_spec(&agent, host, port)?;
     let canonical = canonicalize_json(&spec)?;
 
     match output {
@@ -34,8 +35,10 @@ pub fn check(file: &str, host: &str, port: u16) -> Result<(), String> {
     let committed_json: Value =
         serde_json::from_str(&committed).map_err(|e| format!("Failed to parse {}: {}", file, e))?;
 
+    let agent = ureq::Agent::new_with_defaults();
+
     // Fetch current spec
-    let current = fetch_openapi_spec(host, port)?;
+    let current = fetch_openapi_spec(&agent, host, port)?;
 
     // Compare canonical versions
     let committed_canonical = canonicalize_json(&committed_json)?;
@@ -67,8 +70,10 @@ pub fn diff(base: &str, file: &str, host: &str, port: u16) -> Result<(), String>
     // Get spec from base branch using git
     let base_spec = get_spec_from_branch(base, file)?;
 
+    let agent = ureq::Agent::new_with_defaults();
+
     // Fetch current spec
-    let current_spec = fetch_openapi_spec(host, port)?;
+    let current_spec = fetch_openapi_spec(&agent, host, port)?;
 
     // Detect breaking changes
     let changes = detect_breaking_changes(&base_spec, &current_spec);
@@ -107,22 +112,18 @@ pub fn diff(base: &str, file: &str, host: &str, port: u16) -> Result<(), String>
 }
 
 /// Fetch OpenAPI spec from running application.
-fn fetch_openapi_spec(host: &str, port: u16) -> Result<Value, String> {
+fn fetch_openapi_spec(agent: &ureq::Agent, host: &str, port: u16) -> Result<Value, String> {
     let url = crate::common::urls::build_openapi_url(host, port);
-    let output = Command::new("curl")
-        .args(["-s", "-f", &url])
-        .output()
-        .map_err(|e| format!("Failed to run curl: {}", e))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to fetch OpenAPI spec. Is the server running on {}?",
-            url
-        ));
-    }
-
-    let body =
-        String::from_utf8(output.stdout).map_err(|e| format!("Invalid UTF-8 response: {}", e))?;
+    let mut response = agent.get(&url).call().map_err(|e| {
+        format!(
+            "Failed to fetch OpenAPI spec. Is the server running on {}? ({})",
+            url, e
+        )
+    })?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response body: {}", e))?;
 
     serde_json::from_str(&body).map_err(|e| format!("Invalid JSON response: {}", e))
 }
@@ -376,5 +377,38 @@ mod tests {
         let report = detect_breaking_changes(&spec, &spec);
         assert!(report.breaking.is_empty());
         assert!(report.non_breaking.is_empty());
+    }
+
+    #[test]
+    fn test_fetch_openapi_spec_success() {
+        let json = r#"{"openapi":"3.0.0","info":{"title":"Test","version":"1.0"}}"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            use std::io::Read;
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                json.len(),
+                json
+            );
+            use std::io::Write;
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_openapi_spec(&agent, "127.0.0.1", port);
+        handle.join().unwrap();
+        let value = result.unwrap();
+        assert_eq!(value["info"]["title"], "Test");
+    }
+
+    #[test]
+    fn test_fetch_openapi_spec_connection_refused() {
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_openapi_spec(&agent, "127.0.0.1", 1);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to fetch"));
     }
 }

--- a/rapina-cli/src/commands/openapi.rs
+++ b/rapina-cli/src/commands/openapi.rs
@@ -7,8 +7,7 @@ use std::process::Command;
 
 /// Export OpenAPI spec to stdout or file.
 pub fn export(output: Option<String>, host: &str, port: u16) -> Result<(), String> {
-    let agent = ureq::Agent::new_with_defaults();
-    let spec = fetch_openapi_spec(&agent, host, port)?;
+    let spec = fetch_openapi_spec(host, port)?;
     let canonical = canonicalize_json(&spec)?;
 
     match output {
@@ -35,10 +34,8 @@ pub fn check(file: &str, host: &str, port: u16) -> Result<(), String> {
     let committed_json: Value =
         serde_json::from_str(&committed).map_err(|e| format!("Failed to parse {}: {}", file, e))?;
 
-    let agent = ureq::Agent::new_with_defaults();
-
     // Fetch current spec
-    let current = fetch_openapi_spec(&agent, host, port)?;
+    let current = fetch_openapi_spec(host, port)?;
 
     // Compare canonical versions
     let committed_canonical = canonicalize_json(&committed_json)?;
@@ -70,10 +67,8 @@ pub fn diff(base: &str, file: &str, host: &str, port: u16) -> Result<(), String>
     // Get spec from base branch using git
     let base_spec = get_spec_from_branch(base, file)?;
 
-    let agent = ureq::Agent::new_with_defaults();
-
     // Fetch current spec
-    let current_spec = fetch_openapi_spec(&agent, host, port)?;
+    let current_spec = fetch_openapi_spec(host, port)?;
 
     // Detect breaking changes
     let changes = detect_breaking_changes(&base_spec, &current_spec);
@@ -112,9 +107,9 @@ pub fn diff(base: &str, file: &str, host: &str, port: u16) -> Result<(), String>
 }
 
 /// Fetch OpenAPI spec from running application.
-fn fetch_openapi_spec(agent: &ureq::Agent, host: &str, port: u16) -> Result<Value, String> {
+fn fetch_openapi_spec(host: &str, port: u16) -> Result<Value, String> {
     let url = crate::common::urls::build_openapi_url(host, port);
-    let mut response = agent.get(&url).call().map_err(|e| {
+    let mut response = crate::common::AGENT.get(&url).call().map_err(|e| {
         format!(
             "Failed to fetch OpenAPI spec. Is the server running on {}? ({})",
             url, e
@@ -390,15 +385,14 @@ mod tests {
             use std::io::Read;
             let _ = stream.read(&mut buf);
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
                 json.len(),
                 json
             );
             use std::io::Write;
             stream.write_all(response.as_bytes()).unwrap();
         });
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_openapi_spec(&agent, "127.0.0.1", port);
+        let result = fetch_openapi_spec("127.0.0.1", port);
         handle.join().unwrap();
         let value = result.unwrap();
         assert_eq!(value["info"]["title"], "Test");
@@ -406,8 +400,7 @@ mod tests {
 
     #[test]
     fn test_fetch_openapi_spec_connection_refused() {
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_openapi_spec(&agent, "127.0.0.1", 1);
+        let result = fetch_openapi_spec("127.0.0.1", 1);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to fetch"));
     }

--- a/rapina-cli/src/commands/routes.rs
+++ b/rapina-cli/src/commands/routes.rs
@@ -25,8 +25,7 @@ pub fn execute(config: RoutesConfig) -> Result<(), String> {
         config.host,
         config.port
     );
-    let agent = ureq::Agent::new_with_defaults();
-    let routes = fetch_routes(&agent, &urls::build_routes_url(&config.host, config.port))?;
+    let routes = fetch_routes(&urls::build_routes_url(&config.host, config.port))?;
 
     if routes.is_empty() {
         println!("  {} No routes registered", "⚠".yellow());
@@ -66,8 +65,8 @@ pub fn execute(config: RoutesConfig) -> Result<(), String> {
 }
 
 /// Fetch routes from running application.
-fn fetch_routes(agent: &ureq::Agent, url: &str) -> Result<Vec<RouteInfo>, String> {
-    let mut response = agent.get(url).call().map_err(|e| {
+fn fetch_routes(url: &str) -> Result<Vec<RouteInfo>, String> {
+    let mut response = crate::common::AGENT.get(url).call().map_err(|e| {
         format!(
             "Failed to fetch routes. Is the server running on {}? ({})",
             url, e
@@ -96,26 +95,25 @@ mod tests {
             use std::io::Read;
             let _ = stream.read(&mut buf);
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
                 json.len(),
                 json
             );
             use std::io::Write;
             stream.write_all(response.as_bytes()).unwrap();
         });
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_routes(&agent, &format!("http://127.0.0.1:{}", port));
+        let result = fetch_routes(&format!("http://127.0.0.1:{}", port));
         handle.join().unwrap();
         let routes = result.unwrap();
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].method, "GET");
         assert_eq!(routes[0].path, "/users");
+        assert_eq!(routes[0].handler_name, "list_users");
     }
 
     #[test]
     fn test_fetch_routes_connection_refused() {
-        let agent = ureq::Agent::new_with_defaults();
-        let result = fetch_routes(&agent, "http://127.0.0.1:1");
+        let result = fetch_routes("http://127.0.0.1:1");
         assert!(result.is_err());
     }
 }

--- a/rapina-cli/src/commands/routes.rs
+++ b/rapina-cli/src/commands/routes.rs
@@ -3,7 +3,6 @@
 use crate::common::urls;
 use colored::Colorize;
 use serde::Deserialize;
-use std::process::Command;
 
 #[derive(Deserialize)]
 struct RouteInfo {
@@ -26,7 +25,8 @@ pub fn execute(config: RoutesConfig) -> Result<(), String> {
         config.host,
         config.port
     );
-    let routes = fetch_routes(&urls::build_routes_url(&config.host, config.port))?;
+    let agent = ureq::Agent::new_with_defaults();
+    let routes = fetch_routes(&agent, &urls::build_routes_url(&config.host, config.port))?;
 
     if routes.is_empty() {
         println!("  {} No routes registered", "⚠".yellow());
@@ -66,21 +66,56 @@ pub fn execute(config: RoutesConfig) -> Result<(), String> {
 }
 
 /// Fetch routes from running application.
-fn fetch_routes(url: &str) -> Result<Vec<RouteInfo>, String> {
-    let output = Command::new("curl")
-        .args(["-s", "-f", url])
-        .output()
-        .map_err(|e| format!("Failed to run curl: {}", e))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "Failed to fetch routes. Is the server running on {}?",
-            url
-        ));
-    }
-
-    let body =
-        String::from_utf8(output.stdout).map_err(|e| format!("Invalid UTF-8 response: {}", e))?;
+fn fetch_routes(agent: &ureq::Agent, url: &str) -> Result<Vec<RouteInfo>, String> {
+    let mut response = agent.get(url).call().map_err(|e| {
+        format!(
+            "Failed to fetch routes. Is the server running on {}? ({})",
+            url, e
+        )
+    })?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .map_err(|e| format!("Failed to read response body: {}", e))?;
 
     serde_json::from_str(&body).map_err(|e| format!("Invalid JSON response: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fetch_routes_success() {
+        let json = r#"[{"method":"GET","path":"/users","handler_name":"list_users"}]"#;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            use std::io::Read;
+            let _ = stream.read(&mut buf);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                json.len(),
+                json
+            );
+            use std::io::Write;
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_routes(&agent, &format!("http://127.0.0.1:{}", port));
+        handle.join().unwrap();
+        let routes = result.unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].method, "GET");
+        assert_eq!(routes[0].path, "/users");
+    }
+
+    #[test]
+    fn test_fetch_routes_connection_refused() {
+        let agent = ureq::Agent::new_with_defaults();
+        let result = fetch_routes(&agent, "http://127.0.0.1:1");
+        assert!(result.is_err());
+    }
 }

--- a/rapina-cli/src/commands/routes.rs
+++ b/rapina-cli/src/commands/routes.rs
@@ -115,5 +115,6 @@ mod tests {
     fn test_fetch_routes_connection_refused() {
         let result = fetch_routes("http://127.0.0.1:1");
         assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to fetch"));
     }
 }

--- a/rapina-cli/src/commands/routes.rs
+++ b/rapina-cli/src/commands/routes.rs
@@ -4,7 +4,7 @@ use crate::common::urls;
 use colored::Colorize;
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 struct RouteInfo {
     method: String,
     path: String,

--- a/rapina-cli/src/common/mod.rs
+++ b/rapina-cli/src/common/mod.rs
@@ -1,2 +1,6 @@
 pub mod env;
 pub mod urls;
+
+use std::sync::LazyLock;
+
+pub(crate) static AGENT: LazyLock<ureq::Agent> = LazyLock::new(ureq::Agent::new_with_defaults);


### PR DESCRIPTION
## Summary

What does this PR do?

- Swap Command::new("curl") for ureq::get() in fetch functions
- Accept &ureq::Agent parameter for testability
- Add unit tests with local TcpListener for success/error cases

## Related Issues

Closes #579 

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
