### PR TITLE
fix: add llms.txt check to rapina doctor

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,8 @@ ignore = [
     "RUSTSEC-2023-0071",
     # protobuf: stack overflow - locked by prometheus v0.13 depending on protobuf v2
     "RUSTSEC-2024-0437",
+    # proc-macro-error2: unmaintained - transitive via sea-orm and validator, no safe upgrade available
+    "RUSTSEC-2026-0173",
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -28,8 +28,6 @@ ignore = [
     "RUSTSEC-2023-0071",
     # protobuf: stack overflow - locked by prometheus v0.13 depending on protobuf v2
     "RUSTSEC-2024-0437",
-    # proc-macro-error2: unmaintained - transitive via sea-orm and validator, no safe upgrade available
-    "RUSTSEC-2026-0173",
 ]
 
 [sources]

--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -28,14 +28,14 @@ This creates:
 
 ### Options
 
-| Flag | Description |
-|------|-------------|
-| `--template <T>` | Starter template: `rest-api` (default), `crud`, `auth` |
-| `--db <DB>` | Database: `sqlite`, `postgres`, `mysql`. Required for `--template crud` |
-| `--no-ai` | Skip all AI files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules`, `.rapina-docs/`) |
-| `--no-agents-md` | Skip `AGENTS.md` and `CLAUDE.md` only |
-| `--no-bundled-docs` | Skip `.rapina-docs/` only |
-| `--agents-md-only` | Generate `AGENTS.md` and `CLAUDE.md` but skip `.rapina-docs/` and `.cursor/rules` |
+| Flag                | Description                                                                       |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `--template <T>`    | Starter template: `rest-api` (default), `crud`, `auth`                            |
+| `--db <DB>`         | Database: `sqlite`, `postgres`, `mysql`. Required for `--template crud`           |
+| `--no-ai`           | Skip all AI files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules`, `.rapina-docs/`)    |
+| `--no-agents-md`    | Skip `AGENTS.md` and `CLAUDE.md` only                                             |
+| `--no-bundled-docs` | Skip `.rapina-docs/` only                                                         |
+| `--agents-md-only`  | Generate `AGENTS.md` and `CLAUDE.md` but skip `.rapina-docs/` and `.cursor/rules` |
 
 Examples:
 
@@ -293,6 +293,7 @@ Doctor runs two classes of checks:
 - Error documentation present
 - OpenAPI metadata (descriptions)
 - No duplicate handler paths
+- `llms.txt` endpoint reachable (warns if disabled — enabled by default in debug builds, disabled in release builds; call `enable_llms_txt()` on your `App` to enable it in production)
 
 Output:
 
@@ -302,18 +303,19 @@ Output:
 
   ✓ All routes have response schemas
   ✓ No duplicate handler paths
+  ✓ llms.txt is enabled and reachable
   ⚠ Missing documentation: GET /users/:id
   ⚠ No documented errors: POST /users
 
