### PR TITLE
fix: allow entity types as primary keys in join tables

### DIFF
--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -227,6 +227,8 @@ UserRole {
 }
 ```
 
+A relationship field named in `#[primary_key(...)]` keeps its column name **verbatim**. Elsewhere a `belongs_to` field gets an `_id` suffix (`author: User` becomes `author_id`), but a primary key column is referenced by the name you declared, so `user_id: User` stays `user_id` rather than becoming `user_id_id`. Name these fields the way you want the columns to read. The field still resolves to the target's primary key type, and the target must have a single primary key column.
+
 #### Field Attributes
 
 | Attribute | Description |

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -18,3 +18,6 @@ syn = { version = "3.0", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 heck = "0.5"
+
+[dev-dependencies]
+proc-macro2 = { version = "1", features = ["span-locations"] }

--- a/rapina-macros/src/schema/analyze.rs
+++ b/rapina-macros/src/schema/analyze.rs
@@ -122,17 +122,36 @@ fn analyze_entity(entity: EntityDef, registry: &EntityRegistry) -> Result<Analyz
             }
         }
 
-        // Validate PK columns are scalar types (not relationships)
+        // Validate PK columns are database columns. A (required) belongs_to field
+        // is allowed because it generates a non-null FK column using the target
+        // entity's PK type. A has_many field has no column, and an optional
+        // belongs_to would produce a nullable column, neither of which can be a
+        // primary key.
         for field in &analyzed_fields {
             let fname = field.name.to_string();
-            if pk_cols.contains(&fname) && !matches!(field.ty, FieldType::Scalar { .. }) {
-                return Err(syn::Error::new(
-                    field.name.span(),
-                    format!(
-                        "primary_key column '{}' must be a scalar type, not a relationship",
-                        fname
-                    ),
-                ));
+            if !pk_cols.contains(&fname) {
+                continue;
+            }
+            match &field.ty {
+                FieldType::HasMany { .. } => {
+                    return Err(syn::Error::new(
+                        field.name.span(),
+                        format!(
+                            "primary_key column '{}' cannot be a has_many relationship",
+                            fname
+                        ),
+                    ));
+                }
+                FieldType::BelongsTo { optional: true, .. } => {
+                    return Err(syn::Error::new(
+                        field.name.span(),
+                        format!(
+                            "primary_key column '{}' cannot be an optional relationship; a primary key cannot be nullable",
+                            fname
+                        ),
+                    ));
+                }
+                _ => {}
             }
         }
     }
@@ -437,24 +456,82 @@ mod tests {
     }
 
     #[test]
