### PR TITLE
docs: update landing auth example

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -84,13 +84,13 @@ async fn get_user(
         <div class="showcase-container">
             <div class="showcase-text">
                 <h2 class="gradient-text-subtle">Just Add #[public]</h2>
-                <p>Every route is authenticated. Write your handler, access the user's claims directly from the function signature. Need a public endpoint? One attribute. No middleware chains, no guard configs, no forgetting to protect a route.</p>
+                <p>Every route is authenticated. Write your handler, access the current user directly from the function signature. Need a public endpoint? One attribute. No middleware chains, no guard configs, no forgetting to protect a route.</p>
             </div>
             <div class="showcase-code code-showcase">
                 <pre><code class="language-rust">#[get("/me")]
-async fn me(claims: Claims) -&gt; Result&lt;Json&lt;User&gt;&gt; {
-    // claims.sub is the authenticated user
-    Ok(Json(find_user(claims.sub).await?))
+async fn me(user: CurrentUser) -&gt; Result&lt;Json&lt;User&gt;&gt; {
+    // user.id is the authenticated user's id
+    Ok(Json(find_user(user.id).await?))
 }
 
 #[public]

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -84,12 +84,13 @@ async fn get_user(
         <div class="showcase-container">
             <div class="showcase-text">
                 <h2 class="gradient-text-subtle">Just Add #[public]</h2>
-                <p>Every route is authenticated. Write your handler, access the current user directly from the function signature. Need a public endpoint? One attribute. No middleware chains, no guard configs, no forgetting to protect a route.</p>
+                <p>Every route is authenticated. Write your handler, access the current user's data directly from the function signature. Need a public endpoint? One attribute. No middleware chains, no guard configs, no forgetting to protect a route.</p>
             </div>
             <div class="showcase-code code-showcase">
                 <pre><code class="language-rust">#[get("/me")]
 async fn me(user: CurrentUser) -&gt; Result&lt;Json&lt;User&gt;&gt; {
-    // user.id is the authenticated user's id
+    // Uses the authenticated user's id to query the database
+    // and returns a JSON response containing the queried info
     Ok(Json(find_user(user.id).await?))
 }
 


### PR DESCRIPTION
Closes #640.

## Summary
- Update the landing page "Just Add #[public]" example to use the current `CurrentUser` extractor instead of the outdated `Claims` handler parameter.
- Adjust the surrounding copy and comment to match the current extractor docs.

## Validation
- `rg` verified `Claims` / `claims.sub` no longer appear in `docs/templates/index.html`
- `git diff --check` passed

Note: I did not run the Zola docs build locally because `zola` is not installed in this environment.
