### PR TITLE
docs: describe multi-database background jobs

### DIFF
--- a/docs/content/docs/cli/commands.md
+++ b/docs/content/docs/cli/commands.md
@@ -417,7 +417,7 @@ This adds the framework's `create_rapina_jobs` migration to `src/migrations/mod.
 
 The migration creates the `rapina_jobs` table used by the background jobs system. It uses a zero timestamp prefix so it always runs before your application migrations. See [Background Jobs](/docs/core-concepts/background-jobs/) for the full table schema and types.
 
-> **Note:** The jobs migration requires PostgreSQL. It uses `gen_random_uuid()` and partial indexes, which are not available in MySQL or SQLite.
+The jobs migration supports PostgreSQL, MySQL 8.0+, and SQLite 3.35+. Rapina selects the migration implementation for the database backend used by your application.
 
 ## rapina jobs list
 
@@ -457,7 +457,7 @@ This appends a table of failed jobs showing ID, queue, job type, attempt count (
 Requires the `jobs` feature:
 
 ```bash
-cargo install rapina-cli --features jobs-postgres
+cargo install rapina-cli --features jobs
 ```
 
 ## rapina llms export

--- a/docs/content/docs/core-concepts/background-jobs.md
+++ b/docs/content/docs/core-concepts/background-jobs.md
@@ -1,13 +1,13 @@
 +++
 title = "Background Jobs"
-description = "Persistent job queue backed by PostgreSQL"
+description = "Persistent job queue backed by PostgreSQL, MySQL, or SQLite"
 weight = 9
 date = 2026-03-17
 +++
 
 Background jobs let you defer work to run outside the request cycle. Sending emails, processing uploads, generating reports — anything that shouldn't block an HTTP response.
 
-Rapina's job system uses your existing PostgreSQL database as the queue. No Redis, no RabbitMQ, no extra infrastructure. Jobs are rows in a `rapina_jobs` table, claimed by in-process workers with `FOR UPDATE SKIP LOCKED` for safe concurrent processing.
+Rapina's job system uses your existing PostgreSQL, MySQL, or SQLite database as the queue. No Redis, no RabbitMQ, no extra infrastructure. Jobs are rows in a `rapina_jobs` table and are claimed by in-process workers using a strategy suited to each database.
 
 This page covers setup, defining jobs, enqueuing, running the worker, and the retry system.
 
@@ -18,19 +18,20 @@ tl;dr: Use Background Jobs for durable, transactional work that must complete re
 | | Cron Scheduler                               | Background Jobs                                                |
 |---|----------------------------------------------|----------------------------------------------------------------|
 | **Trigger** | Time-based (cron expression)                 | Event-based (enqueued from code)                               |
-| **Persistence** | None, in-memory only                         | PostgreSQL-backed                                              |
+| **Persistence** | None, in-memory only                         | Database-backed                                                |
 | **Retries** | None built-in                                | Configurable (exponential, fixed, none)                        |
 | **Survives restarts** | No. Schedule restarts with the process       | Yes. Pending jobs persist in the database                      |
 | **Use case** | Periodic maintenance, polling, cache refresh | Durable, transactional deferred work: emails, uploads, reports |
-| **Infrastructure** | No extra dependencies                        | Requires PostgreSQL                                            |
+| **Infrastructure** | No extra dependencies                        | Uses PostgreSQL, MySQL, or SQLite                              |
 
 ## Prerequisites
 
-You need the `database` feature with PostgreSQL. The jobs migration uses PostgreSQL-specific features (`gen_random_uuid()`, partial indexes) and does not support MySQL or SQLite.
+Enable one of Rapina's database features. Background jobs support PostgreSQL, MySQL 8.0+, and SQLite 3.35+:
 
 ```toml
 [dependencies]
 rapina = { version = "0.13.1", features = ["postgres"] }
+# Or use `features = ["mysql"]` or `features = ["sqlite"]`.
 ```
 
 You also need a database connection configured in your app — see the [Database](/docs/core-concepts/database/) page.
@@ -159,7 +160,9 @@ pending → running → completed
                   ↘ failed   (or back to pending if retries remain)
 ```
 
-The worker atomically transitions each job from `pending` to `running` in a single SQL statement. On completion the job moves to `completed` or `failed`.
+The worker transitions each claimed job from `pending` to `running` while preventing duplicate claims. PostgreSQL uses a CTE with `FOR UPDATE SKIP LOCKED`. MySQL uses a transaction that selects rows with `FOR UPDATE SKIP LOCKED`, updates them, and then fetches the updated rows because MySQL does not support `UPDATE ... RETURNING`. SQLite uses one `UPDATE ... WHERE id IN (...) ... RETURNING` statement and relies on its single-writer model.
+
+On completion the job moves to `completed` or `failed`.
 
 Failed jobs are retried according to the `retry_policy` set on the handler.
 
@@ -188,6 +191,8 @@ async fn sync_inventory(payload: SyncPayload) -> JobResult { ... }
 
 Every retry waits the same `retry_delay_secs`. The first retry is always immediate regardless of the configured delay.
 
+MySQL expresses retry delays in microseconds, so fractional-second delays retain their configured precision.
+
 ### No retries
 
 ```rust
@@ -212,22 +217,22 @@ The migration creates a `rapina_jobs` table with the following columns:
 
 | Column | Type | Default | Description |
 |--------|------|---------|-------------|
-| `id` | UUID | `gen_random_uuid()` | Primary key |
+| `id` | UUID | — | Application-generated primary key |
 | `queue` | VARCHAR(255) | `'default'` | Logical queue name |
 | `job_type` | VARCHAR(255) | — | Fully-qualified type name for dispatch |
-| `payload` | JSONB | `'{}'` | Arbitrary data passed to the handler |
+| `payload` | JSON | — | Arbitrary data passed to the handler |
 | `status` | VARCHAR(32) | `'pending'` | Lifecycle state |
 | `attempts` | INTEGER | `0` | Number of times this job has been attempted |
 | `max_retries` | INTEGER | `3` | Maximum retry count before permanent failure |
-| `run_at` | TIMESTAMPTZ | `now()` | Earliest time to execute |
+| `run_at` | TIMESTAMPTZ | — | Earliest time to execute; supplied by the application |
 | `started_at` | TIMESTAMPTZ | NULL | When a worker started processing |
 | `locked_until` | TIMESTAMPTZ | NULL | Lease expiry for crash recovery |
 | `finished_at` | TIMESTAMPTZ | NULL | When the job completed or permanently failed |
 | `last_error` | TEXT | NULL | Error from the most recent failed attempt |
 | `trace_id` | VARCHAR(64) | NULL | Distributed trace ID from the enqueuing request |
-| `created_at` | TIMESTAMPTZ | `now()` | Insertion timestamp |
+| `created_at` | TIMESTAMPTZ | — | Insertion timestamp; supplied by the application |
 
-A partial index on `(queue, run_at) WHERE status = 'pending'` optimizes the worker's claim query.
+The migration uses portable `JSON` rather than PostgreSQL `JSONB`, so PostgreSQL JSONB indexing is unavailable. PostgreSQL creates a partial index on `(queue, run_at) WHERE status = 'pending'`; MySQL creates a regular `(queue, run_at)` index; SQLite skips this index because it is a single-writer database.
 
 ## Types
 

--- a/docs/content/docs/core-concepts/background-jobs.md
+++ b/docs/content/docs/core-concepts/background-jobs.md
@@ -232,6 +232,8 @@ The migration creates a `rapina_jobs` table with the following columns:
 | `trace_id` | VARCHAR(64) | NULL | Distributed trace ID from the enqueuing request |
 | `created_at` | TIMESTAMPTZ | — | Insertion timestamp; supplied by the application |
 
+Types shown are the PostgreSQL mapping; SeaORM emits the corresponding backend types for MySQL and SQLite.
+
 The migration uses portable `JSON` rather than PostgreSQL `JSONB`, so PostgreSQL JSONB indexing is unavailable. PostgreSQL creates a partial index on `(queue, run_at) WHERE status = 'pending'`; MySQL creates a regular `(queue, run_at)` index; SQLite skips this index because it is a single-writer database.
 
 ## Types
@@ -264,23 +266,25 @@ let parsed: JobStatus = "running".parse().unwrap();
 `JobRow` is a plain struct that maps directly to a row in the `rapina_jobs` table. It derives SeaORM's `FromQueryResult` so you can use it with raw queries:
 
 ```rust
+use rapina::database::{Db, DbError};
 use rapina::jobs::JobRow;
-use rapina::sea_orm::{FromQueryResult, Statement, DatabaseBackend};
-use rapina::database::Db;
+use rapina::sea_orm::{ConnectionTrait, FromQueryResult, Statement};
 
-let rows: Vec<JobRow> = JobRow::find_by_statement(
-    Statement::from_string(
-        DatabaseBackend::Postgres,
-        "SELECT * FROM rapina_jobs WHERE queue = 'emails' AND status = 'failed'"
-    )
-)
-.all(db.conn())
-.await
-.map_err(DbError::from)?;
+async fn failed_email_jobs(db: &Db) -> Result<Vec<JobRow>, DbError> {
+    let rows = JobRow::find_by_statement(Statement::from_string(
+        db.conn().get_database_backend(),
+        "SELECT * FROM rapina_jobs WHERE queue = 'emails' AND status = 'failed'",
+    ))
+    .all(db.conn())
+    .await
+    .map_err(DbError::from)?;
 
-for row in &rows {
-    let status = row.parse_status().unwrap();
-    println!("{}: {} (attempts: {})", row.id, status, row.attempts);
+    for row in &rows {
+        let status = row.parse_status().unwrap();
+        println!("{}: {} (attempts: {})", row.id, status, row.attempts);
+    }
+
+    Ok(rows)
 }
 ```
 

--- a/docs/content/docs/core-concepts/cron-scheduler.md
+++ b/docs/content/docs/core-concepts/cron-scheduler.md
@@ -16,11 +16,11 @@ tl;dr: Use the cron scheduler for lightweight, periodic tasks that are safe to m
 | | Cron Scheduler                               | Background Jobs                                                |
 |---|----------------------------------------------|----------------------------------------------------------------|
 | **Trigger** | Time-based (cron expression)                 | Event-based (enqueued from code)                               |
-| **Persistence** | None, in-memory only                         | PostgreSQL-backed                                              |
+| **Persistence** | None, in-memory only                         | Database-backed                                                |
 | **Retries** | None built-in                                | Configurable (exponential, fixed, none)                        |
 | **Survives restarts** | No. Schedule restarts with the process       | Yes. Pending jobs persist in the database                      |
 | **Use case** | Periodic maintenance, polling, cache refresh | Durable, transactional deferred work: emails, uploads, reports |
-| **Infrastructure** | No extra dependencies                        | Requires PostgreSQL                                            |
+| **Infrastructure** | No extra dependencies                        | Uses PostgreSQL, MySQL, or SQLite                              |
 
 ## Prerequisites
 

--- a/rapina-cli/src/main.rs
+++ b/rapina-cli/src/main.rs
@@ -474,8 +474,8 @@ fn main() {
                 {
                     let _ = failed;
                     eprintln!(
-                        "{} The jobs list command requires a database feature. \
-                             Reinstall with: cargo install rapina-cli --features jobs-postgres",
+                        "{} The jobs list command requires the jobs feature. \
+                             Reinstall with: cargo install rapina-cli --features jobs",
                         "Error:".red().bold()
                     );
                     std::process::exit(1);


### PR DESCRIPTION
Closes #655.

Updates the background-jobs guide for PostgreSQL, MySQL 8.0+, and SQLite 3.35+, including feature flags, schema defaults, claim strategies, indexes, and MySQL retry precision. The duplicated comparison table in the cron guide is kept consistent.

Validation: `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets --all-features -- -D warnings`; `git diff --check`.
