### PR TITLE
Ignore proc-macro-error2 advisory in ci cargo-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173
 
   deny:
     name: Cargo Deny


### PR DESCRIPTION
Security Audit job in ci.yml runs cargo-audit with its own inline ignore list, separate from both deny.toml and the audit.yml workflow. #623 synced audit.yml but not this one, so the unmaintained proc-macro-error2 advisory still failed on push to main. Adds `RUSTSEC-2026-0173` here too so all three advisory gates match.