### PR TITLE
Respect column attributes on composite primary key fields

### DIFF
--- a/rapina-macros/src/schema/generate.rs
+++ b/rapina-macros/src/schema/generate.rs
@@ -723,6 +723,23 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_custom_pk_keeps_column_type() {
+        let input = quote! {
+            #[primary_key(code)]
+            #[timestamps(none)]
+            Region {
+                code: Text,
+            }
+        };
+
+        let parsed = parse_schema(input).unwrap();
+        let analyzed = analyze_schema(parsed).unwrap();
+        let output = generate_schema(analyzed).to_string();
+
+        assert!(output.contains("column_type = \"Text\""));
+    }
+
+    #[test]
     fn test_generate_default_pk_unchanged() {
         // Entities without #[primary_key] should still get auto id
         let input = quote! {

--- a/rapina-macros/src/schema/generate.rs
+++ b/rapina-macros/src/schema/generate.rs
@@ -118,21 +118,47 @@ fn generate_entity_module(entity: &AnalyzedEntity, schema: &AnalyzedSchema) -> T
     }
 }
 
+fn sea_orm_parts(field: &AnalyzedField) -> Vec<TokenStream> {
+    let mut parts = Vec::new();
+    if field.attrs.unique {
+        parts.push(quote! {unique});
+    }
+    if field.attrs.indexed {
+        parts.push(quote! {indexed});
+    }
+    if let Some(ref col_name) = field.attrs.column_name {
+        parts.push(quote! {column_name = #col_name});
+    }
+    parts
+}
+
+fn build_field_attr(parts: &[TokenStream], column_type: Option<TokenStream>) -> TokenStream {
+    match (parts.is_empty(), column_type) {
+        (true, ct) => ct.unwrap_or_default(),
+        (false, Some(ct)) => quote! {#[sea_orm(#(#parts), *)] #ct },
+        (false, None) => quote! {#[sea_orm(#(#parts), *)]},
+    }
+}
+
 fn generate_custom_pk_fields(entity: &AnalyzedEntity, pk_cols: &[String]) -> TokenStream {
     let fields: Vec<TokenStream> = pk_cols
         .iter()
         .filter_map(|col_name| {
             let field = entity.fields.iter().find(|f| f.name == col_name)?;
-            if let FieldType::Scalar { scalar, .. } = &field.ty {
-                let field_name = &field.name;
-                let rust_type = scalar.rust_type();
-                Some(quote! {
-                    #[sea_orm(primary_key, auto_increment = false)]
-                    pub #field_name: #rust_type,
-                })
-            } else {
-                None
-            }
+            let FieldType::Scalar { scalar, .. } = &field.ty else {
+                return None;
+            };
+            let field_name = &field.name;
+            let rust_type = scalar.rust_type();
+
+            let mut parts = vec![quote! {primary_key}, quote! {auto_increment = false}];
+            parts.extend(sea_orm_parts(field));
+            let field_attr = build_field_attr(&parts, scalar.column_type_attr());
+
+            Some(quote! {
+                #field_attr
+                pub #field_name: #rust_type,
+            })
         })
         .collect();
 
@@ -160,51 +186,12 @@ fn generate_model_field(field: &AnalyzedField, schema: &AnalyzedSchema) -> Optio
     match &field.ty {
         FieldType::Scalar { scalar, optional } => {
             let rust_type = scalar.rust_type();
-            let column_type_attr = scalar.column_type_attr();
-
             let final_type = if *optional {
                 quote! { Option<#rust_type> }
             } else {
                 rust_type
             };
-
-            // Build sea_orm attribute parts
-            let mut sea_orm_parts: Vec<TokenStream> = Vec::new();
-
-            // Add unique if specified
-            if field.attrs.unique {
-                sea_orm_parts.push(quote! { unique });
-            }
-
-            // Add indexed if specified
-            if field.attrs.indexed {
-                sea_orm_parts.push(quote! { indexed });
-            }
-
-            // Add custom column name if specified
-            if let Some(ref col_name) = field.attrs.column_name {
-                sea_orm_parts.push(quote! { column_name = #col_name });
-            }
-
-            // Combine column_type_attr with other attributes
-            let field_attr = if sea_orm_parts.is_empty() {
-                column_type_attr.unwrap_or_default()
-            } else if let Some(col_type) = column_type_attr {
-                // Extract the column_type value and combine
-                let col_type_str = col_type.to_string();
-                if col_type_str.contains("column_type") {
-                    // Parse out the column_type value
-                    let combined = quote! {
-                        #[sea_orm(#(#sea_orm_parts),*)]
-                        #col_type
-                    };
-                    combined
-                } else {
-                    quote! { #[sea_orm(#(#sea_orm_parts),*)] }
-                }
-            } else {
-                quote! { #[sea_orm(#(#sea_orm_parts),*)] }
-            };
+            let field_attr = build_field_attr(&sea_orm_parts(field), scalar.column_type_attr());
 
             Some(quote! {
                 #field_attr

--- a/rapina/tests/schema_test.rs
+++ b/rapina/tests/schema_test.rs
@@ -40,6 +40,14 @@ schema! {
         label_id: i32,
     }
 
+    #[table_name = "test_regions"]
+    #[timestamps(none)]
+    #[primary_key(code)]
+    TestRegion {
+        #[column = "region_code"]
+        code: Text,
+    }
+
 }
 
 #[test]
@@ -137,4 +145,5 @@ fn test_entity_traits_implemented() {
 fn test_composite_pk_respects_column_rename() {
     assert_eq!(test_tx_label::Column::TxId.as_str(), "transaction_id");
     assert_eq!(test_tx_label::Column::LabelId.as_str(), "label_id");
+    assert_eq!(test_region::Column::Code.as_str(), "region_code");
 }

--- a/rapina/tests/schema_test.rs
+++ b/rapina/tests/schema_test.rs
@@ -30,6 +30,16 @@ schema! {
         post: TestPost,
         author: Option<TestUser>,
     }
+
+    #[table_name = "test_tx_labels"]
+    #[timestamps(none)]
+    #[primary_key(tx_id, label_id)]
+    TestTxLabel {
+        #[column = "transaction_id"]
+        tx_id: i32,
+        label_id: i32,
+    }
+
 }
 
 #[test]
@@ -121,4 +131,10 @@ fn test_entity_traits_implemented() {
     let _ = test_user::Entity::table_name(&test_user::Entity);
     let _ = test_post::Entity::table_name(&test_post::Entity);
     let _ = test_comment::Entity::table_name(&test_comment::Entity);
+}
+
+#[test]
+fn test_composite_pk_respects_column_rename() {
+    assert_eq!(test_tx_label::Column::TxId.as_str(), "transaction_id");
+    assert_eq!(test_tx_label::Column::LabelId.as_str(), "label_id");
 }


### PR DESCRIPTION
Closes #745.

We were silently ignoring #[column = "..."] on any field listed in #[primary_key(...)]. `generate_custom_pk_fields` built those fields from scratch and only ever emitted `primary_key`, `auto_increment = false`, never reading `field.attrs`, while `generate_model_fields` filtered the primary key columns out of the path that does read them. Two functions producing the same thing, one of them a stub.

The regression test asserts on `Column::TxId.as_str()`, the name that actually reaches SQL, rather than on the generated token stream, so it survives a change in how the attribute is spelled. `TestRegion` covers primary key, rename and column type together, which is the first case in the suite where the generated two-attribute output has to compile.

This should go out as a patch, ahead of 0.14.0.