### PR TITLE
feat: Updated sea-orm to version 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Cargo.lock
 
 # Zola build output
 docs/public/
+
+# vscode
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +144,165 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,7 +320,7 @@ dependencies = [
  "async-io",
  "async-trait",
  "asynk-strim",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "fast_chemail",
  "fnv",
@@ -335,6 +508,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -618,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +862,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "core-foundation"
@@ -748,7 +953,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -769,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -872,6 +1077,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1012,6 +1226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1310,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1187,7 +1413,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1236,6 +1462,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1329,6 +1565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1586,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1386,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1402,9 +1655,9 @@ checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1569,6 +1822,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1594,7 +1848,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1611,7 +1865,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1619,6 +1873,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1627,6 +1886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1659,7 +1927,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1669,6 +1946,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1973,6 +2259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,14 +2393,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2145,6 +2449,63 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -2241,6 +2602,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2429,6 +2800,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2696,7 +3076,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2867,6 +3247,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -2994,7 +3384,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3014,7 +3404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3031,9 +3421,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "ptr_meta"
@@ -3165,7 +3569,7 @@ dependencies = [
  "async-graphql",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "criterion",
  "dashmap",
@@ -3196,7 +3600,7 @@ dependencies = [
  "regex",
  "rust_decimal",
  "schemars",
- "sea-orm",
+ "sea-orm 2.0.0",
  "sea-orm-migration",
  "serde",
  "serde_json",
@@ -3233,13 +3637,13 @@ dependencies = [
  "notify 8.2.0",
  "notify-debouncer-mini",
  "openapiv3",
- "sea-orm",
- "sea-schema",
+ "sea-orm 1.1.20",
+ "sea-schema 0.16.2",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
- "sqlx",
+ "sqlx 0.8.6",
  "tempfile",
  "terminal_size",
  "tokio",
@@ -3388,7 +3792,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3637,12 +4041,12 @@ dependencies = [
  "ouroboros",
  "pgvector",
  "rust_decimal",
- "sea-orm-macros",
- "sea-query",
+ "sea-orm-macros 1.1.20",
+ "sea-query 0.32.7",
  "sea-query-binder",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "strum 0.26.3",
  "thiserror 2.0.18",
  "time",
@@ -3652,18 +4056,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-orm-cli"
-version = "1.1.20"
+name = "sea-orm"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+checksum = "549c6d29a2e7a84e35c5dfbc06370a62c4d35f2328c31005267bec586b34f682"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive-where",
+ "derive_more",
+ "futures-util",
+ "itertools 0.14.0",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-arrow",
+ "sea-orm-macros 2.0.0",
+ "sea-query 1.0.1",
+ "sea-query-sqlx",
+ "sea-schema 0.18.1",
+ "serde",
+ "serde_json",
+ "sqlx 0.9.0",
+ "sqlx-core 0.9.0",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2eee8405f16c1f337fe3a83389361caea83c928d14dbd666a480407072c365"
+dependencies = [
+ "arrow",
+ "sea-query 1.0.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec4b7c39c90efa92b8bb0b91ac7159684b9fa0d6371ce39bfab0a9793ce7394"
 dependencies = [
  "chrono",
  "clap",
  "dotenvy",
  "glob",
+ "indoc",
  "regex",
- "sea-schema",
- "sqlx",
+ "sea-schema 0.18.1",
+ "sqlx 0.9.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3685,17 +4138,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-orm-migration"
-version = "1.1.20"
+name = "sea-orm-macros"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+checksum = "b4cbb7ae053b9b37c919ea944a3bc52f7830a90c223f8a765c908293bca8f22d"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3576c5301b67ea7d2ce4515858d700066e51911c7d228a439c00ff258695c8"
 dependencies = [
  "async-trait",
  "clap",
  "dotenvy",
- "sea-orm",
+ "sea-orm 2.0.0",
  "sea-orm-cli",
- "sea-schema",
+ "sea-schema 0.18.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3711,7 +4180,22 @@ dependencies = [
  "inherent",
  "ordered-float",
  "rust_decimal",
- "sea-query-derive",
+ "sea-query-derive 0.4.3",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
+dependencies = [
+ "chrono",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive 1.0.0",
  "serde_json",
  "time",
  "uuid",
@@ -3726,9 +4210,9 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "rust_decimal",
- "sea-query",
+ "sea-query 0.32.7",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "time",
  "uuid",
 ]
@@ -3748,16 +4232,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query 1.0.1",
+ "sqlx 0.9.0",
+]
+
+[[package]]
 name = "sea-schema"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
 dependencies = [
  "futures",
- "sea-query",
+ "sea-query 0.32.7",
  "sea-query-binder",
  "sea-schema-derive",
- "sqlx",
+ "sqlx 0.8.6",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3553c77dceed56e95bece9ea876c4dd67ca879ef51055a0b97a7bb89a8ae4fed"
+dependencies = [
+ "async-trait",
+ "sea-query 1.0.1",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx 0.9.0",
 ]
 
 [[package]]
@@ -4105,11 +4626,24 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-macros 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core 0.9.0",
+ "sqlx-macros 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
 ]
 
 [[package]]
@@ -4118,7 +4652,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bytes",
  "chrono",
@@ -4131,7 +4665,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -4154,6 +4688,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
+ "indexmap",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "sqlx-macros"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,8 +4735,21 @@ checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
- "sqlx-core",
- "sqlx-macros-core",
+ "sqlx-core 0.8.6",
+ "sqlx-macros-core 0.8.6",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core 0.9.0",
+ "sqlx-macros-core 0.9.0",
  "syn 2.0.119",
 ]
 
@@ -4182,10 +4769,35 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+ "syn 2.0.119",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
  "syn 2.0.119",
  "tokio",
  "url",
@@ -4198,7 +4810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.10.0",
  "byteorder",
@@ -4214,11 +4826,11 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -4229,13 +4841,43 @@ dependencies = [
  "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "rust_decimal",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core 0.9.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4245,24 +4887,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-bigint",
  "once_cell",
@@ -4272,13 +4914,52 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera 0.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core 0.9.0",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami 2.1.2",
 ]
 
 [[package]]
@@ -4289,7 +4970,7 @@ checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4300,7 +4981,34 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_urlencoded",
- "sqlx-core",
+ "sqlx-core 0.8.6",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core 0.9.0",
  "thiserror 2.0.18",
  "time",
  "tracing",
@@ -4357,6 +5065,12 @@ checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -4533,6 +5247,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4728,7 +5451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -4978,7 +5701,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -4995,7 +5718,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",
@@ -5266,6 +5989,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -52,13 +52,20 @@ rust_decimal = "1"
 dotenvy = "0.15.7"
 
 # OpenAPI
-schemars = { version = "1.2.0", features = ["chrono04", "uuid1", "rust_decimal1"] }
+schemars = { version = "1.2.0", features = [
+  "chrono04",
+  "uuid1",
+  "rust_decimal1",
+] }
 
 # JWT Authentication
-jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 
 # JWKS (optional)
-hyper-rustls = { version = "0.27.9", optional = true, features = ["http1", "http2"] }
+hyper-rustls = { version = "0.27.9", optional = true, features = [
+  "http1",
+  "http2",
+] }
 
 # Concurrent map (used by cache + rate-limit)
 dashmap = "6.2.1"
@@ -79,20 +86,28 @@ rapina-macros = { version = "0.13.0", path = "../rapina-macros/" }
 inventory = "0.3"
 
 # Database (optional)
-sea-orm = { version = "1.1", optional = true, features = ["runtime-tokio-rustls"] }
+sea-orm = { version = "2.0.0", optional = true, features = [
+  "runtime-tokio-rustls",
+] }
 
 # Database migration (optional)
-sea-orm-migration = { version = "1.1", optional = true, features = ["runtime-tokio-rustls"] }
+sea-orm-migration = { version = "2.0.0", optional = true, features = [
+  "runtime-tokio-rustls",
+] }
 async-trait = { version = "0.1", optional = true }
-base64 = { version = "0.22", optional = true }
+base64 = { version = "0.23.0", optional = true }
 
 # Prometheus (optional)
-prometheus = { version = '0.13', optional = true }
+prometheus = { version = '0.14.0', optional = true }
 
 # OpenTelemetry OTLP export (optional)
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry_sdk = { version = "0.32", optional = true }
-opentelemetry-otlp = { version = "0.32", optional = true, default-features = false, features = ["grpc-tonic", "trace", "internal-logs"] }
+opentelemetry-otlp = { version = "0.32", optional = true, default-features = false, features = [
+  "grpc-tonic",
+  "trace",
+  "internal-logs",
+] }
 tracing-opentelemetry = { version = "0.33", optional = true }
 
 # Redis cache backend (optional)
@@ -105,7 +120,11 @@ tower-layer = { version = "0.3", optional = true }
 # WebSocket (optional)
 hyper-tungstenite = { version = "0.30", optional = true }
 tokio-tungstenite = { version = "0.30", optional = true }
-futures-util = { version = "0.3", default-features = false, features = ["alloc", "sink", "async-await"] }
+futures-util = { version = "0.3", default-features = false, features = [
+  "alloc",
+  "sink",
+  "async-await",
+] }
 
 # Cron Scheduler (optional)
 tokio-cron-scheduler = { version = "0.15.1", optional = true }
@@ -155,11 +174,20 @@ default = ["compression", "rate-limit"]
 rate-limit = []
 compression = ["flate2"]
 database = ["sea-orm", "sea-orm-migration", "async-trait", "base64"]
-postgres = ["database", "sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
+postgres = [
+  "database",
+  "sea-orm/sqlx-postgres",
+  "sea-orm-migration/sqlx-postgres",
+]
 mysql = ["database", "sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 sqlite = ["database", "sea-orm/sqlx-sqlite", "sea-orm-migration/sqlx-sqlite"]
 metrics = ["prometheus"]
-otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "tracing-opentelemetry"]
+otel = [
+  "opentelemetry",
+  "opentelemetry_sdk",
+  "opentelemetry-otlp",
+  "tracing-opentelemetry",
+]
 otel-tls = ["otel", "opentelemetry-otlp/tls-roots"]
 cache-redis = ["redis"]
 multipart = ["multer"]

--- a/rapina/examples/todo-app/Cargo.toml
+++ b/rapina/examples/todo-app/Cargo.toml
@@ -11,4 +11,4 @@ rapina = { path = "../../", features = ["sqlite"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-validator = { version = "0.20.0", features = ["derive"] }
+validator = { version = "0.21.0", features = ["derive"] }

--- a/rapina/src/health/endpoint.rs
+++ b/rapina/src/health/endpoint.rs
@@ -64,7 +64,7 @@ pub async fn readiness_check(
         if let Some(conn) = state.get::<sea_orm::DatabaseConnection>() {
             let backend = conn.get_database_backend();
             let db_ok = conn
-                .execute(Statement::from_string(backend, "SELECT 1"))
+                .execute_raw(Statement::from_string(backend, "SELECT 1"))
                 .await
                 .is_ok();
             checks.insert(

--- a/rapina/src/jobs/backend.rs
+++ b/rapina/src/jobs/backend.rs
@@ -37,7 +37,7 @@ impl Postgres {
             DbBackend::Postgres,
             &sql,
             [
-                Value::String(Some(Box::new(id.to_string()))),
+                Value::String(Some(id.to_string())),
                 req.job_type.into(),
                 req.queue.into(),
                 req.payload.into(),
@@ -52,7 +52,7 @@ impl Postgres {
         config: &JobConfig,
     ) -> Result<Vec<JobRow>, DbErr> {
         let stmt = Self::build_claim_stmt(config);
-        let rows = db.query_all(stmt).await?;
+        let rows = db.query_all_raw(stmt).await?;
         rows.iter()
             .map(|row| JobRow::from_query_result(row, ""))
             .collect()
@@ -97,7 +97,7 @@ impl Postgres {
         let mut values: Vec<Value> = config
             .queues
             .iter()
-            .map(|q| Value::String(Some(Box::new(q.clone()))))
+            .map(|q| Value::String(Some(q.clone())))
             .collect();
         values.push(Value::Int(Some(config.batch_size)));
         values.push(Value::Double(Some(config.job_timeout.as_secs_f64())));
@@ -130,9 +130,9 @@ impl Postgres {
             DbBackend::Postgres,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
+                Value::String(Some(error.to_owned())),
                 Value::Double(Some(delay_secs)),
-                Value::String(Some(Box::new(job_id.to_string()))),
+                Value::String(Some(job_id.to_string())),
             ],
         )
     }
@@ -158,8 +158,8 @@ impl Postgres {
             DbBackend::Postgres,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
-                Value::String(Some(Box::new(job_id.to_string()))),
+                Value::String(Some(error.to_owned())),
+                Value::String(Some(job_id.to_string())),
             ],
         )
     }
@@ -182,7 +182,7 @@ impl Postgres {
         Statement::from_sql_and_values(
             DbBackend::Postgres,
             &sql,
-            [Value::String(Some(Box::new(job_id.to_string())))],
+            [Value::String(Some(job_id.to_string()))],
         )
     }
 }
@@ -209,7 +209,7 @@ impl Mysql {
             DbBackend::MySql,
             &sql,
             [
-                Value::Uuid(Some(Box::new(id))),
+                Value::Uuid(Some(id)),
                 req.job_type.into(),
                 req.queue.into(),
                 req.payload.into(),
@@ -226,7 +226,7 @@ impl Mysql {
         let txn = db.begin().await?;
 
         let select_sql = Self::build_claim_select(config);
-        let rows = txn.query_all(select_sql).await?;
+        let rows = txn.query_all_raw(select_sql).await?;
         let ids: Vec<Uuid> = rows
             .iter()
             .map(|r| {
@@ -243,10 +243,10 @@ impl Mysql {
         }
 
         let update_sql = Self::build_claim_update(config, &ids);
-        txn.execute(update_sql).await?;
+        txn.execute_raw(update_sql).await?;
 
         let fetch_sql = Self::build_fetch(&ids);
-        let updated = txn.query_all(fetch_sql).await?;
+        let updated = txn.query_all_raw(fetch_sql).await?;
         txn.commit().await?;
 
         updated
@@ -282,7 +282,7 @@ impl Mysql {
         let mut values: Vec<Value> = config
             .queues
             .iter()
-            .map(|q| Value::String(Some(Box::new(q.clone()))))
+            .map(|q| Value::String(Some(q.clone())))
             .collect();
         values.push(Value::Int(Some(config.batch_size)));
 
@@ -309,7 +309,7 @@ impl Mysql {
         let mut values: Vec<Value> = vec![Value::BigInt(Some(
             (config.job_timeout.as_secs_f64() * 1_000_000.0) as i64,
         ))];
-        values.extend(ids.iter().map(|id| Value::Uuid(Some(Box::new(*id)))));
+        values.extend(ids.iter().map(|id| Value::Uuid(Some(*id))));
 
         Statement::from_sql_and_values(DbBackend::MySql, &sql, values)
     }
@@ -322,10 +322,7 @@ impl Mysql {
 
         let sql = format!(r#"SELECT * FROM {t} WHERE {id} IN ({id_placeholders})"#);
 
-        let values: Vec<Value> = ids
-            .iter()
-            .map(|id| Value::Uuid(Some(Box::new(*id))))
-            .collect();
+        let values: Vec<Value> = ids.iter().map(|id| Value::Uuid(Some(*id))).collect();
 
         Statement::from_sql_and_values(DbBackend::MySql, &sql, values)
     }
@@ -355,9 +352,9 @@ impl Mysql {
             DbBackend::MySql,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
+                Value::String(Some(error.to_owned())),
                 Value::BigInt(Some((delay_secs * 1_000_000.0) as i64)),
-                Value::Uuid(Some(Box::new(job_id))),
+                Value::Uuid(Some(job_id)),
             ],
         )
     }
@@ -383,8 +380,8 @@ impl Mysql {
             DbBackend::MySql,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
-                Value::Uuid(Some(Box::new(job_id))),
+                Value::String(Some(error.to_owned())),
+                Value::Uuid(Some(job_id)),
             ],
         )
     }
@@ -404,11 +401,7 @@ impl Mysql {
                WHERE {id} = ?"#
         );
 
-        Statement::from_sql_and_values(
-            DbBackend::MySql,
-            &sql,
-            [Value::Uuid(Some(Box::new(job_id)))],
-        )
+        Statement::from_sql_and_values(DbBackend::MySql, &sql, [Value::Uuid(Some(job_id))])
     }
 }
 
@@ -434,7 +427,7 @@ impl Sqlite {
             DbBackend::Sqlite,
             &sql,
             [
-                Value::String(Some(Box::new(id.to_string()))),
+                Value::String(Some(id.to_string())),
                 req.job_type.into(),
                 req.queue.into(),
                 req.payload.into(),
@@ -449,7 +442,7 @@ impl Sqlite {
         config: &JobConfig,
     ) -> Result<Vec<JobRow>, DbErr> {
         let stmt = Self::build_claim_stmt(config);
-        let rows = db.query_all(stmt).await?;
+        let rows = db.query_all_raw(stmt).await?;
         rows.iter()
             .map(|row| JobRow::from_query_result(row, ""))
             .collect()
@@ -488,12 +481,7 @@ impl Sqlite {
         );
 
         let mut values: Vec<Value> = vec![Value::Double(Some(config.job_timeout.as_secs_f64()))];
-        values.extend(
-            config
-                .queues
-                .iter()
-                .map(|q| Value::String(Some(Box::new(q.clone())))),
-        );
+        values.extend(config.queues.iter().map(|q| Value::String(Some(q.clone()))));
         values.push(Value::Int(Some(config.batch_size)));
 
         Statement::from_sql_and_values(DbBackend::Sqlite, &sql, values)
@@ -524,9 +512,9 @@ impl Sqlite {
             DbBackend::Sqlite,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
+                Value::String(Some(error.to_owned())),
                 Value::Double(Some(delay_secs)),
-                Value::String(Some(Box::new(job_id.to_string()))),
+                Value::String(Some(job_id.to_string())),
             ],
         )
     }
@@ -552,8 +540,8 @@ impl Sqlite {
             DbBackend::Sqlite,
             &sql,
             [
-                Value::String(Some(Box::new(error.to_owned()))),
-                Value::String(Some(Box::new(job_id.to_string()))),
+                Value::String(Some(error.to_owned())),
+                Value::String(Some(job_id.to_string())),
             ],
         )
     }
@@ -576,7 +564,7 @@ impl Sqlite {
         Statement::from_sql_and_values(
             DbBackend::Sqlite,
             &sql,
-            [Value::String(Some(Box::new(job_id.to_string())))],
+            [Value::String(Some(job_id.to_string()))],
         )
     }
 }

--- a/rapina/src/jobs/create_rapina_jobs.rs
+++ b/rapina/src/jobs/create_rapina_jobs.rs
@@ -143,6 +143,9 @@ impl MigrationTrait for Migration {
             sea_orm::DbBackend::Sqlite => {
                 // no index needed — SQLite is single-writer
             }
+            _ => {
+                // Other database backends are not supported by Rapina, but we don't want to panic in a migration.
+            }
         }
 
         Ok(())
@@ -167,6 +170,9 @@ impl MigrationTrait for Migration {
             }
             sea_orm::DbBackend::Sqlite => {
                 // no index was created in `up`
+            }
+            _ => {
+                // Other database backends are not supported by Rapina, but we don't want to panic in a migration.
             }
         }
 

--- a/rapina/src/jobs/mod.rs
+++ b/rapina/src/jobs/mod.rs
@@ -260,9 +260,15 @@ where
         DbBackend::Postgres => backend::Postgres::build_insert_stmt(req, trace_id, id),
         DbBackend::MySql => backend::Mysql::build_insert_stmt(req, trace_id, id),
         DbBackend::Sqlite => backend::Sqlite::build_insert_stmt(req, trace_id, id),
+        _ => {
+            return Err(crate::error::Error::internal(format!(
+                "database backend {} not supported",
+                conn.get_database_backend().as_str()
+            )));
+        }
     };
 
-    conn.execute(stmt)
+    conn.execute_raw(stmt)
         .await
         .map_err(|e| crate::error::Error::internal(format!("failed to enqueue job: {e}")))?;
 

--- a/rapina/src/jobs/retry.rs
+++ b/rapina/src/jobs/retry.rs
@@ -143,16 +143,23 @@ pub(crate) async fn apply_failure(
             DbBackend::Postgres => Postgres::build_retry_stmt(job_id, error, delay_secs),
             DbBackend::MySql => Mysql::build_retry_stmt(job_id, error, delay_secs),
             DbBackend::Sqlite => Sqlite::build_retry_stmt(job_id, error, delay_secs),
+            _ => {
+                return Err(sea_orm::error::DbErr::BackendNotSupported {
+                    db: db.get_database_backend().as_str(),
+                    ctx: "Unable to apply_failure: database backend not supported",
+                });
+            }
         }
     } else {
         match db.get_database_backend() {
             DbBackend::Postgres => Postgres::build_fail_stmt(job_id, error),
             DbBackend::MySql => Mysql::build_fail_stmt(job_id, error),
             DbBackend::Sqlite => Sqlite::build_fail_stmt(job_id, error),
+            _ => unreachable!("unsupported database backend"),
         }
     };
 
-    db.execute(stmt).await?;
+    db.execute_raw(stmt).await?;
     Ok(())
 }
 
@@ -165,8 +172,9 @@ pub(crate) async fn apply_success(
         DbBackend::Postgres => Postgres::build_success_stmt(job_id),
         DbBackend::MySql => Mysql::build_success_stmt(job_id),
         DbBackend::Sqlite => Sqlite::build_success_stmt(job_id),
+        _ => unreachable!("unsupported database backend"),
     };
-    db.execute(stmt).await?;
+    db.execute_raw(stmt).await?;
     Ok(())
 }
 

--- a/rapina/src/jobs/worker.rs
+++ b/rapina/src/jobs/worker.rs
@@ -34,7 +34,7 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use sea_orm::{ConnectionTrait, DatabaseConnection};
+use sea_orm::DatabaseConnection;
 use tracing::Instrument;
 
 use crate::jobs::backend::{Mysql, Postgres, Sqlite};
@@ -325,6 +325,7 @@ async fn claim_batch(
         sea_orm::DbBackend::Postgres => Postgres::claim_batch(db, config).await,
         sea_orm::DbBackend::MySql => Mysql::claim_batch(db, config).await,
         sea_orm::DbBackend::Sqlite => Sqlite::claim_batch(db, config).await,
+        _ => unreachable!("unsupported database backend"),
     }
 }
 

--- a/rapina/tests/pagination.rs
+++ b/rapina/tests/pagination.rs
@@ -247,7 +247,7 @@ mod cursor_e2e {
         let backend = conn.get_database_backend();
         let schema = Schema::new(DbBackend::Sqlite);
         let stmt = schema.create_table_from_entity(entity::Entity);
-        conn.execute(backend.build(&stmt)).await.unwrap();
+        conn.execute_raw(backend.build(&stmt)).await.unwrap();
 
         for i in 1..=rows {
             entity::ActiveModel {


### PR DESCRIPTION
Targeting the #751, I updated the sea-orm dependency to the last 2.0.0
It's a simple update of the code relating using sea-orm. 
It is not using the new table format descriptor of sea-orm.

## Checklist

- [X] `cargo fmt` passes
- [X] `cargo clippy` has no warnings
- [X] Tests pass
- [X] Documentation updated (if needed)

Some tests are not passing but are not related to my change.
The detail of failing tests are:
    jwt::extract::tests::test_jsonwebtoken_extractor
    jwt::extract::tests::test_jsonwebtoken_extractor_bad_token
    jwt::extract::tests::test_jsonwebtoken_extractor_malformed_token
    jwt::extract::tests::test_jsonwebtoken_extractor_oidc_discovery
    jwt::jwks_client::tests::test_cache_empty_by_default_direct
    jwt::jwks_client::tests::test_cache_empty_by_default_oidc
    jwt::jwks_client::tests::test_cache_shared_across_clones_direct
    jwt::jwks_client::tests::test_cache_shared_across_clones_oidc
    jwt::jwks_client::tests::test_refresh_populates_cache_direct
    jwt::jwks_client::tests::test_refresh_populates_cache_oidc
    jwt::jwks_client::tests::test_refresh_schedule_direct
    jwt::jwks_client::tests::test_refresh_schedule_oidc
    jwt::jwks_client::tests::test_refresh_with_unreachable_server_direct
    jwt::jwks_client::tests::test_refresh_with_unreachable_server_oidc