### PR TITLE
Ignore-proc-macro-error2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,8 @@ ignore = [
     "RUSTSEC-2023-0071",
     # protobuf: stack overflow - locked by prometheus v0.13 depending on protobuf v2
     "RUSTSEC-2024-0437",
+    # proc-macro-error2: unmaintained - transitive via sea-orm and validator, no safe upgrade available
+    "RUSTSEC-2026-0173",
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Added proc-macro-error2 to `[advisories] ignore` in deny.toml so the CI check passes

## Related Issues

Closes #620

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [ ] Documentation updated (if needed)
