### PR TITLE
Add OpenTelemetry OTLP tracing exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OpenTelemetry OTLP tracing exporter**: `with_telemetry(TelemetryConfig { endpoint, service_name, sample_rate })` exports traces over OTLP gRPC to a collector such as Jaeger or Datadog, behind the `otel` feature. Incoming W3C `traceparent` headers are honored so traces continue across service boundaries, request spans follow the HTTP semantic conventions and carry the response status, the OTel `trace_id`/`span_id` are recorded on the request span so logs correlate with the exported trace, and pending spans are flushed on graceful shutdown. Plaintext gRPC by default; enable `otel-tls` for `https://` collectors (#93).
+
+### Changed
+- `with_tracing` now installs the tracing subscriber when the server starts (in `listen`) rather than at call time, so it can be composed with the OTLP export layer onto a single global subscriber.
+
 ## [0.12.0] - 2026-05-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1288,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1560,6 +1572,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2306,6 +2331,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2530,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2609,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2613,6 +2725,38 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2754,6 +2898,9 @@ dependencies = [
  "matchit",
  "multer",
  "nix 0.31.3",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "pin-project-lite",
  "prometheus",
  "rapina-macros",
@@ -2777,6 +2924,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
  "validator",
@@ -3957,6 +4105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,12 +4406,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4319,6 +4528,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4678,6 +4903,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/docs/content/docs/core-concepts/observability.md
+++ b/docs/content/docs/core-concepts/observability.md
@@ -1,0 +1,129 @@
++++
+title = "Observability"
+description = "Structured logging and OpenTelemetry trace export with the otel feature flag"
+weight = 13
+date = 2026-06-07
++++
+
+Rapina has two observability layers: structured logging built on [tracing](https://docs.rs/tracing), and distributed tracing exported over OTLP to any OpenTelemetry collector such as Jaeger, Grafana Tempo, or Datadog.
+
+## Structured logging
+
+`with_tracing` installs a global `tracing` subscriber that formats logs to stdout:
+
+```rust
+use rapina::prelude::*;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    Rapina::new()
+        .with_tracing(TracingConfig::default())
+        .router(router)
+        .listen("127.0.0.1:3000")
+        .await
+}
+```
+
+`TracingConfig` controls the output format:
+
+| Field              | Default       | Description                          |
+| ------------------ | ------------- | ------------------------------------ |
+| `json`             | `false`       | JSON output instead of plain text    |
+| `level`            | `Level::INFO` | Minimum level to log                 |
+| `with_target`      | `true`        | Include the module path              |
+| `with_file`        | `false`       | Include the source file name         |
+| `with_line_number` | `false`       | Include the source line number       |
+
+Each field has a builder method:
+
+```rust
+TracingConfig::new()
+    .json()
+    .level(Level::DEBUG)
+    .with_file(true)
+    .with_line_number(true)
+```
+
+When the `RUST_LOG` environment variable is set, it takes precedence over `level` and supports the full [EnvFilter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) syntax (`RUST_LOG=info,my_api=debug`).
+
+## OpenTelemetry trace export
+
+Enable the `otel` feature flag:
+
+```toml
+[dependencies]
+rapina = { version = "0.12.0", features = ["otel"] }
+```
+
+Then configure the exporter with `with_telemetry`:
+
+```rust
+use rapina::prelude::*;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    Rapina::new()
+        .with_telemetry(TelemetryConfig {
+            endpoint: "http://localhost:4317".into(),
+            service_name: "my-api".into(),
+            sample_rate: 1.0,
+        })
+        .router(router)
+        .listen("127.0.0.1:3000")
+        .await
+}
+```
+
+`TelemetryConfig` fields and defaults:
+
+| Field          | Default                  | Description                                            |
+| -------------- | ------------------------ | ------------------------------------------------------ |
+| `endpoint`     | `http://localhost:4317`  | OTLP gRPC endpoint of the collector                    |
+| `service_name` | `rapina`                 | Reported as the `service.name` resource attribute      |
+| `sample_rate`  | `1.0`                    | Fraction of traces to sample, `0.0` (none) to `1.0` (all) |
+
+The same builder style works here:
+
+```rust
+TelemetryConfig::new()
+    .endpoint("http://jaeger:4317")
+    .service_name("my-api")
+    .sample_rate(0.25)
+```
+
+Export is plaintext OTLP gRPC by default. For an `https://` collector enable the `otel-tls` feature, which adds TLS with the system root certificates.
+
+`with_telemetry` and `with_tracing` compose: when both are set, logs go to stdout and spans go to the collector through a single subscriber. Spans are exported in batches and flushed during graceful shutdown, so in-flight traces are not dropped.
+
+## Sampling
+
+The sampler is parent-based. When a request carries a propagated trace context, the upstream sampling decision is honored; otherwise the trace id is sampled at `sample_rate`. Out-of-range values are clamped to `[0.0, 1.0]`.
+
+## Request spans
+
+With telemetry configured, every request gets a server span following the [OpenTelemetry HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/). The span is named `{method} {route}` using the matched route template (`GET /users/:id`, not `GET /users/42`), falling back to the bare method when no route matches.
+
+Recorded attributes:
+
+| Attribute                   | Example       |
+| --------------------------- | ------------- |
+| `http.request.method`       | `GET`         |
+| `http.route`                | `/users/:id`  |
+| `url.path`                  | `/users/42`   |
+| `http.response.status_code` | `200`         |
+
+Responses with a 5xx status mark the span as an error. Log lines emitted inside a request carry `otel_trace_id` and `otel_span_id` fields, so logs correlate with the exported trace.
+
+## Distributed tracing
+
+Incoming requests with a W3C `traceparent` header continue the upstream trace: the request span is linked to the remote parent, and spans exported from your service appear in the same trace as the calling service.
+
+## Trying it locally
+
+Run Jaeger all-in-one:
+
+```sh
+docker run --rm -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one
+```
+
+Start your app with the `otel` feature and default `TelemetryConfig`, send a few requests, and open the Jaeger UI at `http://localhost:16686`. The repository ships a runnable example: `cargo run --example telemetry --features otel`.

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -89,6 +89,12 @@ base64 = { version = "0.22", optional = true }
 # Prometheus (optional)
 prometheus = { version = '0.13', optional = true }
 
+# OpenTelemetry OTLP export (optional)
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", optional = true }
+opentelemetry-otlp = { version = "0.32", optional = true, default-features = false, features = ["grpc-tonic", "trace", "internal-logs"] }
+tracing-opentelemetry = { version = "0.33", optional = true }
+
 # Redis cache backend (optional)
 redis = { version = "1.2", optional = true, features = ["tokio-comp"] }
 
@@ -111,6 +117,8 @@ criterion = { version = "0.5", features = ["html_reports"] }
 insta = "1"
 matchit = "0.9"
 nix = { version = "0.31", features = ["signal"] }
+# In-memory span exporter for the otel propagation/export test.
+opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 serial_test = "3"
 tempfile = "3"
 tower = { version = "0.5", features = ["limit"] }
@@ -131,6 +139,10 @@ required-features = ["compression", "rate-limit"]
 name = "multipart"
 required-features = ["multipart"]
 
+[[example]]
+name = "telemetry"
+required-features = ["otel"]
+
 [features]
 default = ["compression", "rate-limit"]
 rate-limit = []
@@ -140,6 +152,8 @@ postgres = ["database", "sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgre
 mysql = ["database", "sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 sqlite = ["database", "sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]
 metrics = ["prometheus"]
+otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]
+otel-tls = ["otel", "opentelemetry-otlp/tls-roots"]
 cache-redis = ["redis"]
 multipart = ["multer"]
 tower = ["tower-service", "tower-layer"]

--- a/rapina/examples/telemetry.rs
+++ b/rapina/examples/telemetry.rs
@@ -1,0 +1,31 @@
+//! Export traces over OTLP to a collector such as Jaeger or Datadog.
+//!
+//! Run a local collector, for example Jaeger all-in-one:
+//!
+//! ```sh
+//! docker run --rm -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one
+//! ```
+//!
+//! Then `cargo run --example telemetry --features otel` and open the Jaeger UI
+//! at http://localhost:16686. Requests carrying a W3C `traceparent` header
+//! continue the upstream trace.
+
+use rapina::prelude::*;
+
+#[get("/")]
+async fn hello() -> &'static str {
+    "Hello, Rapina!"
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    Rapina::new()
+        .with_telemetry(TelemetryConfig {
+            endpoint: "http://localhost:4317".into(),
+            service_name: "my-api".into(),
+            sample_rate: 1.0,
+        })
+        .discover()
+        .listen("127.0.0.1:3000")
+        .await
+}

--- a/rapina/src/app.rs
+++ b/rapina/src/app.rs
@@ -100,7 +100,18 @@ pub struct Rapina {
     pub(crate) jobs_config: Option<crate::jobs::JobConfig>,
     #[cfg(feature = "cron-scheduler")]
     pub(crate) cron_scheduler: Option<CronScheduler>,
+    /// Tracing/logging configuration, applied when the server starts.
+    pub(crate) tracing_config: Option<TracingConfig>,
+    /// OTLP telemetry export configuration (if enabled)
+    #[cfg(feature = "otel")]
+    pub(crate) telemetry_config: Option<crate::observability::TelemetryConfig>,
 }
+
+/// Tracks whether the process-global telemetry pipeline has been installed, so a
+/// second `listen` does not build a second exporter or silently fail to install.
+#[cfg(feature = "otel")]
+static TELEMETRY_INITIALIZED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 // Resolves the listen address, preferring RAPINA_HOST/RAPINA_PORT over addr when both are set.
 pub(crate) fn resolve_listen_addr(addr: &str) -> SocketAddr {
@@ -145,6 +156,9 @@ impl Rapina {
             jobs_config: None,
             #[cfg(feature = "cron-scheduler")]
             cron_scheduler: None,
+            tracing_config: None,
+            #[cfg(feature = "otel")]
+            telemetry_config: None,
         }
     }
 
@@ -431,8 +445,28 @@ impl Rapina {
     }
 
     /// Configures tracing/logging for the application.
-    pub fn with_tracing(self, config: TracingConfig) -> Self {
-        config.init();
+    ///
+    /// The subscriber is installed when the server starts (in [`listen`]), so it
+    /// can be composed with the OTLP export layer from [`with_telemetry`] onto a
+    /// single global subscriber.
+    ///
+    /// [`listen`]: Self::listen
+    /// [`with_telemetry`]: Self::with_telemetry
+    pub fn with_tracing(mut self, config: TracingConfig) -> Self {
+        self.tracing_config = Some(config);
+        self
+    }
+
+    /// Configures OTLP trace export to a collector such as Jaeger or Datadog.
+    ///
+    /// Traces are exported over OTLP gRPC and incoming W3C `traceparent` headers
+    /// are honored so traces continue across service boundaries. The exporter is
+    /// built and the subscriber installed when the server starts (in [`listen`]).
+    ///
+    /// [`listen`]: Self::listen
+    #[cfg(feature = "otel")]
+    pub fn with_telemetry(mut self, config: crate::observability::TelemetryConfig) -> Self {
+        self.telemetry_config = Some(config);
         self
     }
 
@@ -895,6 +929,14 @@ impl Rapina {
             base_uri: self.rfc7807_base_uri.clone(),
         });
 
+        // Trace context propagation runs first so the request span carries the
+        // parent extracted from incoming headers and wraps every other layer.
+        #[cfg(feature = "otel")]
+        if self.telemetry_config.is_some() {
+            self.middlewares
+                .prepend(crate::middleware::TraceContextMiddleware::new());
+        }
+
         // Auto-discover routes from inventory (must run before auth middleware)
         if self.auto_discover {
             let manual_count = self.router.routes.len();
@@ -1035,7 +1077,62 @@ impl Rapina {
     /// in dev mode and the banner is correct by construction.
     pub async fn listen(self, addr: &str) -> std::io::Result<()> {
         let addr: SocketAddr = resolve_listen_addr(addr);
+
+        // Install the tracing subscriber before anything else so startup logs are
+        // captured. When telemetry is configured the OTLP export layer is composed
+        // onto the same subscriber, since a global subscriber can only be set once.
+        // The global state (subscriber, tracer provider, propagator) is installed
+        // at most once per process; a second `listen` reuses it.
+        let tracing_config = self.tracing_config.clone();
+        #[cfg(feature = "otel")]
+        let otel_provider = match self.telemetry_config.clone() {
+            Some(config)
+                if !TELEMETRY_INITIALIZED.swap(true, std::sync::atomic::Ordering::SeqCst) =>
+            {
+                let (provider, layer) = crate::observability::build_otel_pipeline(&config)
+                    .map_err(std::io::Error::other)?;
+                opentelemetry::global::set_tracer_provider(provider.clone());
+                opentelemetry::global::set_text_map_propagator(
+                    opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+                );
+                if crate::observability::init_subscriber(tracing_config, Some(layer)).is_err() {
+                    eprintln!(
+                        "rapina: telemetry is enabled but a tracing subscriber is already installed; \
+                         OTLP traces will not be exported"
+                    );
+                }
+                Some(provider)
+            }
+            Some(_) => {
+                eprintln!("rapina: telemetry already initialized; ignoring repeated configuration");
+                None
+            }
+            None => {
+                let _ = crate::observability::init_subscriber(tracing_config, None);
+                None
+            }
+        };
+        #[cfg(not(feature = "otel"))]
+        let _ = crate::observability::init_subscriber(tracing_config, None);
+
         let app = self.prepare();
+
+        // Flush exported spans during graceful shutdown so in-flight traces are
+        // not dropped. The hook runs after connections drain.
+        #[cfg(feature = "otel")]
+        let app = {
+            let mut app = app;
+            if let Some(provider) = otel_provider {
+                app.shutdown_hooks.push(Box::new(move || {
+                    Box::pin(async move {
+                        // shutdown joins the exporter's background thread, so run it
+                        // off the async runtime worker.
+                        let _ = tokio::task::spawn_blocking(move || provider.shutdown()).await;
+                    })
+                }));
+            }
+            app
+        };
 
         // Spawn the background job worker if configured.  The worker receives
         // a cheap clone of AppState (inner values are Arc-wrapped) so it shares

--- a/rapina/src/lib.rs
+++ b/rapina/src/lib.rs
@@ -156,6 +156,8 @@ pub mod prelude {
     pub use crate::middleware::{Middleware, Next, RequestLogConfig};
     #[cfg(feature = "tower")]
     pub use crate::middleware::{RapinaService, TowerLayerMiddleware};
+    #[cfg(feature = "otel")]
+    pub use crate::observability::TelemetryConfig;
     pub use crate::observability::TracingConfig;
     #[cfg(feature = "database")]
     pub use crate::pagination::{

--- a/rapina/src/middleware/mod.rs
+++ b/rapina/src/middleware/mod.rs
@@ -14,6 +14,8 @@ mod body_limit;
 #[cfg(feature = "compression")]
 mod compression;
 mod cors;
+#[cfg(feature = "otel")]
+mod otel;
 #[cfg(feature = "rate-limit")]
 mod rate_limit;
 mod request_log;
@@ -26,6 +28,8 @@ pub use body_limit::BodyLimitMiddleware;
 #[cfg(feature = "compression")]
 pub use compression::{CompressionConfig, CompressionMiddleware};
 pub use cors::{AllowedHeaders, AllowedMethods, AllowedOrigins, CorsConfig, CorsMiddleware};
+#[cfg(feature = "otel")]
+pub use otel::TraceContextMiddleware;
 #[cfg(feature = "rate-limit")]
 pub use rate_limit::{KeyExtractor, RateLimitConfig, RateLimitMiddleware};
 pub use request_log::{RequestLogConfig, RequestLogMiddleware};
@@ -143,6 +147,12 @@ impl MiddlewareStack {
 
     pub fn add<M: Middleware>(&mut self, middleware: M) {
         self.middlewares.push(Arc::new(middleware));
+    }
+
+    /// Inserts a middleware at the front of the stack so it runs first.
+    #[cfg(feature = "otel")]
+    pub(crate) fn prepend<M: Middleware>(&mut self, middleware: M) {
+        self.middlewares.insert(0, Arc::new(middleware));
     }
 
     pub fn push(&mut self, middleware: Arc<dyn Middleware>) {

--- a/rapina/src/middleware/otel.rs
+++ b/rapina/src/middleware/otel.rs
@@ -7,7 +7,7 @@ use tracing::field::Empty;
 use tracing::{Instrument, info_span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::context::RequestContext;
+use crate::context::{MatchedPattern, RequestContext};
 use crate::response::BoxBody;
 
 use super::{BoxFuture, Middleware, Next};
@@ -57,7 +57,11 @@ impl Middleware for TraceContextMiddleware {
         let parent_cx = global::get_text_map_propagator(|propagator| {
             propagator.extract(&HeaderExtractor(req.headers()))
         });
-        let span = server_span(req.method(), req.uri().path(), parent_cx);
+        let route = req
+            .extensions()
+            .get::<MatchedPattern>()
+            .map(|m| m.as_str().to_owned());
+        let span = server_span(req.method(), req.uri().path(), route.as_deref(), parent_cx);
 
         let response_span = span.clone();
         Box::pin(
@@ -75,24 +79,33 @@ impl Middleware for TraceContextMiddleware {
 /// conventions, links it to the remote parent, and records the OTel ids onto it
 /// so log lines emitted within the span correlate with the exported trace.
 ///
-/// The route template isn't known before routing, so the span name is the
-/// method per the spec's low-cardinality fallback.
+/// Named `{method} {route}` when the router matched a template, plain method
+/// otherwise per the spec's low-cardinality fallback.
 fn server_span(
     method: &hyper::Method,
     path: &str,
+    route: Option<&str>,
     parent_cx: opentelemetry::Context,
 ) -> tracing::Span {
+    let name = match route {
+        Some(route) => format!("{method} {route}"),
+        None => method.to_string(),
+    };
     let span = info_span!(
         "http.request",
-        otel.name = %method,
+        otel.name = %name,
         otel.kind = "server",
         otel.status_code = Empty,
         http.request.method = %method,
+        http.route = Empty,
         url.path = %path,
         http.response.status_code = Empty,
         otel_trace_id = Empty,
         otel_span_id = Empty,
     );
+    if let Some(route) = route {
+        span.record("http.route", route);
+    }
     let _ = span.set_parent(parent_cx);
 
     let span_context = span.context().span().span_context().clone();
@@ -177,7 +190,12 @@ mod tests {
         // records it synchronously.
         tracing::subscriber::with_default(subscriber, || {
             let parent_cx = TraceContextPropagator::new().extract(&HeaderExtractor(&headers));
-            let span = server_span(&hyper::Method::GET, "/users/42", parent_cx);
+            let span = server_span(
+                &hyper::Method::GET,
+                "/users/42",
+                Some("/users/:id"),
+                parent_cx,
+            );
             record_response(&span, hyper::StatusCode::INTERNAL_SERVER_ERROR);
         });
 
@@ -187,6 +205,7 @@ mod tests {
 
         assert_eq!(format!("{:032x}", span.span_context.trace_id()), trace_id);
         assert_eq!(format!("{:016x}", span.parent_span_id), parent_span_id);
+        assert_eq!(span.name, "GET /users/:id");
         assert_eq!(span.status, Status::error(""));
 
         let attr = |key: &str| {
@@ -196,7 +215,45 @@ mod tests {
                 .map(|kv| kv.value.to_string())
         };
         assert_eq!(attr("http.request.method").as_deref(), Some("GET"));
+        assert_eq!(attr("http.route").as_deref(), Some("/users/:id"));
         assert_eq!(attr("url.path").as_deref(), Some("/users/42"));
         assert_eq!(attr("http.response.status_code").as_deref(), Some("500"));
+    }
+
+    #[test]
+    fn unmatched_route_falls_back_to_method_span_name() {
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tracing_subscriber::Registry;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let subscriber = Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = server_span(
+                &hyper::Method::GET,
+                "/nope",
+                None,
+                opentelemetry::Context::new(),
+            );
+            record_response(&span, hyper::StatusCode::NOT_FOUND);
+        });
+
+        let spans = exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+
+        assert_eq!(span.name, "GET");
+        assert!(
+            !span
+                .attributes
+                .iter()
+                .any(|kv| kv.key.as_str() == "http.route")
+        );
     }
 }

--- a/rapina/src/middleware/otel.rs
+++ b/rapina/src/middleware/otel.rs
@@ -1,0 +1,202 @@
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+use opentelemetry::global;
+use opentelemetry::propagation::Extractor;
+use opentelemetry::trace::TraceContextExt;
+use tracing::field::Empty;
+use tracing::{Instrument, info_span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::context::RequestContext;
+use crate::response::BoxBody;
+
+use super::{BoxFuture, Middleware, Next};
+
+/// Adapts an HTTP header map to the OpenTelemetry propagation `Extractor` so a
+/// W3C `traceparent` (and friends) can be read from an incoming request.
+struct HeaderExtractor<'a>(&'a http::HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|name| name.as_str()).collect()
+    }
+}
+
+/// Middleware that continues a distributed trace from incoming request headers.
+///
+/// It extracts the remote trace context (W3C `traceparent`) using the globally
+/// configured propagator and attaches it as the parent of the request span, so
+/// spans exported over OTLP link back to the calling service. Registered
+/// automatically at the front of the stack when telemetry is configured.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceContextMiddleware;
+
+impl TraceContextMiddleware {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TraceContextMiddleware {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Middleware for TraceContextMiddleware {
+    fn handle<'a>(
+        &'a self,
+        req: Request<Incoming>,
+        _ctx: &'a RequestContext,
+        next: Next<'a>,
+    ) -> BoxFuture<'a, Response<BoxBody>> {
+        let parent_cx = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(req.headers()))
+        });
+        let span = server_span(req.method(), req.uri().path(), parent_cx);
+
+        let response_span = span.clone();
+        Box::pin(
+            async move {
+                let response = next.run(req).await;
+                record_response(&response_span, response.status());
+                response
+            }
+            .instrument(span),
+        )
+    }
+}
+
+/// Builds the server request span following the OpenTelemetry HTTP semantic
+/// conventions, links it to the remote parent, and records the OTel ids onto it
+/// so log lines emitted within the span correlate with the exported trace.
+///
+/// The route template isn't known before routing, so the span name is the
+/// method per the spec's low-cardinality fallback.
+fn server_span(
+    method: &hyper::Method,
+    path: &str,
+    parent_cx: opentelemetry::Context,
+) -> tracing::Span {
+    let span = info_span!(
+        "http.request",
+        otel.name = %method,
+        otel.kind = "server",
+        otel.status_code = Empty,
+        http.request.method = %method,
+        url.path = %path,
+        http.response.status_code = Empty,
+        otel_trace_id = Empty,
+        otel_span_id = Empty,
+    );
+    let _ = span.set_parent(parent_cx);
+
+    let span_context = span.context().span().span_context().clone();
+    if span_context.is_valid() {
+        span.record("otel_trace_id", span_context.trace_id().to_string());
+        span.record("otel_span_id", span_context.span_id().to_string());
+    }
+    span
+}
+
+/// Records the response status onto the request span, marking server errors.
+fn record_response(span: &tracing::Span, status: hyper::StatusCode) {
+    span.record("http.response.status_code", status.as_u16());
+    if status.is_server_error() {
+        span.record("otel.status_code", "ERROR");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::propagation::TextMapPropagator;
+    use opentelemetry::trace::TraceContextExt;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+    #[test]
+    fn extracts_w3c_traceparent_into_remote_context() {
+        let trace_id = "0af7651916cd43dd8448eb211c80319c";
+        let parent_span_id = "b7ad6b7169203331";
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            format!("00-{trace_id}-{parent_span_id}-01")
+                .parse()
+                .unwrap(),
+        );
+
+        let propagator = TraceContextPropagator::new();
+        let cx = propagator.extract(&HeaderExtractor(&headers));
+        let remote = cx.span().span_context().clone();
+
+        assert!(remote.is_remote());
+        assert_eq!(format!("{:032x}", remote.trace_id()), trace_id);
+        assert_eq!(format!("{:016x}", remote.span_id()), parent_span_id);
+    }
+
+    #[test]
+    fn missing_traceparent_yields_invalid_context() {
+        let headers = http::HeaderMap::new();
+        let propagator = TraceContextPropagator::new();
+        let cx = propagator.extract(&HeaderExtractor(&headers));
+
+        assert!(!cx.span().span_context().is_valid());
+    }
+
+    #[test]
+    fn exported_span_continues_remote_trace_and_records_status() {
+        use opentelemetry::trace::{Status, TracerProvider as _};
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tracing_subscriber::Registry;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let trace_id = "0af7651916cd43dd8448eb211c80319c";
+        let parent_span_id = "b7ad6b7169203331";
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            format!("00-{trace_id}-{parent_span_id}-01")
+                .parse()
+                .unwrap(),
+        );
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let subscriber = Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")));
+
+        // Drive the real span helpers under a scoped subscriber so we don't touch
+        // the global one. Dropping the span closes it and the simple exporter
+        // records it synchronously.
+        tracing::subscriber::with_default(subscriber, || {
+            let parent_cx = TraceContextPropagator::new().extract(&HeaderExtractor(&headers));
+            let span = server_span(&hyper::Method::GET, "/users/42", parent_cx);
+            record_response(&span, hyper::StatusCode::INTERNAL_SERVER_ERROR);
+        });
+
+        let spans = exporter.get_finished_spans().unwrap();
+        assert_eq!(spans.len(), 1);
+        let span = &spans[0];
+
+        assert_eq!(format!("{:032x}", span.span_context.trace_id()), trace_id);
+        assert_eq!(format!("{:016x}", span.parent_span_id), parent_span_id);
+        assert_eq!(span.status, Status::error(""));
+
+        let attr = |key: &str| {
+            span.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.to_string())
+        };
+        assert_eq!(attr("http.request.method").as_deref(), Some("GET"));
+        assert_eq!(attr("url.path").as_deref(), Some("/users/42"));
+        assert_eq!(attr("http.response.status_code").as_deref(), Some("500"));
+    }
+}

--- a/rapina/src/observability/mod.rs
+++ b/rapina/src/observability/mod.rs
@@ -2,6 +2,13 @@
 //!
 //! This module provides tools for logging, tracing, and monitoring.
 
+#[cfg(feature = "otel")]
+mod telemetry;
 mod tracing;
 
+#[cfg(feature = "otel")]
+pub use self::telemetry::TelemetryConfig;
+#[cfg(feature = "otel")]
+pub(crate) use self::telemetry::build_otel_pipeline;
 pub use self::tracing::TracingConfig;
+pub(crate) use self::tracing::init_subscriber;

--- a/rapina/src/observability/telemetry.rs
+++ b/rapina/src/observability/telemetry.rs
@@ -1,0 +1,146 @@
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{ExporterBuildError, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use tracing_subscriber::{Layer, Registry};
+
+/// Configuration for exporting traces over OTLP to a collector such as Jaeger
+/// or Datadog.
+///
+/// Export is plaintext OTLP gRPC by default. For an `https://` collector enable
+/// the `otel-tls` feature, which adds TLS with the system root certificates.
+///
+/// # Examples
+///
+/// ```ignore
+/// use rapina::prelude::*;
+///
+/// Rapina::new()
+///     .with_telemetry(TelemetryConfig {
+///         endpoint: "http://jaeger:4317".into(),
+///         service_name: "my-api".into(),
+///         sample_rate: 1.0,
+///     })
+///     .router(router)
+///     .listen("127.0.0.1:3000")
+///     .await
+/// ```
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    /// OTLP gRPC endpoint of the collector (for example `http://jaeger:4317`).
+    pub endpoint: String,
+    /// Service name reported as the `service.name` resource attribute.
+    pub service_name: String,
+    /// Fraction of traces to sample, from `0.0` (none) to `1.0` (all).
+    pub sample_rate: f64,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:4317".to_string(),
+            service_name: "rapina".to_string(),
+            sample_rate: 1.0,
+        }
+    }
+}
+
+impl TelemetryConfig {
+    /// Creates a telemetry configuration with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the OTLP collector endpoint.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    /// Sets the service name.
+    pub fn service_name(mut self, name: impl Into<String>) -> Self {
+        self.service_name = name.into();
+        self
+    }
+
+    /// Sets the sampling rate (`0.0` to `1.0`).
+    pub fn sample_rate(mut self, rate: f64) -> Self {
+        self.sample_rate = rate;
+        self
+    }
+}
+
+/// Clamps a sampling rate into `[0.0, 1.0]`, mapping NaN to full sampling so a
+/// misconfigured value never silently disables tracing.
+fn normalize_sample_rate(rate: f64) -> f64 {
+    if rate.is_nan() {
+        1.0
+    } else {
+        rate.clamp(0.0, 1.0)
+    }
+}
+
+/// Builds the OTLP tracing pipeline.
+///
+/// Returns the tracer provider (kept so it can be installed globally and flushed
+/// on shutdown) and the `tracing-opentelemetry` layer to compose onto the
+/// subscriber. The sampler is parent-based so it honors the sampling decision
+/// carried in a propagated trace context. Installing the provider globally is
+/// left to the caller so all process-global mutation stays in one place.
+pub(crate) fn build_otel_pipeline(
+    config: &TelemetryConfig,
+) -> Result<(SdkTracerProvider, Box<dyn Layer<Registry> + Send + Sync>), ExporterBuildError> {
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(&config.endpoint)
+        .build()?;
+
+    let resource = Resource::builder()
+        .with_service_name(config.service_name.clone())
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+            normalize_sample_rate(config.sample_rate),
+        ))))
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("rapina");
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer).boxed();
+
+    Ok((provider, layer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.endpoint, "http://localhost:4317");
+        assert_eq!(config.service_name, "rapina");
+        assert_eq!(config.sample_rate, 1.0);
+    }
+
+    #[test]
+    fn builder_overrides_fields() {
+        let config = TelemetryConfig::new()
+            .endpoint("http://jaeger:4317")
+            .service_name("my-api")
+            .sample_rate(0.25);
+        assert_eq!(config.endpoint, "http://jaeger:4317");
+        assert_eq!(config.service_name, "my-api");
+        assert_eq!(config.sample_rate, 0.25);
+    }
+
+    #[test]
+    fn sample_rate_is_normalized() {
+        assert_eq!(normalize_sample_rate(0.5), 0.5);
+        assert_eq!(normalize_sample_rate(-1.0), 0.0);
+        assert_eq!(normalize_sample_rate(2.0), 1.0);
+        assert_eq!(normalize_sample_rate(f64::NAN), 1.0);
+    }
+}

