### PR TITLE
Ignore rkyv advisory and let the audit job report findings

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,13 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: rm rust-toolchain.toml
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173
+          # rkyv: optional dependency of rust_decimal that no feature activates,
+          # so it is never compiled. cargo-deny agrees, it resolves the feature graph.
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173,RUSTSEC-2026-0235
 
   deny:
     name: Cargo Deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,13 +193,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: rm rust-toolchain.toml
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95  # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173
+          # rkyv: optional dependency of rust_decimal that no feature activates,
+          # so it is never compiled. cargo-deny agrees, it resolves the feature graph.
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0437,RUSTSEC-2026-0097,RUSTSEC-2026-0173,RUSTSEC-2026-0235
 
   deny:
     name: Cargo Deny


### PR DESCRIPTION
`rkyv` is an optional dependency of rust_decimal that no feature of ours activates, so it's never compiled, and Cargo Deny stayed green on the same commit because it resolves the feature graph instead of scanning lockfile entries.