### PR TITLE
Feature: add handler descriptions to llms.txt output

### DIFF
--- a/docs/content/docs/core-concepts/extractors.md
+++ b/docs/content/docs/core-concepts/extractors.md
@@ -7,22 +7,37 @@ date = 2025-02-13
 
 Extractors automatically parse request data and inject it into your handlers. If parsing fails, they return appropriate error responses.
 
+## Handler Attributes
+
+The route macros (`#[get]`, `#[post]`, etc.) accept optional attributes alongside the path:
+
+| Attribute     | Type   | Description                                              |
+| ------------- | ------ | -------------------------------------------------------- |
+| `description` | `&str` | Human-readable description included in `llms.txt` output |
+
+```rust
+#[get("/users", description = "List all users")]
+async fn list_users() -> Json<Vec<User>> { ... }
+```
+
+See [llms.txt](/docs/core-concepts/llms-txt/#handler-descriptions) for the full description resolution order.
+
 ## Available Extractors
 
-| Extractor | Description |
-|-----------|-------------|
-| [`Path<T>`](#path-parameters) | URL path parameters |
-| [`Query<T>`](#query-parameters) | Query string parameters |
-| [`Json<T>`](#json-body) | JSON request body |
-| [`Form<T>`](#form-data) | URL-encoded form data |
-| [`Headers`](#headers) | Request headers |
-| [`State<T>`](#application-state) | Application state |
-| [`Context`](#request-context) | Request context (trace_id) |
-| [`Cookie<T>`](#cookies) | Typed cookie access |
-| [`CurrentUser`](#currentuser) | Authenticated user (JWT) |
-| [`Validated<T>`](#validation) | Validated extractor |
-| [`Paginate`](#paginate) | Pagination params (requires feature) |
-| [`Db`](#db) | Database connection (requires feature) |
+| Extractor                        | Description                            |
+| -------------------------------- | -------------------------------------- |
+| [`Path<T>`](#path-parameters)    | URL path parameters                    |
+| [`Query<T>`](#query-parameters)  | Query string parameters                |
+| [`Json<T>`](#json-body)          | JSON request body                      |
+| [`Form<T>`](#form-data)          | URL-encoded form data                  |
+| [`Headers`](#headers)            | Request headers                        |
+| [`State<T>`](#application-state) | Application state                      |
+| [`Context`](#request-context)    | Request context (trace_id)             |
+| [`Cookie<T>`](#cookies)          | Typed cookie access                    |
+| [`CurrentUser`](#currentuser)    | Authenticated user (JWT)               |
+| [`Validated<T>`](#validation)    | Validated extractor                    |
+| [`Paginate`](#paginate)          | Pagination params (requires feature)   |
+| [`Db`](#db)                      | Database connection (requires feature) |
 
 ## Accessing Extractor Values
 
@@ -46,7 +61,7 @@ async fn create_user(body: Json<CreateUser>) -> String {
 
 - **Direct field access** — `body.name`, `config.app_name`, `query.page`. Works anywhere you need `&T` thanks to auto-deref. This is the common case.
 - **Explicit deref (`*`)** — `*id`, `*count`. Needed for primitives in format strings or when passing a `Copy` value where the compiler needs the concrete type.
-- **`into_inner()`** — when you need to *own* the value. Moving it into a struct, passing it to a function that takes `T` (not `&T`), or consuming it in a builder chain.
+- **`into_inner()`** — when you need to _own_ the value. Moving it into a struct, passing it to a function that takes `T` (not `&T`), or consuming it in a builder chain.
 
 Avoid using `.0` to access extractor contents — it's an implementation detail. Deref or `into_inner()` are always clearer.
 
@@ -204,6 +219,7 @@ async fn me(user: CurrentUser) -> Json<UserResponse> {
 ```
 
 The `CurrentUser` extractor provides:
+
 - `user.id` - The user ID from the JWT `sub` claim
 - `user.claims` - The full JWT claims
 
@@ -263,12 +279,13 @@ async fn list_users(db: Db, page: Paginate) -> Result<Paginated<user::Model>> {
 
 The `Paginate` extractor reads `?page=1&per_page=20` from the query string:
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `page` | 1 | Page number (1-indexed) |
-| `per_page` | 20 | Items per page |
+| Parameter  | Default | Description             |
+| ---------- | ------- | ----------------------- |
+| `page`     | 1       | Page number (1-indexed) |
+| `per_page` | 20      | Items per page          |
 
 Returns 422 Validation Error when:
+
 - `page` < 1
 - `per_page` < 1
 - `per_page` exceeds the configured maximum (default: 100)
@@ -310,6 +327,7 @@ async fn create_post(body: Json<CreatePost>, db: Db) -> Result<Json<PostResponse
 ```
 
 The `Db` extractor provides:
+
 - `db.conn()` - A reference to the SeaORM database connection
 
 > **Note:** This extractor requires the database feature. See [Database](database.md) for setup and entity definitions.

--- a/docs/content/docs/core-concepts/extractors.md
+++ b/docs/content/docs/core-concepts/extractors.md
@@ -7,21 +7,6 @@ date = 2025-02-13
 
 Extractors automatically parse request data and inject it into your handlers. If parsing fails, they return appropriate error responses.
 
-## Handler Attributes
-
-The route macros (`#[get]`, `#[post]`, etc.) accept optional attributes alongside the path:
-
-| Attribute     | Type   | Description                                              |
-| ------------- | ------ | -------------------------------------------------------- |
-| `description` | `&str` | Human-readable description included in `llms.txt` output |
-
-```rust
-#[get("/users", description = "List all users")]
-async fn list_users() -> Json<Vec<User>> { ... }
-```
-
-See [llms.txt](/docs/core-concepts/llms-txt/#handler-descriptions) for the full description resolution order.
-
 ## Available Extractors
 
 | Extractor                        | Description                            |

--- a/docs/content/docs/core-concepts/llms-txt.md
+++ b/docs/content/docs/core-concepts/llms-txt.md
@@ -73,6 +73,8 @@ Built with [Rapina](https://rapina.rs) v0.11.0.
 
 ### POST /v1/users
 
+Create user
+
 Request (application/json):
 {
 "type": "object",
@@ -98,6 +100,29 @@ Errors:
 ```
 
 Request and response schemas are rendered verbatim from the same JSON Schema that powers the OpenAPI spec. Handlers that don't return `Json<T>` or don't accept a typed request body produce no schema block for that section.
+
+---
+
+## Handler Descriptions
+
+Each route entry in `llms.txt` includes a human-readable description between the route heading and the request block. Rapina resolves it in priority order:
+
+1. **Explicit `description` attribute** on the handler macro — highest priority:
+
+```rust
+#[post("/users", description = "Create a new user account")]
+async fn create_user(body: Json<CreateUser>) -> Json<User> { ... }
+```
+
+2. **First `///` doc comment** above the handler — zero extra syntax for already-documented handlers:
+
+```rust
+/// Create a new user account
+#[post("/users")]
+async fn create_user(body: Json<CreateUser>) -> Json<User> { ... }
+```
+
+3. **Humanized fallback** from the handler name — `create_user` → `"Create user"`. Every route always has a description even without any annotation.
 
 ---
 

--- a/docs/content/docs/core-concepts/routing.md
+++ b/docs/content/docs/core-concepts/routing.md
@@ -27,14 +27,14 @@ let router = Router::new()
 
 Rapina provides convenience methods for common HTTP verbs:
 
-| Method | Description |
-|--------|-------------|
-| `.get(pattern, handler)` | GET requests (read) |
-| `.post(pattern, handler)` | POST requests (create) |
-| `.put(pattern, handler)` | PUT requests (full update) |
-| `.patch(pattern, handler)` | PATCH requests (partial update) |
-| `.delete(pattern, handler)` | DELETE requests (remove) |
-| `.route(Method, pattern, handler)` | Any HTTP method |
+| Method                             | Description                     |
+| ---------------------------------- | ------------------------------- |
+| `.get(pattern, handler)`           | GET requests (read)             |
+| `.post(pattern, handler)`          | POST requests (create)          |
+| `.put(pattern, handler)`           | PUT requests (full update)      |
+| `.patch(pattern, handler)`         | PATCH requests (partial update) |
+| `.delete(pattern, handler)`        | DELETE requests (remove)        |
+| `.route(Method, pattern, handler)` | Any HTTP method                 |
 
 ### Using Macros
 
@@ -169,6 +169,31 @@ async fn health() -> &'static str {
 }
 // Public route at /api/health
 ```
+
+### Handler Descriptions
+
+The route macros accept a `description` attribute that adds a human-readable label to each route in `llms.txt` output:
+
+| Attribute     | Type   | Description                                              |
+| ------------- | ------ | -------------------------------------------------------- |
+| `description` | `&str` | Human-readable description included in `llms.txt` output |
+
+```rust
+#[get("/users", description = "List all users")]
+async fn list_users() -> Json<Vec<User>> { ... }
+```
+
+`description` composes with `group` and `#[public]`:
+
+```rust
+#[public]
+#[get("/health", group = "/api", description = "Health check")]
+async fn health() -> &'static str {
+    "ok"
+}
+```
+
+See [llms.txt](/docs/core-concepts/llms-txt/#handler-descriptions) for the full description resolution order.
 
 ## Path Parameters
 

--- a/rapina-macros/src/lib.rs
+++ b/rapina-macros/src/lib.rs
@@ -4,31 +4,49 @@ use quote::quote;
 use syn::spanned::Spanned;
 use syn::{FnArg, ItemFn, LitStr, Pat};
 
-/// Parsed route macro attribute: `"/path"` or `"/path", group = "/prefix"`.
+/// Parsed route macro attribute: `"/path"`, `"/path", group = "/prefix"`,
+/// `"/path", description = "..."`, or any combination thereof.
 struct RouteAttr {
     path: LitStr,
     group: Option<LitStr>,
+    description: Option<LitStr>,
 }
 
 impl syn::parse::Parse for RouteAttr {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let path: LitStr = input.parse()?;
-        let group = if input.peek(syn::Token![,]) {
+        let mut group: Option<LitStr> = None;
+        let mut description: Option<LitStr> = None;
+
+        while input.peek(syn::Token![,]) {
             input.parse::<syn::Token![,]>()?;
-            let ident: syn::Ident = input.parse()?;
-            if ident != "group" {
-                return Err(syn::Error::new(ident.span(), "expected `group`"));
+            if input.is_empty() {
+                break;
             }
+            let ident: syn::Ident = input.parse()?;
             input.parse::<syn::Token![=]>()?;
-            let value: LitStr = input.parse()?;
-            Some(value)
-        } else {
-            None
-        };
+            if ident == "group" {
+                let value: LitStr = input.parse()?;
+                group = Some(value);
+            } else if ident == "description" {
+                let value: LitStr = input.parse()?;
+                description = Some(value);
+            } else {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    "expected `group` or `description`",
+                ));
+            }
+        }
+
         if !input.is_empty() {
             return Err(input.error("unexpected tokens after route attribute"));
         }
-        Ok(RouteAttr { path, group })
+        Ok(RouteAttr {
+            path,
+            group,
+            description,
+        })
     }
 }
 
@@ -184,6 +202,13 @@ fn route_macro_core(
     // Extract #[public] attribute if present (when #[public] is below the route macro)
     let is_public = extract_public_attr(&mut func.attrs);
 
+    // Resolve description: explicit attr wins, then first rustdoc line, then None
+    let description_value: Option<String> = route_attr
+        .description
+        .as_ref()
+        .map(|l| l.value())
+        .or_else(|| extract_doc_description(&func.attrs));
+
     // Extract #[errors(ErrorType)] attribute if present
     let error_type = extract_errors_attr(&mut func.attrs);
 
@@ -276,6 +301,17 @@ fn route_macro_core(
                 vec![#(#entries),*]
             }
         }
+    };
+
+    // Build description() impl for the Handler trait
+    let description_impl = if let Some(ref desc) = description_value {
+        quote! {
+            fn description() -> Option<&'static str> {
+                Some(#desc)
+            }
+        }
+    } else {
+        quote! {}
     };
 
     let args: Vec<_> = func.sig.inputs.iter().collect();
@@ -483,6 +519,7 @@ fn route_macro_core(
             #request_body_required_impl
             #error_responses_impl
             #header_parameters_impl
+            #description_impl
 
             fn call(
                 &self,
@@ -513,6 +550,7 @@ fn route_macro_core(
                 request_body_required: <#func_name as rapina::handler::Handler>::request_body_required,
                 error_responses: <#func_name as rapina::handler::Handler>::error_responses,
                 header_parameters: <#func_name as rapina::handler::Handler>::header_parameters,
+                description: <#func_name as rapina::handler::Handler>::description,
                 register: #register_fn_name,
             }
         }
@@ -608,6 +646,29 @@ fn extract_body_inner_type(ty: &syn::Type) -> Option<RequestBodyMeta> {
             if let Some(mut meta) = extract_body_inner_type(inner_extractor) {
                 meta.required = false;
                 return Some(meta);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the first non-empty line from `///` doc comments on a function.
+fn extract_doc_description(attrs: &[syn::Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("doc") {
+            continue;
+        }
+        if let syn::Meta::NameValue(nv) = &attr.meta {
+            if let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(s),
+                ..
+            }) = &nv.value
+            {
+                let line = s.value();
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
             }
         }
     }

--- a/rapina/src/discovery.rs
+++ b/rapina/src/discovery.rs
@@ -54,6 +54,8 @@ pub struct RouteDescriptor {
     pub error_responses: fn() -> Vec<ErrorVariant>,
     /// Returns typed header parameters declared on this handler
     pub header_parameters: fn() -> Vec<HeaderParamInfo>,
+    /// Returns a human-readable description of this handler, if any
+    pub description: fn() -> Option<&'static str>,
     /// Registers this route on the given Router and returns it
     pub register: fn(Router) -> Router,
 }

--- a/rapina/src/handler.rs
+++ b/rapina/src/handler.rs
@@ -54,6 +54,11 @@ pub trait Handler: Clone + Send + Sync + 'static {
         Vec::new()
     }
 
+    /// Human-readable description of what this handler does.
+    fn description() -> Option<&'static str> {
+        None
+    }
+
     /// Handle the request.
     fn call(&self, req: Request<Incoming>, params: PathParams, state: Arc<AppState>) -> BoxFuture;
 }

--- a/rapina/src/introspection/endpoint.rs
+++ b/rapina/src/introspection/endpoint.rs
@@ -93,6 +93,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "POST",
@@ -104,6 +105,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         let registry = RouteRegistry::with_routes(routes);
@@ -122,6 +124,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let registry = RouteRegistry::with_routes(routes);
         let cloned = registry.clone();
@@ -141,6 +144,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "POST",
@@ -152,6 +156,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         let registry = RouteRegistry::with_routes(routes);

--- a/rapina/src/introspection/llms.rs
+++ b/rapina/src/introspection/llms.rs
@@ -9,6 +9,30 @@ use std::fmt::Write as _;
 
 use crate::introspection::RouteInfo;
 
+/// Convert a snake_case handler name to a human-readable description.
+///
+/// Examples: `create_user` → `"Create user"`, `list_all_posts` → `"List all posts"`.
+pub(crate) fn humanize_handler_name(name: &str) -> String {
+    let words: Vec<&str> = name.split('_').filter(|w| !w.is_empty()).collect();
+    if words.is_empty() {
+        return name.to_string();
+    }
+    let mut result = String::new();
+    for (i, word) in words.iter().enumerate() {
+        if i == 0 {
+            let mut chars = word.chars();
+            if let Some(first) = chars.next() {
+                result.extend(first.to_uppercase());
+                result.push_str(chars.as_str());
+            }
+        } else {
+            result.push(' ');
+            result.push_str(word);
+        }
+    }
+    result
+}
+
 macro_rules! w {
     ($dst:expr) => { writeln!($dst).unwrap() };
     ($dst:expr, $($t:tt)*) => { writeln!($dst, $($t)*).unwrap() };
@@ -33,6 +57,14 @@ pub fn to_llms_txt(title: &str, routes: &[RouteInfo]) -> String {
     for route in &user_routes {
         w!(out);
         w!(out, "### {} {}", route.method, route.path);
+
+        let desc = route
+            .description
+            .as_deref()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| humanize_handler_name(&route.handler_name));
+        w!(out);
+        w!(out, "{desc}");
 
         if let Some(ct) = &route.request_content_type {
             if let Some(schema) = &route.request_schema {
@@ -91,6 +123,7 @@ mod tests {
                 description: "email already registered",
             }],
             vec![],
+            None::<String>,
         )
     }
 
@@ -113,6 +146,7 @@ mod tests {
             None,
             vec![],
             vec![],
+            None::<String>,
         );
         let routes = vec![make_route(), internal];
         let output = to_llms_txt("My API", &routes);
@@ -132,5 +166,63 @@ mod tests {
     fn test_to_llms_txt_title_used_as_heading() {
         let output = to_llms_txt("Custom Title", &[]);
         assert!(output.starts_with("# Custom Title\n"));
+    }
+
+    #[test]
+    fn test_humanize_handler_name_single_word() {
+        assert_eq!(humanize_handler_name("create"), "Create");
+    }
+
+    #[test]
+    fn test_humanize_handler_name_multi_word() {
+        assert_eq!(humanize_handler_name("create_user"), "Create user");
+        assert_eq!(humanize_handler_name("list_all_posts"), "List all posts");
+    }
+
+    #[test]
+    fn test_humanize_handler_name_empty() {
+        assert_eq!(humanize_handler_name(""), "");
+    }
+
+    #[test]
+    fn test_humanize_handler_name_leading_underscores() {
+        assert_eq!(humanize_handler_name("_get_user"), "Get user");
+    }
+
+    #[test]
+    fn test_to_llms_txt_uses_explicit_description() {
+        let route = RouteInfo::new(
+            "GET",
+            "/users",
+            "list_users",
+            None,
+            None,
+            None::<String>,
+            None,
+            vec![],
+            vec![],
+            Some("Returns all users in the system"),
+        );
+        let output = to_llms_txt("My API", &[route]);
+        assert!(output.contains("Returns all users in the system"));
+        assert!(!output.contains("List users"));
+    }
+
+    #[test]
+    fn test_to_llms_txt_falls_back_to_humanized_name() {
+        let route = RouteInfo::new(
+            "DELETE",
+            "/users/:id",
+            "delete_user",
+            None,
+            None,
+            None::<String>,
+            None,
+            vec![],
+            vec![],
+            None::<String>,
+        );
+        let output = to_llms_txt("My API", &[route]);
+        assert!(output.contains("Delete user"));
     }
 }

--- a/rapina/src/introspection/route_info.rs
+++ b/rapina/src/introspection/route_info.rs
@@ -15,7 +15,7 @@ use crate::error::ErrorVariant;
 /// ```
 /// use rapina::introspection::RouteInfo;
 ///
-/// let info = RouteInfo::new("GET", "/users/:id", "get_user", None, None, None::<String>, None, Vec::new(), Vec::new());
+/// let info = RouteInfo::new("GET", "/users/:id", "get_user", None, None, None::<String>, None, Vec::new(), Vec::new(), None::<String>);
 /// assert_eq!(info.method, "GET");
 /// assert_eq!(info.path, "/users/:id");
 /// ```
@@ -45,6 +45,9 @@ pub struct RouteInfo {
     /// Typed header parameters declared on this handler.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub header_parameters: Vec<HeaderParamInfo>,
+    /// Human-readable description of what this handler does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 impl RouteInfo {
@@ -67,6 +70,7 @@ impl RouteInfo {
         request_body_required: Option<bool>,
         error_responses: Vec<ErrorVariant>,
         header_parameters: Vec<HeaderParamInfo>,
+        description: Option<impl Into<String>>,
     ) -> Self {
         Self {
             method: method.into(),
@@ -78,6 +82,7 @@ impl RouteInfo {
             request_body_required,
             error_responses,
             header_parameters,
+            description: description.map(|s| s.into()),
         }
     }
 }
@@ -98,6 +103,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         );
         assert_eq!(info.method, "GET");
         assert_eq!(info.path, "/users");
@@ -116,6 +122,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         );
         assert_eq!(info.path, "/users/:id");
     }
@@ -132,6 +139,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         );
         let cloned = info.clone();
         assert_eq!(info, cloned);
@@ -149,6 +157,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         );
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"method\":\"GET\""));
@@ -168,6 +177,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         );
         let debug = format!("{:?}", info);
         assert!(debug.contains("DELETE"));
@@ -191,8 +201,79 @@ mod tests {
             None,
             errors,
             Vec::new(),
+            None::<String>,
         );
         assert_eq!(info.error_responses.len(), 1);
         assert_eq!(info.error_responses[0].status, 404);
+    }
+
+    #[test]
+    fn test_route_info_with_description() {
+        let info = RouteInfo::new(
+            "GET",
+            "/users",
+            "list_users",
+            None,
+            None,
+            None::<String>,
+            None,
+            Vec::new(),
+            Vec::new(),
+            Some("List all users"),
+        );
+        assert_eq!(info.description, Some("List all users".to_string()));
+    }
+
+    #[test]
+    fn test_route_info_description_none_by_default() {
+        let info = RouteInfo::new(
+            "GET",
+            "/users",
+            "list_users",
+            None,
+            None,
+            None::<String>,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None::<String>,
+        );
+        assert!(info.description.is_none());
+    }
+
+    #[test]
+    fn test_route_info_description_serialized_when_present() {
+        let info = RouteInfo::new(
+            "GET",
+            "/users",
+            "list_users",
+            None,
+            None,
+            None::<String>,
+            None,
+            Vec::new(),
+            Vec::new(),
+            Some("All users"),
+        );
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("\"description\":\"All users\""));
+    }
+
+    #[test]
+    fn test_route_info_description_omitted_when_none() {
+        let info = RouteInfo::new(
+            "GET",
+            "/users",
+            "list_users",
+            None,
+            None,
+            None::<String>,
+            None,
+            Vec::new(),
+            Vec::new(),
+            None::<String>,
+        );
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(!json.contains("description"));
     }
 }

--- a/rapina/src/introspection/route_info.rs
+++ b/rapina/src/introspection/route_info.rs
@@ -274,6 +274,6 @@ mod tests {
             None::<String>,
         );
         let json = serde_json::to_string(&info).unwrap();
-        assert!(!json.contains("description"));
+        assert!(!json.contains("\"description\""));
     }
 }

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: rapina/src/introspection/llms.rs
+assertion_line: 134
 expression: output
 ---
 # My API
@@ -9,6 +10,8 @@ Built with [Rapina](https://rapina.rs) v0.12.0.
 ## Routes
 
 ### POST /v1/users
+
+Create user
 
 Request (application/json):
 ```json

--- a/rapina/src/openapi/spec.rs
+++ b/rapina/src/openapi/spec.rs
@@ -678,6 +678,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "POST",
@@ -689,6 +690,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "GET",
@@ -700,6 +702,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
@@ -728,6 +731,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "GET",
@@ -739,6 +743,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         build_openapi_spec("Test API", "1.0.0", &routes);
@@ -758,6 +763,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "GET",
@@ -769,6 +775,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         build_openapi_spec("Test API", "1.0.0", &routes);
@@ -789,6 +796,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "GET",
@@ -800,6 +808,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         // Should not panic — internal route is excluded from uniqueness tracking

--- a/rapina/src/openapi/spec.rs
+++ b/rapina/src/openapi/spec.rs
@@ -395,6 +395,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 
@@ -427,6 +428,7 @@ mod tests {
             None,
             errors,
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 
@@ -506,6 +508,7 @@ mod tests {
             None,
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 
@@ -536,6 +539,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
             RouteInfo::new(
                 "GET",
@@ -547,6 +551,7 @@ mod tests {
                 None,
                 Vec::new(),
                 Vec::new(),
+                None::<String>,
             ),
         ];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
@@ -575,6 +580,7 @@ mod tests {
             Some(true),
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 
@@ -608,6 +614,7 @@ mod tests {
             Some(true),
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 
@@ -644,6 +651,7 @@ mod tests {
             Some(false), // optional request body
             Vec::new(),
             Vec::new(),
+            None::<String>,
         )];
         let spec = build_openapi_spec("Test API", "1.0.0", &routes);
 

--- a/rapina/src/router/mod.rs
+++ b/rapina/src/router/mod.rs
@@ -41,6 +41,8 @@ pub struct RouteConfig {
     pub error_responses: Vec<ErrorVariant>,
     /// Typed header parameters declared on this handler.
     pub header_parameters: Vec<HeaderParamInfo>,
+    /// Human-readable description of what this handler does.
+    pub description: Option<&'static str>,
 }
 
 impl Default for RouteConfig {
@@ -53,6 +55,7 @@ impl Default for RouteConfig {
             request_body_required: None,
             error_responses: Vec::new(),
             header_parameters: Vec::new(),
+            description: None,
         }
     }
 }
@@ -66,6 +69,7 @@ pub(crate) struct Route {
     pub(crate) request_body_required: Option<bool>,
     pub(crate) error_responses: Vec<ErrorVariant>,
     pub(crate) header_parameters: Vec<HeaderParamInfo>,
+    pub(crate) description: Option<&'static str>,
     handler: HandlerFn,
 }
 
@@ -146,6 +150,7 @@ impl Router {
             request_body_required: config.request_body_required,
             error_responses: config.error_responses,
             header_parameters: config.header_parameters,
+            description: config.description,
             handler,
         };
 
@@ -215,6 +220,7 @@ impl Router {
                 request_body_required: H::request_body_required(),
                 error_responses: H::error_responses(),
                 header_parameters: H::header_parameters(),
+                description: H::description(),
             },
             move |req, params, state| {
                 let h = handler.clone();
@@ -236,6 +242,7 @@ impl Router {
                 request_body_required: H::request_body_required(),
                 error_responses: H::error_responses(),
                 header_parameters: H::header_parameters(),
+                description: H::description(),
             },
             move |req, params, state| {
                 let h = handler.clone();
@@ -275,6 +282,7 @@ impl Router {
                 request_body_required: H::request_body_required(),
                 error_responses: H::error_responses(),
                 header_parameters: H::header_parameters(),
+                description: H::description(),
             },
             move |req, params, state| {
                 let h = handler.clone();
@@ -314,6 +322,7 @@ impl Router {
                 request_body_required: H::request_body_required(),
                 error_responses: H::error_responses(),
                 header_parameters: H::header_parameters(),
+                description: H::description(),
             },
             move |req, params, state| {
                 let h = handler.clone();
@@ -353,6 +362,7 @@ impl Router {
                 request_body_required: H::request_body_required(),
                 error_responses: H::error_responses(),
                 header_parameters: H::header_parameters(),
+                description: H::description(),
             },
             move |req, params, state| {
                 let h = handler.clone();
@@ -395,6 +405,7 @@ impl Router {
                     route.request_body_required,
                     route.error_responses.clone(),
                     route.header_parameters.clone(),
+                    route.description,
                 )
             })
             .collect()

--- a/rapina/tests/llms.rs
+++ b/rapina/tests/llms.rs
@@ -18,6 +18,17 @@ async fn llms_create_user() -> &'static str {
     "created"
 }
 
+#[get("/llms-described", description = "Fetch the described resource")]
+async fn llms_explicit_description() -> &'static str {
+    "described"
+}
+
+/// Return a summary of health status
+#[get("/llms-health")]
+async fn llms_rustdoc_description() -> &'static str {
+    "ok"
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -103,6 +114,60 @@ async fn test_llms_txt_returns_404_when_disabled() {
     let resp = client.get("/__rapina/llms.txt").send().await;
 
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_llms_txt_shows_explicit_description() {
+    let app = Rapina::new()
+        .with_introspection(false)
+        .enable_llms_txt()
+        .discover();
+
+    let client = TestClient::new(app).await;
+    let resp = client.get("/__rapina/llms.txt").send().await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.text();
+    assert!(
+        body.contains("Fetch the described resource"),
+        "Expected explicit description in llms.txt, got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_llms_txt_shows_rustdoc_description() {
+    let app = Rapina::new()
+        .with_introspection(false)
+        .enable_llms_txt()
+        .discover();
+
+    let client = TestClient::new(app).await;
+    let resp = client.get("/__rapina/llms.txt").send().await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.text();
+    assert!(
+        body.contains("Return a summary of health status"),
+        "Expected rustdoc description in llms.txt, got:\n{body}"
+    );
+}
+
+#[tokio::test]
+async fn test_llms_txt_humanizes_handler_name_when_no_description() {
+    let app = Rapina::new()
+        .with_introspection(false)
+        .enable_llms_txt()
+        .discover();
+
+    let client = TestClient::new(app).await;
+    let resp = client.get("/__rapina/llms.txt").send().await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.text();
+    assert!(
+        body.contains("Llms list users") || body.contains("Llms create user"),
+        "Expected humanized handler name in llms.txt, got:\n{body}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implements #585. Adds human-readable descriptions to each route entry in `llms.txt` output, with three resolution layers:

1. **Explicit attribute** — `#[get("/users", description = "List all users")]` — highest priority
2. **Rustdoc extraction** — first non-empty `///` line above the handler — zero extra syntax for documented handlers
3. **Humanized fallback** — `create_user` → `"Create user"` — ensures every route has a description even without any annotation

The description is rendered between the route heading and the request block:

\`\`\`
### GET /users

List all users

Request (application/json):
...
\`\`\`

**Changes:**
- `RouteInfo` and `RouteDescriptor` gain a `description` field
- `Handler` trait gains a `description()` default method (returns `None`)
- Proc macro parses `description = "..."` attribute and extracts rustdoc via `extract_doc_description()`
- `to_llms_txt` renders the description; `humanize_handler_name` provides the fallback
- All existing `RouteInfo::new()` call sites updated (new 10th parameter)

## Related Issues

Closes #585

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)