--- a/rapina/src/observability/tracing.rs
+++ b/rapina/src/observability/tracing.rs
@@ -1,5 +1,7 @@
 use tracing::Level;
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::{SubscriberInitExt, TryInitError};
+use tracing_subscriber::{EnvFilter, Layer, Registry, fmt};
 
 /// Configuration for the tracing/logging system.
 ///
@@ -81,26 +83,52 @@ impl TracingConfig {
 
     /// Initializes the tracing subscriber with this configuration.
     pub fn init(self) {
-        let filter = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new(self.level.to_string()));
-
-        if self.json {
-            fmt()
-                .with_env_filter(filter)
-                .with_target(self.with_target)
-                .with_file(self.with_file)
-                .with_line_number(self.with_line_number)
-                .json()
-                .init();
-        } else {
-            fmt()
-                .with_env_filter(filter)
-                .with_target(self.with_target)
-                .with_file(self.with_file)
-                .with_line_number(self.with_line_number)
-                .init();
-        }
+        let _ = init_subscriber(Some(self), None);
     }
+}
+
+/// Builds the stdout formatting layer for the given configuration.
+fn fmt_layer(config: &TracingConfig) -> Box<dyn Layer<Registry> + Send + Sync> {
+    let layer = fmt::layer()
+        .with_target(config.with_target)
+        .with_file(config.with_file)
+        .with_line_number(config.with_line_number);
+
+    if config.json {
+        layer.json().boxed()
+    } else {
+        layer.boxed()
+    }
+}
+
+/// Installs the global tracing subscriber.
+///
+/// Composes the stdout formatting layer with an optional extra layer (the OTLP
+/// export layer when telemetry is configured) onto a single `Registry`, since a
+/// global subscriber can only be set once. Does nothing when neither a tracing
+/// config nor an extra layer is given. Uses `try_init` so a second call (for
+/// example a direct `TracingConfig::init`) degrades to a no-op instead of
+/// panicking.
+pub(crate) fn init_subscriber(
+    tracing: Option<TracingConfig>,
+    extra_layer: Option<Box<dyn Layer<Registry> + Send + Sync>>,
+) -> Result<(), TryInitError> {
+    if tracing.is_none() && extra_layer.is_none() {
+        return Ok(());
+    }
+
+    let config = tracing.unwrap_or_default();
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(config.level.to_string()));
+
+    let mut layers: Vec<Box<dyn Layer<Registry> + Send + Sync>> = vec![fmt_layer(&config)];
+    if let Some(layer) = extra_layer {
+        layers.push(layer);
+    }
+
+    Registry::default()
+        .with(layers.with_filter(filter))
+        .try_init()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #93

Adds an `otel` feature that exports traces over OTLP gRPC to a collector like Jaeger or Datadog. `with_telemetry(TelemetryConfig { endpoint, service_name, sample_rate })` composes a `tracing-opentelemetry` layer onto the same subscriber as the stdout `fmt` layer. Incoming W3C `traceparent` headers continue the trace across services, request spans follow the HTTP semantic conventions and record the response status, the OTel `trace_id`/`span_id` land on the request span so logs correlate with the trace, and spans flush on graceful shutdown. Export is plaintext by default. Enable `otel-tls` for system-root TLS to reach `https://` collectors. Because a global subscriber can only be set once, `with_tracing` now installs at `listen()` instead of at call time so the two layers compose.
