### PR TITLE
fix: Validation struct constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64",
  "ed25519-dalek",

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -55,7 +55,7 @@ dotenvy = "0.15.7"
 schemars = { version = "1.2.0", features = ["chrono04", "uuid1", "rust_decimal1"] }
 
 # JWT Authentication
-jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 
 # JWKS (optional)
 hyper-rustls = { version = "0.27.9", optional = true, features = ["http1", "http2"] }

--- a/rapina/src/jwt/jwks_client.rs
+++ b/rapina/src/jwt/jwks_client.rs
@@ -121,15 +121,15 @@ impl JwksClient {
 }
 
 pub fn default_validation() -> Validation {
-    let mut validation = Validation::default();
-
     // account for 10 seconds of clock skew per default
-    validation.leeway = 10;
-
     // enable aud (audience), exp (expiration) and nbf (not before) field validation
-    validation.validate_aud = true;
-    validation.validate_exp = true;
-    validation.validate_nbf = true;
+    let mut validation = Validation {
+        leeway: 10,
+        validate_aud: true,
+        validate_exp: true,
+        validate_nbf: true,
+        ..Validation::default()
+    };
 
     // require aud to be present in every token — aligns with jsonwebtoken crate recommendation
     validation.required_spec_claims.insert("aud".to_string());


### PR DESCRIPTION
## Summary

Applied changes suggested by the Ci check
in order to cargo clippy to pass

edit:
- also bumps the jsonwebtoken from 10.4.0 to 11.0.0

## Related Issues

Closes #732 