-  Summary: 2 passed, 2 warnings, 0 errors
+  Summary: 3 passed, 2 warnings, 0 errors
 ```
 
 ### Options
 
-| Flag | Description |
-|------|-------------|
-| `--fix-agents` | Refresh `AGENTS.md` from current bundled fragments |
-| `--force` | With `--fix-agents`: overwrite even if the block has user edits inside the markers |
+| Flag           | Description                                                                        |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `--fix-agents` | Refresh `AGENTS.md` from current bundled fragments                                 |
+| `--force`      | With `--fix-agents`: overwrite even if the block has user edits inside the markers |
 
 ### Fixing a stale `AGENTS.md`
 
@@ -337,7 +339,9 @@ If you want to keep your custom content, move it outside the markers first:
 <!-- your custom rules here — above the managed block -->
 
 <!-- BEGIN:rapina-agent-rules v0.11.0 sha256:... -->
+
 ...managed content, do not edit...
+
 <!-- END:rapina-agent-rules -->
 
 <!-- or below the managed block -->

--- a/rapina-cli/src/commands/doctor.rs
+++ b/rapina-cli/src/commands/doctor.rs
@@ -47,6 +47,7 @@ pub fn execute(config: DoctorConfig) -> Result<(), String> {
     check_error_documentation(&routes, &mut result);
     check_openapi_metadata(&openapi, &mut result);
     check_duplicate_routes(&routes, &mut result);
+    check_llms_txt(&config.host, config.port, &mut result);
 
     print_results(&result);
 
@@ -313,6 +314,37 @@ fn check_openapi_metadata(openapi: &Result<Value, String>, result: &mut Diagnost
             result
                 .warnings
                 .push(format!("Missing documentation: {}", op));
+        }
+    }
+}
+
+/// Check that /__rapina/llms.txt is reachable and not returning 404.
+fn check_llms_txt(host: &str, port: u16, result: &mut DiagnosticResult) {
+    let url = urls::build_llms_url(host, port);
+    match crate::common::AGENT.get(&url).call() {
+        Ok(_) => {
+            result
+                .passed
+                .push("llms.txt is enabled and reachable".to_string());
+        }
+        Err(ureq::Error::StatusCode(404)) => {
+            result.warnings.push(
+                "llms.txt endpoint returns 404 — disabled in release builds by default. \
+                Call enable_llms_txt() on your App to turn it on."
+                    .to_string(),
+            );
+        }
+        Err(ureq::Error::StatusCode(status)) => {
+            result.warnings.push(format!(
+                "llms.txt endpoint returned unexpected status {status} — expected 200"
+            ));
+        }
+        Err(_) => {
+            result.warnings.push(
+                "llms.txt endpoint is unreachable — disabled in release builds by default. \
+                Call enable_llms_txt() on your App to turn it on."
+                    .to_string(),
+            );
         }
     }
 }
@@ -628,5 +660,67 @@ mod tests {
     fn test_fetch_json_connection_refused() {
         let result = fetch_json("http://127.0.0.1:1");
         assert!(result.is_err());
+    }
+
+    fn serve_once(status: u16, body: &'static str) -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0; 4096];
+            use std::io::Read;
+            let _ = stream.read(&mut buf);
+            let status_text = if status == 200 { "OK" } else { "Not Found" };
+            let response = format!(
+                "HTTP/1.1 {status} {status_text}\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            use std::io::Write;
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        port
+    }
+
+    #[test]
+    fn check_llms_txt_passes_when_200() {
+        let port = serve_once(200, "# LLMs\n");
+        let mut result = DiagnosticResult {
+            warnings: Vec::new(),
+            errors: Vec::new(),
+            passed: Vec::new(),
+        };
+        check_llms_txt("127.0.0.1", port, &mut result);
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.passed.len(), 1);
+        assert!(result.passed[0].contains("llms.txt"));
+    }
+
+    #[test]
+    fn check_llms_txt_warns_when_404() {
+        let port = serve_once(404, "");
+        let mut result = DiagnosticResult {
+            warnings: Vec::new(),
+            errors: Vec::new(),
+            passed: Vec::new(),
+        };
+        check_llms_txt("127.0.0.1", port, &mut result);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("404"));
+        assert!(result.warnings[0].contains("enable_llms_txt()"));
+        assert!(result.passed.is_empty());
+    }
+
+    #[test]
+    fn check_llms_txt_warns_when_unreachable() {
+        let mut result = DiagnosticResult {
+            warnings: Vec::new(),
+            errors: Vec::new(),
+            passed: Vec::new(),
+        };
+        check_llms_txt("127.0.0.1", 1, &mut result);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("unreachable"));
+        assert!(result.warnings[0].contains("enable_llms_txt()"));
+        assert!(result.passed.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Add `llms.txt` check to `rapina doctor`. The endpoint `/__rapina/llms.txt` is enabled by default in debug builds and disabled in release builds. Without this check, users promoting from `rapina dev` to a release build would see silent 404s from any agent or tool fetching that URL. The new check warns when the endpoint is unreachable or returns 404, and tells the user to call `enable_llms_txt()` to enable it.

## Related Issues

Closes #581

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)