### PR TITLE
chore: update good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -3,13 +3,17 @@ description: Template for maintainers to create beginner-friendly issues for ext
 title: "[Good First Issue]: "
 labels: ["good first issue", "help wanted"]
 body:
-  - type: markdown
+  - type: textarea
+    id: intro
     attributes:
+      label: Welcome
       value: |
         This issue is marked as a **good first issue** — it's a great starting point if you're new to contributing to Rapina.
 
         Before picking this up, please read the [Contributing Guide](https://github.com/rapina-rs/rapina/blob/main/CONTRIBUTING.md).
         Comment `/take` to claim this issue.
+    validations:
+      required: false
 
   - type: textarea
     id: summary


### PR DESCRIPTION
## Summary

Changes the welcome block in the good-first-issue form from a non-submitted Markdown element to an optional pre-filled textarea. This makes the contributor guidance visible in the final issue body while preserving the existing text.

## Related Issues

Closes #702

## Checklist

- [x] `cargo fmt` passes (not applicable; YAML-only change)
- [x] `cargo clippy` has no warnings (not applicable; YAML-only change)
- [x] Tests pass (YAML parsing and structural assertions)
- [x] Documentation updated (if needed)

## Validation

- Parsed the template as YAML
- Asserted the welcome element type, unique ID, label, and optional validation
- `git diff --check`
