### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ Routine dependency-only updates are intentionally omitted unless they change use
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-25
+
 ### Added
 - **Database import relationships**: `rapina import database` now turns single-column foreign keys into `BelongsTo` and `HasMany` relationship fields in generated `schema!` blocks when both sides of the relationship are imported (#548).
 - **Handler descriptions in discovery output**: Route macros can now carry explicit descriptions, with rustdoc fallback, into `llms.txt` and OpenAPI output (#596).
 - **OpenTelemetry OTLP tracing exporter**: `with_telemetry(TelemetryConfig { endpoint, service_name, sample_rate })` exports traces over OTLP gRPC to a collector such as Jaeger or Datadog, behind the `otel` feature. Incoming W3C `traceparent` headers are honored so traces continue across service boundaries, request spans follow the HTTP semantic conventions and carry the response status, the OTel `trace_id`/`span_id` are recorded on the request span so logs correlate with the exported trace, and pending spans are flushed on graceful shutdown. Plaintext gRPC by default; enable `otel-tls` for `https://` collectors (#607).
 - **Redis TLS certificates**: `CacheConfig::redis_with_tls` and `RedisTlsConfig` support CA certificates plus client certificates and keys for `rediss://` Redis cache connections (#617).
 - **`rapina doctor` `llms.txt` check**: `rapina doctor` now checks whether `/__rapina/llms.txt` is reachable and warns when it is disabled or unreachable (#618).
+- **Multi-database background jobs**: Background job persistence now supports MySQL and SQLite alongside PostgreSQL, with backend-specific SQL (insert, claim, retry, success/fail) dispatched by `DbBackend` and UUIDs parsed from text on SQLite (#631).
+- **`rapina import database --diff`**: Compares the `schema!` blocks in `src/entity.rs` against the live database and reports drift, columns on only one side, type and nullability mismatches, missing tables, and primary-key differences. Exits 0 when in sync, 2 on drift, and 1 on error for CI use; `--tables` scopes the comparison, round-trip-safe differences (`String` vs `text`, `bool` vs MySQL `tinyint`) are reported as notes, and combining it with `--force` is rejected since `--diff` writes nothing (#632).
 
 ### Changed
 - **Native CLI HTTP client**: `rapina doctor`, `rapina routes`, `rapina openapi`, and `rapina llms` use an internal `ureq` client instead of shelling out to `curl` (#586).
@@ -142,7 +146,8 @@ Routine dependency-only updates are intentionally omitted unless they change use
 - Standardized error handling with `trace_id`
 - CLI (`rapina new`, `rapina dev`)
 
-[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/rapina-rs/rapina/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/rapina-rs/rapina/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/rapina-rs/rapina/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/rapina-rs/rapina/compare/v0.9.0...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "rapina"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-macros"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/docs/content/docs/core-concepts/background-jobs.md
+++ b/docs/content/docs/core-concepts/background-jobs.md
@@ -30,7 +30,7 @@ You need the `database` feature with PostgreSQL. The jobs migration uses Postgre
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["postgres"] }
+rapina = { version = "0.13.0", features = ["postgres"] }
 ```
 
 You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page.

--- a/docs/content/docs/core-concepts/caching.md
+++ b/docs/content/docs/core-concepts/caching.md
@@ -111,7 +111,7 @@ For multi-instance deployments where all instances need to share the same cache 
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["cache-redis"] }
+rapina = { version = "0.13.0", features = ["cache-redis"] }
 ```
 
 ```rust

--- a/docs/content/docs/core-concepts/cron-scheduler.md
+++ b/docs/content/docs/core-concepts/cron-scheduler.md
@@ -28,7 +28,7 @@ Enable the `cron-scheduler` feature flag:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["cron-scheduler"] }
+rapina = { version = "0.13.0", features = ["cron-scheduler"] }
 ```
 
 No database or external service is required. The scheduler runs entirely in-process.

--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -13,7 +13,7 @@ Add the database feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["postgres"] }
+rapina = { version = "0.13.0", features = ["postgres"] }
 # or "mysql", "sqlite"
 ```
 

--- a/docs/content/docs/core-concepts/jwks.md
+++ b/docs/content/docs/core-concepts/jwks.md
@@ -52,7 +52,7 @@ Add the `jwks` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["jwks"] }
+rapina = { version = "0.13.0", features = ["jwks"] }
 ```
 
 This pulls in Rapina's `cron-scheduler` for automatic periodic cache refresh and `hyper-rustls` for HTTPS fetching of the JWKS endpoint using your system's native root CA certificates.

--- a/docs/content/docs/core-concepts/metrics.md
+++ b/docs/content/docs/core-concepts/metrics.md
@@ -13,7 +13,7 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["metrics"] }
+rapina = { version = "0.13.0", features = ["metrics"] }
 ```
 
 Enable the endpoint in your application:

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -401,7 +401,7 @@ impl Middleware for SecurityHeadersMiddleware {
 Rapina can interop with the [Tower](https://docs.rs/tower) ecosystem via the `tower` feature flag. This lets you use battle-tested Tower layers (retry, circuit breakers, concurrency limits, etc.) as Rapina middleware.
 
 ```toml
-rapina = { version = "0.12.0", features = ["tower"] }
+rapina = { version = "0.13.0", features = ["tower"] }
 ```
 
 ### Using Tower layers as middleware

--- a/docs/content/docs/core-concepts/migrations.md
+++ b/docs/content/docs/core-concepts/migrations.md
@@ -15,7 +15,7 @@ Your `Cargo.toml` needs the `database` feature and a database driver:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["sqlite"] }
+rapina = { version = "0.13.0", features = ["sqlite"] }
 ```
 
 Replace `sqlite` with `postgres` or `mysql` depending on your database. You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page if you haven't set that up yet.

--- a/docs/content/docs/core-concepts/observability.md
+++ b/docs/content/docs/core-concepts/observability.md
@@ -52,7 +52,7 @@ Enable the `otel` feature flag:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["otel"] }
+rapina = { version = "0.13.0", features = ["otel"] }
 ```
 
 Then configure the exporter with `with_telemetry`:

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -115,7 +115,7 @@ If you prefer not to use the CLI, add Rapina to an existing project:
 
 ```toml
 [dependencies]
-rapina = "0.12.0"
+rapina = "0.13.0"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```

--- a/docs/content/docs/guides/deployment.md
+++ b/docs/content/docs/guides/deployment.md
@@ -21,7 +21,7 @@ If your app uses a database, make sure the correct feature flag is enabled in yo
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["postgres"] }
+rapina = { version = "0.13.0", features = ["postgres"] }
 ```
 
 Available database features: `postgres`, `mysql`, `sqlite`.
@@ -343,7 +343,7 @@ Enable Prometheus metrics for monitoring:
 
 ```toml
 [dependencies]
-rapina = { version = "0.12.0", features = ["metrics"] }
+rapina = { version = "0.13.0", features = ["metrics"] }
 ```
 
 ```rust

--- a/justfile
+++ b/justfile
@@ -48,10 +48,14 @@ release VERSION:
     # Regenerate Cargo.lock
     cargo check --workspace
 
+    # Refresh snapshots that embed the crate version (e.g. llms.txt footer)
+    INSTA_UPDATE=always cargo test --locked -p rapina --lib introspection::llms
+
     # Create branch, commit, push, open PR
     git checkout -b release_{{VERSION}}
     git add rapina/Cargo.toml rapina-macros/Cargo.toml rapina-cli/Cargo.toml Cargo.lock CHANGELOG.md
     git add docs/ rapina/examples/
+    git add rapina/src/introspection/snapshots/
     git commit -m "Bump version to {{VERSION}}"
     git push origin release_{{VERSION}}
     gh pr create \

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI tool for Rapina web framework - create and run Rapina projects"

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-macros"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Procedural macros for the Rapina web framework"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A fast, type-safe web framework for Rust inspired by FastAPI"
@@ -73,7 +73,7 @@ flate2 = { version = "1.1", optional = true }
 multer = { version = "3.0", optional = true }
 
 # Our macros
-rapina-macros = { version = "0.12.0", path = "../rapina-macros/" }
+rapina-macros = { version = "0.13.0", path = "../rapina-macros/" }
 
 # Auto-discovery
 inventory = "0.3"

--- a/rapina/examples/url-shortener/url-shortner/Cargo.toml
+++ b/rapina/examples/url-shortener/url-shortner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rapina = { version = "0.12.0", features = ["sqlite", "postgres", "cache-redis"] }
+rapina = { version = "0.13.0", features = ["sqlite", "postgres", "cache-redis"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
@@ -4,6 +4,6 @@ expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.12.0.
+Built with [Rapina](https://rapina.rs) v0.13.0.
 
 ## Routes

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
@@ -1,11 +1,10 @@
 ---
 source: rapina/src/introspection/llms.rs
-assertion_line: 134
 expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.12.0.
+Built with [Rapina](https://rapina.rs) v0.13.0.
 
 ## Routes
 


### PR DESCRIPTION
Bumps all version references to 0.13.0. Merge this PR then push the `v0.13.0` tag to trigger the release.