### PR TITLE
dependabot: groups the tungstenite crates into one single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "Update"
+    groups:
+      tungstenite:
+        patterns:
+          - "tokio-tungstenite"
+          - "hyper-tungstenite"
+          - "tungstenite"
     ignore:
       - dependency-name: "sea-schema"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
## Summary

The tungstenite crates depend on each other, every time they fail CI checks, only passing when bumped together.
This PR groups them in the `tungstenite` group

## Related Issues

Closes #697