### PR TITLE
docs: add pagination example

### DIFF
--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -143,6 +143,10 @@ required-features = ["multipart"]
 name = "telemetry"
 required-features = ["otel"]
 
+[[example]]
+name = "pagination"
+required-features = ["database"]
+
 [features]
 default = ["compression", "rate-limit"]
 rate-limit = []

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -32,6 +32,21 @@ fn articles() -> Vec<Article> {
             title: "How to make your own framework in Rust".to_string(),
             author: "JoJo".to_string(),
         },
+        Article {
+            id: 4,
+            title: "Why compilation errors are actually a love language".to_string(),
+            author: "Star Platinum".to_string(),
+        },
+        Article {
+            id: 5,
+            title: "Overcoming the urge to rewrite everything in Zig".to_string(),
+            author: "Gold Experience".to_string(),
+        },
+        Article {
+            id: 6,
+            title: "How I accidentally deleted production using a smart pointer".to_string(),
+            author: "The Hand".to_string(),
+        },
     ]
 }
 

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -1,0 +1,80 @@
+//! Pagination example.
+//!
+//! Run with `cargo run --example pagination`
+//!
+//! Endpoints:
+//! - GET /articles?page=1&per_page=2  — List articles with pagination
+
+use rapina::pagination::{Paginate, Paginated, PaginationConfig};
+use rapina::prelude::*;
+
+#[derive(Clone, Serialize, JsonSchema)]
+struct Article {
+    id: u64,
+    title: String,
+    author: String,
+}
+
+fn articles() -> Vec<Article> {
+    vec![
+        Article {
+            id: 1,
+            title: "Pagination example for Rapina".to_string(),
+            author: "Crazy Diamond".to_string(),
+        },
+        Article {
+            id: 2,
+            title: "The AI tragedy of 2026".to_string(),
+            author: "Killer Queen".to_string(),
+        },
+        Article {
+            id: 3,
+            title: "How to make your own framework in Rust".to_string(),
+            author: "JoJo".to_string(),
+        },
+    ]
+}
+
+#[get("/articles")]
+async fn list_articles(page: Paginate) -> Result<Json<Paginated<Article>>> {
+    let all_articles = articles();
+    let total = all_articles.len() as u64;
+
+    let total_pages = total.div_ceil(page.per_page);
+    let start = ((page.page - 1) * page.per_page) as usize;
+
+    let data = all_articles
+        .into_iter()
+        .skip(start)
+        .take(page.per_page as usize)
+        .collect();
+
+    Ok(Json(Paginated {
+        data,
+        page: page.page,
+        per_page: page.per_page,
+        total,
+        total_pages,
+        has_prev: page.page > 1,
+        has_next: page.page < total_pages,
+    }))
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let addr = "127.0.0.1:3000";
+
+    println!("Rapina Pagination Example");
+    println!("  Usage:");
+    println!("    GET /articles");
+    println!("    GET /articles?page=2&per_page=1");
+
+    Rapina::new()
+        .state(PaginationConfig {
+            default_per_page: 5,
+            max_per_page: 20,
+        })
+        .discover()
+        .listen(addr)
+        .await
+}

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -12,7 +12,7 @@
 use rapina::pagination::{Paginate, Paginated, PaginationConfig};
 use rapina::prelude::*;
 
-#[derive(Clone, Serialize, JsonSchema)]
+#[derive(Serialize, JsonSchema)]
 struct Article {
     id: u64,
     title: String,
@@ -87,7 +87,7 @@ async fn list_articles(page: Paginate) -> Result<Paginated<Article>> {
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let addr = "127.0.0.1:9999";
+    let addr = "127.0.0.1:3000";
 
     println!("Rapina Pagination Example");
     println!("  Try:");

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -39,7 +39,7 @@ fn articles() -> Vec<Article> {
         },
         Article {
             id: 5,
-            title: "Overcoming the urge to rewrite everything in Zig".to_string(),
+            title: "Overcoming the urge to rewrite everything in Rust.".to_string(),
             author: "Gold Experience".to_string(),
         },
         Article {

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -1,6 +1,6 @@
 //! Pagination example.
 //!
-//! Run with `cargo run --example pagination`
+//! Run with `cargo run --example pagination --features database`
 //!
 //! Endpoints:
 //! - GET /articles?page=1&per_page=2  — List articles with pagination
@@ -51,7 +51,7 @@ fn articles() -> Vec<Article> {
 }
 
 #[get("/articles")]
-async fn list_articles(page: Paginate) -> Result<Json<Paginated<Article>>> {
+async fn list_articles(page: Paginate) -> Result<Paginated<Article>> {
     let all_articles = articles();
     let total = all_articles.len() as u64;
 
@@ -64,7 +64,7 @@ async fn list_articles(page: Paginate) -> Result<Json<Paginated<Article>>> {
         .take(page.per_page as usize)
         .collect();
 
-    Ok(Json(Paginated {
+    Ok(Paginated {
         data,
         page: page.page,
         per_page: page.per_page,
@@ -72,17 +72,19 @@ async fn list_articles(page: Paginate) -> Result<Json<Paginated<Article>>> {
         total_pages,
         has_prev: page.page > 1,
         has_next: page.page < total_pages,
-    }))
+    })
 }
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let addr = "127.0.0.1:3000";
+    let addr = "127.0.0.1:9999";
 
     println!("Rapina Pagination Example");
-    println!("  Usage:");
-    println!("    GET /articles");
-    println!("    GET /articles?page=2&per_page=1");
+    println!("  Try:");
+    println!("    GET /articles              # default page size (5)");
+    println!("    GET /articles?page=2       # page 2 → the 6th article");
+    println!("    GET /articles?per_page=2   # explicit override");
+    println!("    GET /articles?per_page=21  # 422: exceeds max (20)");
 
     Rapina::new()
         .state(PaginationConfig {

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -2,8 +2,12 @@
 //!
 //! Run with `cargo run --example pagination --features database`
 //!
-//! Endpoints:
-//! - GET /articles?page=1&per_page=2  — List articles with pagination
+//!
+//! One endpoint, driven entirely by query params. Try:
+//!   GET /articles              → default page size (5, from PaginationConfig)
+//!   GET /articles?page=2       → page 2, still size 5 → returns the 6th article on the 2nd page
+//!   GET /articles?per_page=2   → explicit override, 2 per page
+//!   GET /articles?per_page=21  → 422: exceeds max_per_page (20)
 
 use rapina::pagination::{Paginate, Paginated, PaginationConfig};
 use rapina::prelude::*;

--- a/rapina/examples/pagination.rs
+++ b/rapina/examples/pagination.rs
@@ -54,6 +54,12 @@ fn articles() -> Vec<Article> {
     ]
 }
 
+// With a database, the entire handler would just look like this:
+//   async fn list_articles(db: Db, page: Paginate) -> Result<Paginated<Article>> {
+//       page.exec(Article::find(), db.conn()).await
+//   }
+//
+// To keep this example database-free, we are paginating an in-memory Vec manually.
 #[get("/articles")]
 async fn list_articles(page: Paginate) -> Result<Paginated<Article>> {
     let all_articles = articles();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-02-15"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2026-02-15"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
Add a standalone, database-free example for Pagination.

Edit: Accidentally deleted rust-toolchain.toml (since it's kinda messing my environment somehow) and pushed it... my bad, it's the 1AM effect. I have reverted it back :sweat_smile: 

### Changes
* Added a database-free example in `examples/pagination.rs`.
* Used the framework's `#[get]` macro and `.discover()`.

## Related Issues

Closes #643

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy` has no warnings
- [x] Tests pass
- [x] Documentation updated (if needed)
