### PR TITLE
actions: adds PR status labeler

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,149 @@
+name: PR Status Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, dismissed]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pr-status-${{ github.event.pull_request.number || github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync status labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const AUTHOR = 'needs: author';
+            const REVIEW = 'needs: review';
+            const DIRECTION = 'needs: direction';
+            const STALE = 'stale';
+            const STALE_DAYS = 30;
+
+            const sweep = context.eventName === 'schedule' || context.eventName === 'workflow_dispatch';
+
+            async function openPullRequests() {
+              return github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+            }
+
+            let numbers;
+            if (sweep) {
+              numbers = (await openPullRequests()).map(pr => pr.number);
+            } else if (context.eventName === 'workflow_run') {
+              const sha = context.payload.workflow_run.head_sha;
+              numbers = (await openPullRequests()).filter(pr => pr.head.sha === sha).map(pr => pr.number);
+            } else {
+              numbers = [context.payload.pull_request.number];
+            }
+
+            const QUERY = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    isDraft
+                    mergeable
+                    reviewDecision
+                    createdAt
+                    author { login }
+                    labels(first: 100) { nodes { name } }
+                    comments(last: 50) { nodes { createdAt author { login } } }
+                    commits(last: 1) { nodes { commit { committedDate statusCheckRollup { state } } } }
+                  }
+                }
+              }`;
+
+            async function fetchPullRequest(number) {
+              for (let attempt = 0; attempt < 5; attempt++) {
+                const data = await github.graphql(QUERY, { owner, repo, number });
+                const pr = data.repository.pullRequest;
+                if (pr.mergeable !== 'UNKNOWN') return pr;
+                await new Promise(resolve => setTimeout(resolve, 3000));
+              }
+              return null;
+            }
+
+            function lastAuthorActivity(pr) {
+              const login = pr.author?.login;
+              const dates = [pr.createdAt];
+              const committed = pr.commits.nodes[0]?.commit?.committedDate;
+              if (committed) dates.push(committed);
+              for (const comment of pr.comments.nodes) {
+                if (login && comment.author?.login === login) dates.push(comment.createdAt);
+              }
+              return Math.max(...dates.map(Date.parse));
+            }
+
+            function verdict(pr) {
+              const ci = pr.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? null;
+              if (pr.mergeable === 'CONFLICTING') return AUTHOR;
+              if (ci === 'FAILURE' || ci === 'ERROR') return AUTHOR;
+              if (pr.reviewDecision === 'CHANGES_REQUESTED') return AUTHOR;
+              if (ci === null || ci === 'PENDING' || ci === 'EXPECTED') return null;
+              return REVIEW;
+            }
+
+            for (const number of numbers) {
+              const pr = await fetchPullRequest(number);
+              if (!pr) {
+                core.info(`#${number}: mergeable still UNKNOWN, leaving it for the next run`);
+                continue;
+              }
+
+              const has = new Set(pr.labels.nodes.map(label => label.name));
+
+              if (has.has(DIRECTION)) {
+                core.info(`#${number}: ${DIRECTION} is set, standing down`);
+                continue;
+              }
+
+              let want;
+              if (pr.isDraft) {
+                want = new Set();
+              } else {
+                const target = verdict(pr);
+                if (!target) {
+                  core.info(`#${number}: checks still running, no verdict yet`);
+                  continue;
+                }
+                want = new Set([target]);
+                const idleDays = (Date.now() - lastAuthorActivity(pr)) / 86_400_000;
+                if (sweep && target === AUTHOR && idleDays >= STALE_DAYS) want.add(STALE);
+              }
+
+              for (const name of [AUTHOR, REVIEW, STALE]) {
+                try {
+                  if (want.has(name) && !has.has(name)) {
+                    await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [name] });
+                    core.info(`#${number}: +${name}`);
+                  } else if (!want.has(name) && has.has(name)) {
+                    await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name });
+                    core.info(`#${number}: -${name}`);
+                  }
+                } catch (error) {
+                  core.warning(`#${number}: could not update ${name}: ${error.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
## Summary

Keeps the PR status labels accurate without anyone touching them by hand.

  On every PR push, review, draft toggle and CI completion, the workflow recomputes
  which label the PR has earned and reconciles it:

  - `needs: review` -> no conflicts, CI green
  - `needs: author` -> conflicts, failing CI, or changes requested
  - `stale` -> in `needs: author` with no author activity for 30+ days

  `needs: direction` is never touched. It's a judgement call, so when it's present
  the job stands down entirely and leaves the PR alone.

## Related Issues

Closes #768


