### PR TITLE
docs: add Header extractor examples

### DIFF
--- a/docs/content/docs/core-concepts/extractors.md
+++ b/docs/content/docs/core-concepts/extractors.md
@@ -16,6 +16,7 @@ Extractors automatically parse request data and inject it into your handlers. If
 | [`Json<T>`](#json-body)          | JSON request body                      |
 | [`Form<T>`](#form-data)          | URL-encoded form data                  |
 | [`Headers`](#headers)            | Request headers                        |
+| [`Header<T>`](#typed-headers)    | A single typed request header          |
 | [`State<T>`](#application-state) | Application state                      |
 | [`Context`](#request-context)    | Request context (trace_id)             |
 | [`Cookie<T>`](#cookies)          | Typed cookie access                    |
@@ -152,6 +153,45 @@ async fn debug(headers: Headers) -> String {
         .unwrap_or("unknown");
 
     format!("User-Agent: {}", user_agent)
+}
+```
+
+Use `Headers` when you need to inspect several headers dynamically or iterate
+over the full header map.
+
+## Typed Headers
+
+Use `Header<T>` when you know the header name upfront and only need one value.
+Rapina extracts the header and parses it into `T`.
+
+By default, the parameter name is converted from snake_case to kebab-case, so
+`x_request_id` reads the `x-request-id` header:
+
+```rust
+#[get("/trace")]
+async fn trace(x_request_id: Header<String>) -> String {
+    format!("Request ID: {}", *x_request_id)
+}
+```
+
+Use `#[header("name")]` when the Rust parameter name should differ from the
+HTTP header name:
+
+```rust
+#[get("/agent")]
+async fn agent(#[header("user-agent")] user_agent: Header<String>) -> String {
+    format!("User-Agent: {}", *user_agent)
+}
+```
+
+Optional headers use `Option<Header<T>>`:
+
+```rust
+#[get("/forwarded-for")]
+async fn forwarded_for(x_forwarded_for: Option<Header<String>>) -> String {
+    x_forwarded_for
+        .map(|header| header.into_inner())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 ```
 

--- a/rapina/src/extract/header.rs
+++ b/rapina/src/extract/header.rs
@@ -5,14 +5,28 @@
 //! Rust identifier (snake_case → kebab-case) or can be overridden with the
 //! `#[header("explicit-name")]` attribute on the handler parameter.
 //!
+//! Prefer `Header<T>` over [`Headers`](crate::extract::Headers) when you know
+//! the header name upfront and only need one typed value.
+//!
 //! # Examples
 //!
 //! ```ignore
 //! use rapina::prelude::*;
 //!
-//! #[get("/hello")]
+//! #[get("/trace")]
 //! async fn handler(x_request_id: Header<String>) -> String {
-//!     format!("trace: {}", *x_request_id)
+//!     format!("Request ID: {}", *x_request_id)
+//! }
+//! ```
+//!
+//! Override the inferred header name with `#[header("name")]`:
+//!
+//! ```ignore
+//! use rapina::prelude::*;
+//!
+//! #[get("/agent")]
+//! async fn handler(#[header("user-agent")] user_agent: Header<String>) -> String {
+//!     format!("User-Agent: {}", *user_agent)
 //! }
 //! ```
 //!


### PR DESCRIPTION
## Summary

Adds `Header<T>` to the extractors documentation and expands the `Header<T>` rustdoc examples.

## Reproduction

Before this change, the extractors documentation described `Headers` for reading the full request header map, but did not list or explain the `Header<T>` extractor for reading one known header. The `Header<T>` rustdoc also showed a basic inferred-name example, but did not show an explicit `#[header("name")]` override.

## Root cause

`Header<T>` was added after the main extractors documentation was written, and the guidance that `Header<T>` is preferred for a single known header only existed near the `Headers` implementation.

## Changes

- Add `Header<T>` to the extractors table.
- Add a typed headers section with inferred header names, explicit `#[header("name")]`, and optional header examples.
- Update `Header<T>` rustdoc to explain when to prefer it over `Headers` and include an explicit header-name example.

## Tests

- `cargo fmt --check`
- `cargo test -p rapina header`

## Screenshots/Logs

Documentation-only change. No UI screenshots. The commands above passed locally.

Closes #645