### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Routine dependency-only updates are intentionally omitted unless they change use
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-04
+
+### Fixed
+- **Column attributes on composite primary keys**: `#[column = "..."]` was ignored on any field named in `#[primary_key(...)]`, so the generated entity used the field name as the column name. `column_type` was dropped the same way, so a `Text` primary key landed as VARCHAR. If you had `#[column]` on a primary key field your tables were created with the field name, and you need a rename migration after upgrading (#750).
+
 ## [0.13.0] - 2026-06-25
 
 ### Added
@@ -146,7 +151,8 @@ Routine dependency-only updates are intentionally omitted unless they change use
 - Standardized error handling with `trace_id`
 - CLI (`rapina new`, `rapina dev`)
 
-[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/rapina-rs/rapina/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/rapina-rs/rapina/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/rapina-rs/rapina/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/rapina-rs/rapina/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/rapina-rs/rapina/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rapina"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-graphql",
  "async-stream",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "clap",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "rapina-macros"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/docs/content/docs/core-concepts/background-jobs.md
+++ b/docs/content/docs/core-concepts/background-jobs.md
@@ -30,7 +30,7 @@ You need the `database` feature with PostgreSQL. The jobs migration uses Postgre
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["postgres"] }
+rapina = { version = "0.13.1", features = ["postgres"] }
 ```
 
 You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page.

--- a/docs/content/docs/core-concepts/caching.md
+++ b/docs/content/docs/core-concepts/caching.md
@@ -111,7 +111,7 @@ For multi-instance deployments where all instances need to share the same cache 
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["cache-redis"] }
+rapina = { version = "0.13.1", features = ["cache-redis"] }
 ```
 
 ```rust

--- a/docs/content/docs/core-concepts/cron-scheduler.md
+++ b/docs/content/docs/core-concepts/cron-scheduler.md
@@ -28,7 +28,7 @@ Enable the `cron-scheduler` feature flag:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["cron-scheduler"] }
+rapina = { version = "0.13.1", features = ["cron-scheduler"] }
 ```
 
 No database or external service is required. The scheduler runs entirely in-process.

--- a/docs/content/docs/core-concepts/database.md
+++ b/docs/content/docs/core-concepts/database.md
@@ -13,7 +13,7 @@ Add the database feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["postgres"] }
+rapina = { version = "0.13.1", features = ["postgres"] }
 # or "mysql", "sqlite"
 ```
 

--- a/docs/content/docs/core-concepts/graphql.md
+++ b/docs/content/docs/core-concepts/graphql.md
@@ -15,7 +15,7 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["graphql"] }
+rapina = { version = "0.13.1", features = ["graphql"] }
 async-graphql = "7.0"
 ```
 

--- a/docs/content/docs/core-concepts/jwks.md
+++ b/docs/content/docs/core-concepts/jwks.md
@@ -52,7 +52,7 @@ Add the `jwks` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["jwks"] }
+rapina = { version = "0.13.1", features = ["jwks"] }
 ```
 
 This pulls in Rapina's `cron-scheduler` for automatic periodic cache refresh and `hyper-rustls` for HTTPS fetching of the JWKS endpoint using your system's native root CA certificates.

--- a/docs/content/docs/core-concepts/metrics.md
+++ b/docs/content/docs/core-concepts/metrics.md
@@ -13,7 +13,7 @@ Add the feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["metrics"] }
+rapina = { version = "0.13.1", features = ["metrics"] }
 ```
 
 Enable the endpoint in your application:

