### PR TITLE
docs: backfill changelog for v0.10 to v0.12

### DIFF
--- a/docs/templates/changelog.html
+++ b/docs/templates/changelog.html
@@ -25,6 +25,7 @@
             <li><code>Header&lt;T&gt;</code> typed extractor</li>
             <li>Custom Prometheus collectors</li>
             <li>Opt-in auto migrations</li>
+            <li><code>DatabaseConfig::new</code> and <code>from_env</code> default <code>auto_migrate</code> to <code>false</code></li>
             <li>Bundled AI docs and <code>AGENTS.md</code></li>
             <li>Unified type system improvements</li>
             <li>Cache invalidation improvements</li>
@@ -42,6 +43,9 @@
         <ul>
             <li>Tower compatibility layer</li>
             <li>NextService Clone support for Tower middleware</li>
+            <li>Compression gated behind feature flag</li>
+            <li><code>--force</code> flag for import database</li>
+            <li>Macro preserves <code>mut</code> on handler arguments</li>
         </ul>
     </div>
 </div>

--- a/docs/templates/changelog.html
+++ b/docs/templates/changelog.html
@@ -11,6 +11,62 @@
 
     <div class="changelog-timeline">
 
+            <div class="timeline-item">
+    <div class="timeline-marker"></div>
+    <div class="timeline-content">
+        <div class="timeline-date">May 15, 2026</div>
+        <h2>v0.12.0</h2>
+        <span class="timeline-tag tag-feature">Feature</span>
+        <span class="timeline-tag tag-fix">Fix</span>
+        <ul>
+            <li>Cursor-based pagination: <code>CursorPaginate&lt;V&gt;</code> extractor and <code>CursorPaginated&lt;T&gt;</code> response for stable feeds and infinite scroll</li>
+            <li>Streaming and Server-Sent Events (SSE) responses</li>
+            <li><code>llms.txt</code> endpoint and CLI export</li>
+            <li><code>Header&lt;T&gt;</code> typed extractor</li>
+            <li>Custom Prometheus collectors</li>
+            <li>Opt-in auto migrations</li>
+            <li>Bundled AI docs and <code>AGENTS.md</code></li>
+            <li>Unified type system improvements</li>
+            <li>Cache invalidation improvements</li>
+            <li>Fixed <code>schema!</code> unsigned integer type validation</li>
+        </ul>
+    </div>
+</div>
+
+<div class="timeline-item">
+    <div class="timeline-marker"></div>
+    <div class="timeline-content">
+        <div class="timeline-date">April 1, 2026</div>
+        <h2>v0.11.0</h2>
+        <span class="timeline-tag tag-feature">Feature</span>
+        <ul>
+            <li>Tower compatibility layer</li>
+            <li>NextService Clone support for Tower middleware</li>
+        </ul>
+    </div>
+</div>
+
+<div class="timeline-item">
+    <div class="timeline-marker"></div>
+    <div class="timeline-content">
+        <div class="timeline-date">March 16, 2026</div>
+        <h2>v0.10.0</h2>
+        <span class="timeline-tag tag-feature">Feature</span>
+        <ul>
+            <li>Serde-based Path extraction</li>
+            <li>Database seeding commands</li>
+            <li>Snapshot testing support</li>
+            <li>RFC 7807 Problem Details</li>
+            <li>Three-layer router architecture</li>
+            <li>Router benchmarks</li>
+            <li>Configurable request logging</li>
+            <li>UUID primary key support</li>
+            <li>URL shortener example</li>
+            <li>State wrapped in <code>Arc&lt;T&gt;</code></li>
+        </ul>
+    </div>
+</div>
+
         <div class="timeline-item">
             <div class="timeline-marker"></div>
             <div class="timeline-content">


### PR DESCRIPTION
## Summary

This PR backfills the changelog entries for versions v0.10, v0.11, and v0.12.

### Changes made

* Added missing changelog entries for v0.10
* Added missing changelog entries for v0.11
* Added missing changelog entries for v0.12
* Followed the existing changelog format and structure used in the repository
* Updated documentation only; no code changes were made

## Related Issue

Closes #650