-    fn test_analyze_primary_key_must_be_scalar() {
+    fn test_analyze_primary_key_allows_belongs_to_fields() {
         let input = quote! {
-            User {
-                email: String,
+            #[table_name = "transactions"]
+            Tx {
+                name: String,
             }
 
-            #[primary_key(author)]
+            #[table_name = "labels"]
+            Label {
+                #[unique]
+                name: String,
+            }
+
+            #[table_name = "transaction_labels"]
             #[timestamps(none)]
+            #[primary_key(tx_id, label_id)]
+            TxLabel {
+                tx_id: Tx,
+                label_id: Label,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+
+        let tx_label = &analyzed.entities[2];
+        assert_eq!(
+            tx_label.attrs.primary_key,
+            Some(vec!["tx_id".to_string(), "label_id".to_string()])
+        );
+        assert!(matches!(tx_label.fields[0].ty, FieldType::BelongsTo { .. }));
+        assert!(matches!(tx_label.fields[1].ty, FieldType::BelongsTo { .. }));
+    }
+
+    #[test]
+    fn test_analyze_primary_key_rejects_has_many_fields() {
+        let input = quote! {
+            User {
+                posts: Vec<Post>,
+            }
+
             Post {
-                author: User,
                 title: String,
+            }
+
+            #[primary_key(posts)]
+            #[timestamps(none)]
+            UserPosts {
+                posts: Vec<Post>,
             }
         };
 
         let parsed = parse_schema(input).unwrap();
         let result = analyze_schema(parsed);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("scalar type"));
+        assert!(result.unwrap_err().to_string().contains("has_many"));
+    }
+
+    #[test]
+    fn test_analyze_primary_key_rejects_optional_belongs_to() {
+        let input = quote! {
+            User {
+                email: String,
+            }
+
+            #[primary_key(user_id)]
+            #[timestamps(none)]
+            Membership {
+                user_id: Option<User>,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let result = analyze_schema(parsed);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("optional"));
     }
 
     #[test]

--- a/rapina-macros/src/schema/analyze.rs
+++ b/rapina-macros/src/schema/analyze.rs
@@ -76,9 +76,111 @@ pub fn analyze_schema(schema: Schema) -> Result<AnalyzedSchema> {
         analyzed_entities.push(analyze_entity(entity, &registry)?);
     }
 
-    Ok(AnalyzedSchema {
+    let analyzed = AnalyzedSchema {
         entities: analyzed_entities,
-    })
+    };
+
+    validate_relationship_primary_keys(&analyzed)?;
+
+    Ok(analyzed)
+}
+
+fn validate_relationship_primary_keys(schema: &AnalyzedSchema) -> Result<()> {
+    for entity in &schema.entities {
+        let Some(pk_cols) = &entity.attrs.primary_key else {
+            continue;
+        };
+        if pk_cols.len() != 1 {
+            continue;
+        }
+
+        let Some(field) = entity.fields.iter().find(|field| field.name == pk_cols[0]) else {
+            continue;
+        };
+        let FieldType::BelongsTo { target, .. } = &field.ty else {
+            continue;
+        };
+
+        let mut visiting = HashSet::from([entity.name.to_string()]);
+        if primary_key_relationship_has_cycle(target, schema, &mut visiting) {
+            return Err(syn::Error::new(
+                field.name.span(),
+                format!(
+                    "schema relationship `{}.{}` forms a primary key cycle; primary-key belongs_to relationships must resolve to a scalar primary key column",
+                    entity.name, field.name
+                ),
+            ));
+        }
+    }
+
+    for entity in &schema.entities {
+        for field in &entity.fields {
+            let FieldType::BelongsTo { target, .. } = &field.ty else {
+                continue;
+            };
+
+            let Some(target_entity) = schema.entities.iter().find(|e| &e.name == target) else {
+                continue;
+            };
+            let Some(pk_cols) = &target_entity.attrs.primary_key else {
+                continue;
+            };
+
+            if pk_cols.len() > 1 {
+                let pk_list = pk_cols
+                    .iter()
+                    .map(|col| format!("`{}`", col))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                return Err(syn::Error::new(
+                    field.name.span(),
+                    format!(
+                        "schema relationship `{}.{}` targets `{}` with composite primary key ({}); belongs_to relationships currently require a target with a single primary key column",
+                        entity.name, field.name, target_entity.name, pk_list
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn primary_key_relationship_has_cycle(
+    target: &Ident,
+    schema: &AnalyzedSchema,
+    visiting: &mut HashSet<String>,
+) -> bool {
+    let target_name = target.to_string();
+    if !visiting.insert(target_name.clone()) {
+        return true;
+    }
+
+    let has_cycle = schema
+        .entities
+        .iter()
+        .find(|entity| entity.name == target_name)
+        .and_then(|entity| {
+            let pk_cols = entity.attrs.primary_key.as_ref()?;
+            if pk_cols.len() != 1 {
+                return None;
+            }
+
+            let pk_field = entity
+                .fields
+                .iter()
+                .find(|field| field.name == pk_cols[0])?;
+            let FieldType::BelongsTo { target, .. } = &pk_field.ty else {
+                return None;
+            };
+
+            Some(primary_key_relationship_has_cycle(target, schema, visiting))
+        })
+        .unwrap_or(false);
+
+    visiting.remove(&target_name);
+    has_cycle
 }
 
 fn analyze_entity(entity: EntityDef, registry: &EntityRegistry) -> Result<AnalyzedEntity> {
@@ -532,6 +634,52 @@ mod tests {
         let result = analyze_schema(parsed);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("optional"));
+    }
+
+    #[test]
+    fn test_analyze_primary_key_rejects_self_referential_cycle_at_field() {
+        let input = r#"
+            #[timestamps(none)]
+            #[primary_key(parent)]
+            Category {
+                parent: Category,
+            }
+        "#
+        .parse()
+        .unwrap();
+
+        let parsed = parse_schema(input).unwrap();
+        let error = analyze_schema(parsed).unwrap_err();
+
+        assert!(error.to_string().contains("Category.parent"));
+        assert!(error.to_string().contains("primary key cycle"));
+        assert_eq!(error.span().source_text().as_deref(), Some("parent"));
+    }
+
+    #[test]
+    fn test_analyze_composite_pk_target_error_points_at_field() {
+        let input = r#"
+            #[primary_key(left_id, right_id)]
+            #[timestamps(none)]
+            Pair {
+                left_id: i32,
+                right_id: i32,
+            }
+
+            PairRef {
+                pair: Pair,
+            }
+        "#
+        .parse()
+        .unwrap();
+
+        let parsed = parse_schema(input).unwrap();
+        let error = analyze_schema(parsed).unwrap_err();
+
+        assert!(error.to_string().contains("PairRef.pair"));
+        assert!(error.to_string().contains("left_id"));
+        assert!(error.to_string().contains("right_id"));
+        assert_eq!(error.span().source_text().as_deref(), Some("pair"));
     }
 
     #[test]

--- a/rapina-macros/src/schema/generate.rs
+++ b/rapina-macros/src/schema/generate.rs
@@ -9,10 +9,6 @@ use super::types::{FieldType, ScalarType};
 
 /// Generate the complete schema code from analyzed entities.
 pub fn generate_schema(schema: AnalyzedSchema) -> TokenStream {
-    if let Some(error) = composite_pk_target_error(&schema) {
-        return error;
-    }
-
     let entity_modules: Vec<TokenStream> = schema
         .entities
         .iter()
@@ -143,42 +139,6 @@ fn build_field_attr(parts: &[TokenStream], column_type: Option<TokenStream>) -> 
         (false, None) => quote! {#[sea_orm(#(#parts), *)]},
     }
 }
-
-fn composite_pk_target_error(schema: &AnalyzedSchema) -> Option<TokenStream> {
-    for entity in &schema.entities {
-        for field in &entity.fields {
-            let FieldType::BelongsTo { target, .. } = &field.ty else {
-                continue;
-            };
-
-            let Some(target_entity) = schema.entities.iter().find(|e| &e.name == target) else {
-                continue;
-            };
-            let Some(pk_cols) = &target_entity.attrs.primary_key else {
-                continue;
-            };
-
-            if pk_cols.len() > 1 {
-                let pk_list = pk_cols
-                    .iter()
-                    .map(|col| format!("`{}`", col))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let message = format!(
-                    "schema relationship `{}.{}` targets `{}` with composite primary key ({}); belongs_to relationships currently require a target with a single primary key column",
-                    entity.name, field.name, target_entity.name, pk_list
-                );
-
-                return Some(quote! {
-                    compile_error!(#message);
-                });
-            }
-        }
-    }
-
-    None
-}
-
 fn generate_custom_pk_fields(
     entity: &AnalyzedEntity,
     pk_cols: &[String],
@@ -214,22 +174,6 @@ fn generate_custom_pk_fields(
 }
 
 fn resolve_target_pk_type(target: &Ident, schema: &AnalyzedSchema) -> TokenStream {
-    resolve_target_pk_type_inner(target, schema, &mut Vec::new())
-}
-
-fn resolve_target_pk_type_inner(
-    target: &Ident,
-    schema: &AnalyzedSchema,
-    visiting: &mut Vec<String>,
-) -> TokenStream {
-    let target_name = target.to_string();
-    // Guard against self-referential or mutually-referential relationship PKs,
-    // which would otherwise recurse forever during macro expansion. Falling back
-    // to i32 keeps expansion terminating; such a cyclic PK has no scalar anchor.
-    if visiting.contains(&target_name) {
-        return quote! { i32 };
-    }
-
     let resolved = schema
         .entities
         .iter()
@@ -247,10 +191,7 @@ fn resolve_target_pk_type_inner(
                             target: inner_target,
                             ..
                         } => {
-                            visiting.push(target_name.clone());
-                            let ty = resolve_target_pk_type_inner(inner_target, schema, visiting);
-                            visiting.pop();
-                            return Some(ty);
+                            return Some(resolve_target_pk_type(inner_target, schema));
                         }
                         FieldType::HasMany { .. } => {}
                     }
@@ -856,35 +797,6 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_belongs_to_composite_pk_target_is_compile_error() {
-        let input = quote! {
-            #[primary_key(left_id, right_id)]
-            #[timestamps(none)]
-            Pair {
-                left_id: i32,
-                right_id: i32,
-            }
-
-            PairRef {
-                pair: Pair,
-            }
-        };
-
-        let parsed = parse_schema(input).unwrap();
-        let analyzed = analyze_schema(parsed).unwrap();
-        let generated = generate_schema(analyzed);
-        let output = generated.to_string();
-
-        assert!(output.contains("compile_error !"));
-        assert!(output.contains("PairRef.pair"));
-        assert!(output.contains("Pair"));
-        assert!(output.contains("left_id"));
-        assert!(output.contains("right_id"));
-        assert!(!output.contains("pub pair_id : i32"));
-        assert!(!output.contains("Column::Id"));
-    }
-
-    #[test]
     fn test_generate_belongs_to_pk_resolves_transitively() {
         // A relation to an entity whose own PK is a belongs_to must resolve the
         // FK scalar type transitively, not fall back to i32.
@@ -916,28 +828,6 @@ mod tests {
         // Task.project_id resolves transitively through Project's belongs_to PK.
         assert!(output.contains("pub project_id : rapina :: uuid :: Uuid"));
         assert!(!output.contains("pub project_id : i32"));
-    }
-
-    #[test]
-    fn test_generate_self_referential_belongs_to_pk_terminates() {
-        // A relationship PK that points back at its own entity has no scalar
-        // anchor; generation must terminate (falling back to i32) rather than
-        // recursing forever during macro expansion.
-        let input = quote! {
-            #[timestamps(none)]
-            #[primary_key(parent)]
-            Category {
-                parent: Category,
-            }
-        };
-
-        let parsed = parse_schema(input).unwrap();
-        let analyzed = analyze_schema(parsed).unwrap();
-        let generated = generate_schema(analyzed);
-        let output = generated.to_string();
-
-        assert!(output.contains("pub parent : i32"));
-        assert!(output.contains("auto_increment = false"));
     }
 
     #[test]

--- a/rapina-macros/src/schema/generate.rs
+++ b/rapina-macros/src/schema/generate.rs
@@ -1,7 +1,7 @@
 //! Code generation for SeaORM entity modules.
 
 use heck::ToSnakeCase;
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 
 use super::analyze::{AnalyzedEntity, AnalyzedField, AnalyzedSchema};
@@ -81,7 +81,7 @@ fn generate_entity_module(entity: &AnalyzedEntity, schema: &AnalyzedSchema) -> T
     // Generate primary key fields
     let pk_fields = if let Some(ref pk_cols) = entity.attrs.primary_key {
         // Custom primary key: mark specified fields with #[sea_orm(primary_key, auto_increment = false)]
-        generate_custom_pk_fields(entity, pk_cols)
+        generate_custom_pk_fields(entity, pk_cols, schema)
     } else {
         // Default: auto-increment id
         quote! {
@@ -140,20 +140,29 @@ fn build_field_attr(parts: &[TokenStream], column_type: Option<TokenStream>) -> 
     }
 }
 
-fn generate_custom_pk_fields(entity: &AnalyzedEntity, pk_cols: &[String]) -> TokenStream {
+fn generate_custom_pk_fields(
+    entity: &AnalyzedEntity,
+    pk_cols: &[String],
+    schema: &AnalyzedSchema,
+) -> TokenStream {
     let fields: Vec<TokenStream> = pk_cols
         .iter()
         .filter_map(|col_name| {
             let field = entity.fields.iter().find(|f| f.name == col_name)?;
-            let FieldType::Scalar { scalar, .. } = &field.ty else {
-                return None;
-            };
             let field_name = &field.name;
-            let rust_type = scalar.rust_type();
+            // A relationship PK resolves to the target's PK scalar, which carries
+            // no column_type attribute of its own.
+            let (rust_type, column_type) = match &field.ty {
+                FieldType::Scalar { scalar, .. } => (scalar.rust_type(), scalar.column_type_attr()),
+                FieldType::BelongsTo { target, .. } => {
+                    (resolve_target_pk_type(target, schema), None)
+                }
+                FieldType::HasMany { .. } => return None,
+            };
 
             let mut parts = vec![quote! {primary_key}, quote! {auto_increment = false}];
             parts.extend(sea_orm_parts(field));
-            let field_attr = build_field_attr(&parts, scalar.column_type_attr());
+            let field_attr = build_field_attr(&parts, column_type);
 
             Some(quote! {
                 #field_attr
@@ -163,6 +172,78 @@ fn generate_custom_pk_fields(entity: &AnalyzedEntity, pk_cols: &[String]) -> Tok
         .collect();
 
     quote! { #(#fields)* }
+}
+
+fn resolve_target_pk_type(target: &Ident, schema: &AnalyzedSchema) -> TokenStream {
+    resolve_target_pk_type_inner(target, schema, &mut Vec::new())
+}
+
+fn resolve_target_pk_type_inner(
+    target: &Ident,
+    schema: &AnalyzedSchema,
+    visiting: &mut Vec<String>,
+) -> TokenStream {
+    let target_name = target.to_string();
+    // Guard against self-referential or mutually-referential relationship PKs,
+    // which would otherwise recurse forever during macro expansion. Falling back
+    // to i32 keeps expansion terminating; such a cyclic PK has no scalar anchor.
+    if visiting.contains(&target_name) {
+        return quote! { i32 };
+    }
+
+    let resolved = schema
+        .entities
+        .iter()
+        .find(|e| &e.name == target)
+        .and_then(|e| {
+            if let Some(ref pk_cols) = e.attrs.primary_key {
+                if pk_cols.len() == 1 {
+                    let pk_field = e.fields.iter().find(|f| f.name == pk_cols[0])?;
+                    match &pk_field.ty {
+                        FieldType::Scalar { scalar, .. } => return Some(scalar.rust_type()),
+                        // The target's PK is itself a relationship (a join-table
+                        // style PK). Resolve transitively to the entity it points
+                        // at so the FK column adopts the underlying scalar type.
+                        FieldType::BelongsTo {
+                            target: inner_target,
+                            ..
+                        } => {
+                            visiting.push(target_name.clone());
+                            let ty = resolve_target_pk_type_inner(inner_target, schema, visiting);
+                            visiting.pop();
+                            return Some(ty);
+                        }
+                        FieldType::HasMany { .. } => {}
+                    }
+                }
+            } else {
+                // Default PK is i32
+                return Some(quote! { i32 });
+            }
+            None
+        });
+
+    // Fallback to i32 if target not found or complex PK.
+    resolved.unwrap_or_else(|| quote! { i32 })
+}
+
+/// PascalCase name of the target entity's single primary-key column, used for
+/// the `to = "...::Column::X"` side of a generated belongs_to relation.
+/// Defaults to `Id` for entities using the implicit auto-increment primary key.
+fn resolve_target_pk_column(target: &Ident, schema: &AnalyzedSchema) -> String {
+    schema
+        .entities
+        .iter()
+        .find(|e| &e.name == target)
+        .and_then(|e| {
+            let pk_cols = e.attrs.primary_key.as_ref()?;
+            if pk_cols.len() == 1 {
+                Some(to_pascal_case(&pk_cols[0]))
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "Id".to_string())
 }
 
 fn generate_model_fields(entity: &AnalyzedEntity, schema: &AnalyzedSchema) -> TokenStream {
@@ -204,28 +285,7 @@ fn generate_model_field(field: &AnalyzedField, schema: &AnalyzedSchema) -> Optio
             let fk_name = format_ident!("{}_id", field_name.to_string().to_snake_case());
 
             // Look up target entity's primary key type
-            let target_pk_type = schema
-                .entities
-                .iter()
-                .find(|e| &e.name == target)
-                .and_then(|e| {
-                    if let Some(ref pk_cols) = e.attrs.primary_key {
-                        if pk_cols.len() == 1 {
-                            let pk_field = e.fields.iter().find(|f| f.name == pk_cols[0])?;
-                            if let FieldType::Scalar { scalar, .. } = &pk_field.ty {
-                                return Some(scalar.rust_type());
-                            }
-                        }
-                    } else {
-                        // Default PK is i32
-                        return Some(quote! { i32 });
-                    }
-                    None
-                })
-                .unwrap_or_else(|| {
-                    // Fallback to i32 if target not found or complex PK
-                    quote! { i32 }
-                });
+            let target_pk_type = resolve_target_pk_type(target, schema);
 
             if *optional {
                 Some(quote! {
@@ -259,8 +319,8 @@ fn generate_relation_variants(entity: &AnalyzedEntity, schema: &AnalyzedSchema) 
 
 fn generate_relation_variant(
     field: &AnalyzedField,
-    _entity: &AnalyzedEntity,
-    _schema: &AnalyzedSchema,
+    entity: &AnalyzedEntity,
+    schema: &AnalyzedSchema,
 ) -> Option<TokenStream> {
     match &field.ty {
         FieldType::HasMany { target } => {
@@ -283,11 +343,23 @@ fn generate_relation_variant(
             let variant_ident = format_ident!("{}", variant_name);
             let target_mod_str = target.to_string().to_snake_case();
             let belongs_to_path = format!("super::{}::Entity", target_mod_str);
-            let fk_column_str = format!(
-                "Column::{}",
-                to_pascal_case(&format!("{}_id", field.name.to_string().to_snake_case()))
+            let field_name = field.name.to_string();
+            let is_pk_column = entity
+                .attrs
+                .primary_key
+                .as_ref()
+                .is_some_and(|pk_cols| pk_cols.iter().any(|pk| pk == &field_name));
+            let fk_column = if is_pk_column {
+                field_name
+            } else {
+                format!("{}_id", field.name.to_string().to_snake_case())
+            };
+            let fk_column_str = format!("Column::{}", to_pascal_case(&fk_column));
+            let to_column_str = format!(
+                "super::{}::Column::{}",
+                target_mod_str,
+                resolve_target_pk_column(target, schema)
             );
-            let to_column_str = format!("super::{}::Column::Id", target_mod_str);
 
             Some(quote! {
                 #[sea_orm(
@@ -661,6 +733,172 @@ mod tests {
         // Should NOT have timestamps
         assert!(!output.contains("created_at"));
         assert!(!output.contains("updated_at"));
+    }
+
+    #[test]
+    fn test_generate_composite_primary_key_with_belongs_to_fields() {
+        let input = quote! {
+            #[table_name = "transactions"]
+            Tx {
+                name: String,
+            }
+
+            #[table_name = "labels"]
+            Label {
+                #[unique]
+                name: String,
+            }
+
+            #[table_name = "transaction_labels"]
+            #[timestamps(none)]
+            #[primary_key(tx_id, label_id)]
+            TxLabel {
+                tx_id: Tx,
+                label_id: Label,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+        let tx_label_start = output.find("pub mod tx_label").unwrap();
+        let reexports_start = output.find("pub use tx :: Entity").unwrap();
+        let tx_label_module = &output[tx_label_start..reexports_start];
+
+        assert!(tx_label_module.contains("pub tx_id : i32"));
+        assert!(tx_label_module.contains("pub label_id : i32"));
+        assert!(tx_label_module.contains("auto_increment = false"));
+        assert!(!tx_label_module.contains("pub id : i32"));
+        assert!(!tx_label_module.contains("pub tx_id_id"));
+        assert!(!tx_label_module.contains("pub label_id_id"));
+        assert!(tx_label_module.contains("from = \"Column::TxId\""));
+        assert!(tx_label_module.contains("from = \"Column::LabelId\""));
+        assert!(!tx_label_module.contains("Column::TxIdId"));
+        assert!(!tx_label_module.contains("Column::LabelIdId"));
+        // Both targets use the default auto-increment `id` PK, so the relation
+        // points at Column::Id.
+        assert!(tx_label_module.contains("to = \"super::tx::Column::Id\""));
+        assert!(tx_label_module.contains("to = \"super::label::Column::Id\""));
+    }
+
+    #[test]
+    fn test_generate_belongs_to_pk_targets_non_id_pk_column() {
+        // The target's single PK column is not named `id`; the relation `to`
+        // side must reference that actual column, not a nonexistent Column::Id.
+        let input = quote! {
+            #[primary_key(uuid_pk)]
+            Label {
+                uuid_pk: Uuid,
+                name: String,
+            }
+
+            #[timestamps(none)]
+            #[primary_key(label_id)]
+            LabelRef {
+                label_id: Label,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+        let label_ref_start = output.find("pub mod label_ref").unwrap();
+        let reexports_start = output.find("pub use label :: Entity").unwrap();
+        let label_ref_module = &output[label_ref_start..reexports_start];
+
+        // FK column adopts the target PK scalar type and verbatim name.
+        assert!(label_ref_module.contains("pub label_id : rapina :: uuid :: Uuid"));
+        // Relation references the target's real PK column, not Column::Id.
+        assert!(label_ref_module.contains("from = \"Column::LabelId\""));
+        assert!(label_ref_module.contains("to = \"super::label::Column::UuidPk\""));
+        assert!(!label_ref_module.contains("super::label::Column::Id"));
+    }
+
+    #[test]
+    fn test_generate_belongs_to_pk_resolves_transitively() {
+        // A relation to an entity whose own PK is a belongs_to must resolve the
+        // FK scalar type transitively, not fall back to i32.
+        let input = quote! {
+            #[primary_key(id)]
+            Org {
+                id: Uuid,
+                name: String,
+            }
+
+            #[timestamps(none)]
+            #[primary_key(org_id)]
+            Project {
+                org_id: Org,
+            }
+
+            Task {
+                project: Project,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+
+        // Project.org_id resolves to Org's Uuid PK.
+        assert!(output.contains("pub org_id : rapina :: uuid :: Uuid"));
+        // Task.project_id resolves transitively through Project's belongs_to PK.
+        assert!(output.contains("pub project_id : rapina :: uuid :: Uuid"));
+        assert!(!output.contains("pub project_id : i32"));
+    }
+
+    #[test]
+    fn test_generate_self_referential_belongs_to_pk_terminates() {
+        // A relationship PK that points back at its own entity has no scalar
+        // anchor; generation must terminate (falling back to i32) rather than
+        // recursing forever during macro expansion.
+        let input = quote! {
+            #[timestamps(none)]
+            #[primary_key(parent)]
+            Category {
+                parent: Category,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+
+        assert!(output.contains("pub parent : i32"));
+        assert!(output.contains("auto_increment = false"));
+    }
+
+    #[test]
+    fn test_generate_belongs_to_primary_key_uses_target_uuid_type() {
+        let input = quote! {
+            #[primary_key(id)]
+            Tx {
+                id: Uuid,
+                name: String,
+            }
+
+            #[timestamps(none)]
+            #[primary_key(tx_id)]
+            TxLabel {
+                tx_id: Tx,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+        let tx_label_start = output.find("pub mod tx_label").unwrap();
+        let reexports_start = output.find("pub use tx :: Entity").unwrap();
+        let tx_label_module = &output[tx_label_start..reexports_start];
+
+        assert!(tx_label_module.contains("pub tx_id : rapina :: uuid :: Uuid"));
+        assert!(!tx_label_module.contains("pub tx_id_id"));
+        assert!(tx_label_module.contains("from = \"Column::TxId\""));
     }
 
     #[test]

--- a/rapina-macros/src/schema/generate.rs
+++ b/rapina-macros/src/schema/generate.rs
@@ -9,6 +9,10 @@ use super::types::{FieldType, ScalarType};
 
 /// Generate the complete schema code from analyzed entities.
 pub fn generate_schema(schema: AnalyzedSchema) -> TokenStream {
+    if let Some(error) = composite_pk_target_error(&schema) {
+        return error;
+    }
+
     let entity_modules: Vec<TokenStream> = schema
         .entities
         .iter()
@@ -138,6 +142,41 @@ fn build_field_attr(parts: &[TokenStream], column_type: Option<TokenStream>) -> 
         (false, Some(ct)) => quote! {#[sea_orm(#(#parts), *)] #ct },
         (false, None) => quote! {#[sea_orm(#(#parts), *)]},
     }
+}
+
+fn composite_pk_target_error(schema: &AnalyzedSchema) -> Option<TokenStream> {
+    for entity in &schema.entities {
+        for field in &entity.fields {
+            let FieldType::BelongsTo { target, .. } = &field.ty else {
+                continue;
+            };
+
+            let Some(target_entity) = schema.entities.iter().find(|e| &e.name == target) else {
+                continue;
+            };
+            let Some(pk_cols) = &target_entity.attrs.primary_key else {
+                continue;
+            };
+
+            if pk_cols.len() > 1 {
+                let pk_list = pk_cols
+                    .iter()
+                    .map(|col| format!("`{}`", col))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let message = format!(
+                    "schema relationship `{}.{}` targets `{}` with composite primary key ({}); belongs_to relationships currently require a target with a single primary key column",
+                    entity.name, field.name, target_entity.name, pk_list
+                );
+
+                return Some(quote! {
+                    compile_error!(#message);
+                });
+            }
+        }
+    }
+
+    None
 }
 
 fn generate_custom_pk_fields(
@@ -814,6 +853,35 @@ mod tests {
         assert!(label_ref_module.contains("from = \"Column::LabelId\""));
         assert!(label_ref_module.contains("to = \"super::label::Column::UuidPk\""));
         assert!(!label_ref_module.contains("super::label::Column::Id"));
+    }
+
+    #[test]
+    fn test_generate_belongs_to_composite_pk_target_is_compile_error() {
+        let input = quote! {
+            #[primary_key(left_id, right_id)]
+            #[timestamps(none)]
+            Pair {
+                left_id: i32,
+                right_id: i32,
+            }
+
+            PairRef {
+                pair: Pair,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let generated = generate_schema(analyzed);
+        let output = generated.to_string();
+
+        assert!(output.contains("compile_error !"));
+        assert!(output.contains("PairRef.pair"));
+        assert!(output.contains("Pair"));
+        assert!(output.contains("left_id"));
+        assert!(output.contains("right_id"));
+        assert!(!output.contains("pub pair_id : i32"));
+        assert!(!output.contains("Column::Id"));
     }
 
     #[test]

--- a/rapina/tests/schema_test.rs
+++ b/rapina/tests/schema_test.rs
@@ -50,6 +50,31 @@ schema! {
 
 }
 
+// Join table whose composite primary key is made of entity-typed fields (#619).
+// Each PK column is a belongs_to relationship; the generated FK columns must
+// keep their verbatim names (tx_id / label_id, no extra _id suffix) and adopt
+// the target entities' primary-key scalar types.
+schema! {
+    #[table_name = "transactions"]
+    Tx {
+        name: String,
+    }
+
+    #[table_name = "labels"]
+    Label {
+        #[unique]
+        name: String,
+    }
+
+    #[table_name = "transaction_labels"]
+    #[timestamps(none)]
+    #[primary_key(tx_id, label_id)]
+    TxLabel {
+        tx_id: Tx,
+        label_id: Label,
+    }
+}
+
 #[test]
 fn test_user_model_compiles() {
     use test_user::Model;
@@ -146,4 +171,26 @@ fn test_composite_pk_respects_column_rename() {
     assert_eq!(test_tx_label::Column::TxId.as_str(), "transaction_id");
     assert_eq!(test_tx_label::Column::LabelId.as_str(), "label_id");
     assert_eq!(test_region::Column::Code.as_str(), "region_code");
+}
+
+#[test]
+fn test_join_table_entity_typed_primary_key_compiles() {
+    use tx_label::Model;
+
+    // The composite PK columns are the verbatim field names (no _id suffix)
+    // and resolve to the target entities' i32 primary keys. A join table has
+    // no auto-generated `id` column.
+    let link = Model {
+        tx_id: 1,
+        label_id: 2,
+    };
+
+    assert_eq!(link.tx_id, 1);
+    assert_eq!(link.label_id, 2);
+
+    // Relations to both parent entities are generated (named after the fields).
+    let _ = tx_label::Relation::TxId;
+    let _ = tx_label::Relation::LabelId;
+
+    let _ = tx_label::Entity::table_name(&tx_label::Entity);
 }


### PR DESCRIPTION
## Summary

Allows entity-typed fields to be used as primary-key columns in `#[primary_key(...)]`, making the documented many-to-many join-table pattern compile. Previously the `schema!` macro rejected them at compile time with `primary_key column '...' must be a scalar type, not a relationship`, so the documented pattern was impossible to use.

The exact reproduction from the issue now compiles:

```rust
schema! {
    #[table_name = "transactions"]
    Tx { name: String }

    #[table_name = "labels"]
    Label { #[unique] name: String }

    #[table_name = "transaction_labels"]
    #[timestamps(none)]
    #[primary_key(tx_id, label_id)]
    TxLabel {
        tx_id: Tx,
        label_id: Label,
    }
}
```

What changed:

- `analyze.rs`: A required `belongs_to` field is now accepted as a custom primary-key column. The scalar-only check is relaxed but still rejects `has_many` (no column) and optional `belongs_to` (a primary key cannot be nullable), each with a clear compile-time message. Unknown-type and column-not-found errors are unchanged.
- `generate.rs`:
  - `generate_custom_pk_fields` emits a relationship PK column using the field name verbatim (e.g. `tx_id`, no extra `_id` suffix) and the scalar type inferred from the target entity's primary key.
  - The shared target-PK-type resolution is extracted into `resolve_target_pk_type` (reused by the existing belongs_to model-field path) and now resolves transitively when a target's PK is itself a relationship, with a cycle guard so self/mutually-referential relationship PKs terminate instead of recursing forever.
  - The generated relation `from` column for a relationship PK uses the verbatim PascalCase field name (`Column::TxId`, not `Column::TxIdId`), and the `to` column resolves to the target's actual single PK column instead of a hardcoded `Column::Id`.
- `rapina/tests/schema_test.rs`: Adds an end-to-end compile test for the issue's `TxLabel` join table, verifying the generated `Model` has verbatim PK columns, no auto `id`, and working `Relation` variants.

## Related Issues

Closes #619

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass (`cargo test -p rapina-macros`: 128 passed; `cargo test -p rapina --features database --test schema_test`: 6 passed)
- [ ] Documentation updated (if needed)