--- a/docs/content/docs/core-concepts/middleware.md
+++ b/docs/content/docs/core-concepts/middleware.md
@@ -401,7 +401,7 @@ impl Middleware for SecurityHeadersMiddleware {
 Rapina can interop with the [Tower](https://docs.rs/tower) ecosystem via the `tower` feature flag. This lets you use battle-tested Tower layers (retry, circuit breakers, concurrency limits, etc.) as Rapina middleware.
 
 ```toml
-rapina = { version = "0.13.0", features = ["tower"] }
+rapina = { version = "0.13.1", features = ["tower"] }
 ```
 
 ### Using Tower layers as middleware

--- a/docs/content/docs/core-concepts/migrations.md
+++ b/docs/content/docs/core-concepts/migrations.md
@@ -15,7 +15,7 @@ Your `Cargo.toml` needs the `database` feature and a database driver:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["sqlite"] }
+rapina = { version = "0.13.1", features = ["sqlite"] }
 ```
 
 Replace `sqlite` with `postgres` or `mysql` depending on your database. You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page if you haven't set that up yet.

--- a/docs/content/docs/core-concepts/observability.md
+++ b/docs/content/docs/core-concepts/observability.md
@@ -52,7 +52,7 @@ Enable the `otel` feature flag:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["otel"] }
+rapina = { version = "0.13.1", features = ["otel"] }
 ```
 
 Then configure the exporter with `with_telemetry`:

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -115,7 +115,7 @@ If you prefer not to use the CLI, add Rapina to an existing project:
 
 ```toml
 [dependencies]
-rapina = "0.13.0"
+rapina = "0.13.1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```

--- a/docs/content/docs/guides/deployment.md
+++ b/docs/content/docs/guides/deployment.md
@@ -21,7 +21,7 @@ If your app uses a database, make sure the correct feature flag is enabled in yo
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["postgres"] }
+rapina = { version = "0.13.1", features = ["postgres"] }
 ```
 
 Available database features: `postgres`, `mysql`, `sqlite`.
@@ -343,7 +343,7 @@ Enable Prometheus metrics for monitoring:
 
 ```toml
 [dependencies]
-rapina = { version = "0.13.0", features = ["metrics"] }
+rapina = { version = "0.13.1", features = ["metrics"] }
 ```
 
 ```rust

--- a/rapina-cli/Cargo.toml
+++ b/rapina-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "CLI tool for Rapina web framework - create and run Rapina projects"

--- a/rapina-macros/Cargo.toml
+++ b/rapina-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina-macros"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Procedural macros for the Rapina web framework"

--- a/rapina/Cargo.toml
+++ b/rapina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rapina"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "A fast, type-safe web framework for Rust inspired by FastAPI"
@@ -73,7 +73,7 @@ flate2 = { version = "1.1", optional = true }
 multer = { version = "3.0", optional = true }
 
 # Our macros
-rapina-macros = { version = "0.13.0", path = "../rapina-macros/" }
+rapina-macros = { version = "0.13.1", path = "../rapina-macros/" }
 
 # Auto-discovery
 inventory = "0.3"

--- a/rapina/examples/url-shortener/url-shortner/Cargo.toml
+++ b/rapina/examples/url-shortener/url-shortner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-rapina = { version = "0.13.0", features = ["sqlite", "postgres", "cache-redis"] }
+rapina = { version = "0.13.1", features = ["sqlite", "postgres", "cache-redis"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_empty_routes.snap
@@ -4,6 +4,6 @@ expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.13.0.
+Built with [Rapina](https://rapina.rs) v0.13.1.
 
 ## Routes

--- a/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
+++ b/rapina/src/introspection/snapshots/rapina__introspection__llms__tests__to_llms_txt_snapshot.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 # My API
 
-Built with [Rapina](https://rapina.rs) v0.13.0.
+Built with [Rapina](https://rapina.rs) v0.13.1.
 
 ## Routes
 


### PR DESCRIPTION
Patch release for #750. `#[column]` was ignored on any field named in `#[primary_key(...)]`, so generated entities used the field name as the column.

Anyone who had `#[column]` on a primary key field has tables created with the field name and needs a rename migration after upgrading. The changelog entry says so explicitly, because the gh release notes are generated from commit titles and won't carry it.