### PR TITLE
Ignore proc-macro-error2 advisory in cargo-audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173
 
   deny:
     name: Cargo Deny


### PR DESCRIPTION
Cargo Audit job uses `cargo-audit`, which keeps its own ignore list inline in the workflow rather than reading `deny.toml`. #621 pinned `RUSTSEC-2026-0173` for `cargo-deny` but not here, so the unmaintained `proc-macro-error2` advisory still fails Security Audit on push to main. Adds the same advisory to the audit-check ignore list to bring both gates in sync.